### PR TITLE
Check for a wrap of the counter

### DIFF
--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -11544,6 +11544,14 @@ dictionary <dfn id="dfn-AesDerivedKeyParams">AesDerivedKeyParams</dfn> : <a href
                 </li>
                 <li>
                   <p>
+                    If <var>plaintext</var> has a length greater than 2^(length member of <var>normalizedAlgorithm</var>
+                    bytes,
+                    then <a href="#concept-throw">throw</a> an
+                    <a href="#dfn-OperationError"><code>OperationError</code></a>.
+                  </p>
+                </li>
+                <li>
+                  <p>
                     Let <var>ciphertext</var> be the result of performing the CTR Encryption
                     operation described in Section 6.5 of [<a
                     href="#SP800-38A">NIST SP800-38A</a>] using AES as the block cipher, <a


### PR DESCRIPTION
Need to ensure that the counter does not wrap when doing an encrypt
because otherwise there is a bad leakage of information.

We cannot do the full check on this - would need to also have a check
for starting at zero or something so just do the best we can.  The
algorithm for counters referenced permits the counter to wrap mod 2^m