### PR TITLE
Editorial Notes merged into main text

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -15649,7 +15649,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             </tr>
           </tbody>
         </table>
-        <div class="ednote"><div class="ednoteHeader">Editorial note</div>
           <p>
             The handling of "id-RSASSA-PSS" and "id-RSAES-OAEP" are tricky.
             <a href="#RFC5756">RFC 5756</a> recommends implementations should not include parameters
@@ -15662,7 +15661,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             subjectPublicKeyInfo (which is what "spki" implies) and when it's being used as an
             algorithmIdentifier for transport.
           </p>
-        </div>
       </div>
       <div id="pkcs8-mapping" class="section">
         <h2>C. Mapping between Algorithm and PKCS#8 PrivateKeyInfo</h2>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -842,7 +842,6 @@
             </ol>
           </dd>
         </dl>
-        <div class="ednote"><div class="ednoteHeader">Editorial note</div>
           <p>
             The above definition makes heavy use of directly accessing the internal slot values,
             defined in <a href="#ECMA-262">ECMA262</a>. The motivation for this is to avoid issues
@@ -857,7 +856,6 @@
             always have valid values for the above algorithm. However, that assumption may not be
             safe to make.
           </p>
-        </div>
         <p>
           When this specification states to supply the <dfn id="concept-contents-of-arraybuffer">
           contents of an ArrayBuffer</dfn> named <var>data</var> to an underlying cryptographic

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -4582,13 +4582,13 @@ dictionary <dfn id="dfn-RsaHashedImportParams">RsaHashedImportParams</dfn> {
                                 RSA private key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
                                 <var>key</var>
                               </p>
-                              <div class="ednote"><div class="ednoteHeader">Editorial note</div>
+                          
                                 <a href="#RFC5208">RFC 5208</a> specifies that the encoding of
                                 this field should be <em>BER</em> encoded in Section 5 (as a "for
                                 example"). However, to avoid requiring WebCrypto implementations
                                 support BER-encoding and BER-decoding, only <em>DER</em> encodings
                                 are produced or accepted.
-                              </div>
+                         
                             </li>
                           </ul>                              
                         </li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -7699,13 +7699,11 @@ BufferSource <dfn id="dfn-RsaOaepParams-label">label</dfn>;
                                 RSA private key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
                                 <var>key</var>
                               </p>
-                              <div class="ednote"><div class="ednoteHeader">Editorial note</div>
                                 <a href="#RFC5208">RFC 5208</a> specifies that the encoding of
                                 this field should be <em>BER</em> encoded in Section 5 (as a "for
                                 example"). However, to avoid requiring WebCrypto implementations
                                 support BER-encoding and BER-decoding, only <em>DER</em> encodings
                                 are produced or accepted.
-                              </div>
                             </li>
                           </ul>
                         </li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -56,7 +56,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 12 November 2015 <b>Editor’s Draft</b> of the
+        This document is the 30 November 2015 <b>Editor’s Draft</b> of the
         <cite>Web Cryptography API</cite> specification.
       
       Please send comments about this document to

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14828,9 +14828,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
            <dl>
              <dt id="DOM4">DOM4</dt>
              <dd>
-               <cite><a href="https://dom.spec.whatwg.org/">DOM (Living Standard)</a></cite>,
-               A. Gregor, A. van Kesteren, Ms2ger. WHATWG.
-               <div class="ednote"><div class="ednoteHeader">Editorial note</div>This will be updated to W3C DOM4 once Promises are incorporated.</div>
+               <cite><a href="http://www.w3.org/TR/dom/">W3C DOM4</a></cite>,
+               A. Gregor, A. van Kesteren, Ms2ger, Alex Russell, Robin Berjon. W3C Recommendation 19 November 2015
              </dd>
              <dt id="ECMA-262">ECMA262</dt>
              <dd>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -3236,19 +3236,13 @@ dictionary <dfn id="dfn-CryptoKeyPair">CryptoKeyPair</dfn> {
           document to better understand the risks and concerns that may arise when using certain
           algorithms.
         </p>
-        <div class="ednote"><div class="ednoteHeader">Editorial note</div>
           <p>
-            Note: All algorithms listed should be considered as "features at risk",
-            barring implementors adopting them. Their inclusion in the Editor's Draft
-            reflects requests for their inclusion by members of the community, and are
-            included as an exercise to ensure the robustness of the API defined in this
-            specification.
+            All algorithms listed should be considered have been shown to have two independent implementations at the time of publication of this document. However, this document may be updated over time as new algorithms are added or algorithms removed. Note that implementations may implement algorithms that are not listed in this specification. 
           </p>
           <p>
-            As such, the list of algorithms, and the recommendations, may be significantly
-            altered in future revisions.
+            As such, the list of algorithms may be significantly
+            altered in future revisions of this recommendation.
           </p>
-        </div>
         <table>
           <thead>
             <tr>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -28,7 +28,7 @@
   <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><div><a href="http://www.w3.org/"><img src="//www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web Cryptography API</h1><h2>W3C Editor’s Draft <em>12 November 2015</em></h2><dl><dt>Latest Editor’s Draft:</dt><dd><a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html">https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html</a></dd><dt>Latest Published Version:</dt><dd><a href="http://www.w3.org/TR/WebCryptoAPI/">http://www.w3.org/TR/WebCryptoAPI/</a></dd><dt>Previous Version(s):</dt><dd><a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html">https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html</a></dd><dt>Editors:</dt><dd><a href="http://www.google.com/">Ryan Sleevi</a>, Google, Inc. &lt;sleevi@google.com&gt;</dd><dd><a href="http://www.netflix.com/">Mark Watson</a>, Netflix &lt;watsonm@netflix.com&gt;</dd><dt>Participate:</dt><dd><p>Send feedback to <a href="mailto:public-webcrypto@w3.org?subject=%5BWebCryptoAPI%5D">public-webcrypto@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-webcrypto/">archives</a>), or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=Web%20Cryptography&amp;component=Web%20Cryptography%20API%20Document">file a bug</a> 
+    <div class="head"><div><a href="http://www.w3.org/"><img src="//www.w3.org/Icons/w3c_home" width="72" height="48" alt="W3C" /></a></div><h1>Web Cryptography API</h1><h2>W3C Editor’s Draft <em>30 November 2015</em></h2><dl><dt>Latest Editor’s Draft:</dt><dd><a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html">https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html</a></dd><dt>Latest Published Version:</dt><dd><a href="http://www.w3.org/TR/WebCryptoAPI/">http://www.w3.org/TR/WebCryptoAPI/</a></dd><dt>Previous Version(s):</dt><dd><a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html">https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html</a></dd><dt>Editors:</dt><dd><a href="http://www.google.com/">Ryan Sleevi</a>, Google, Inc. &lt;sleevi@google.com&gt;</dd><dd><a href="http://www.netflix.com/">Mark Watson</a>, Netflix &lt;watsonm@netflix.com&gt;</dd><dt>Participate:</dt><dd><p>Send feedback to <a href="mailto:public-webcrypto@w3.org?subject=%5BWebCryptoAPI%5D">public-webcrypto@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-webcrypto/">archives</a>), or <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=Web%20Cryptography&amp;component=Web%20Cryptography%20API%20Document">file a bug</a> 
     (see <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=Web%20Cryptography&amp;component=Web%20Cryptography%20API%20Document&amp;resolution=---">existing bugs</a>).</p></dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; view <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr />
 
     <div class="section">
@@ -69,24 +69,12 @@
         <acronym title="Working Group">WG</acronym></a> of the <acronym title="World Wide Web Consortium">W3C</acronym>.
       </p>
 
-      <p class="XXX">
-        Implementors should be aware that this specification is not stable.
-        <strong>Implementors who are not taking part in the discussions are likely to find the
-        specification changing out from under them in incompatible ways.</strong> Vendors interested
-        in implementing this specification before it eventually reaches the Proposed Recommendation
-        stage should join the mailing lists that follow and take part in the discussions.
-      </p>
+    
       <p>
         The Web Cryptography Working Group invites discussion and feedback on this draft document by
         web developers, companies, standardization bodies or forums interested in deployment of secure
-        services with web applications. Specifically, Web Cryptography Working Group is looking for
-        feedback on:
+        services with web applications.
       </p>
-      <ul>
-        <li>developer convenience for managing keys and algorithms;</li>
-        <li>comments on open issues the WG is currently dealing with, highlighted in this working draft;</li>
-        <li>potential missing functionalities to deploy secure web applications.</li>
-      </ul>
       <p>
         Previous discussion of this specification has taken place on three other
         mailing lists: <a href="mailto:whatwg@whatwg.org">whatwg@whatwg.org</a>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -43,8 +43,7 @@
         or code signing, and the confidentiality and integrity of
         communications.
       </p>
-  
-      <div class="ednote"><div class="ednoteHeader">Editorial note</div><p>There are 7 further editorial notes in the document.</p></div>
+ 
     </div>
 
     <div class="section">

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -2726,7 +2726,7 @@ dictionary <dfn id="dfn-RsaOtherPrimesInfo">RsaOtherPrimesInfo</dfn> {
 };
 
 dictionary <dfn id="dfn-JsonWebKey">JsonWebKey</dfn> {
-  <span class="comment">// The following fields are defined in Section 3.1 of <a href="#jwk">JSON Web Key</a></span>
+  <span class="comment">// The following fields are defined in Section 3.1 of <a href="#RFC7517">JSON Web Key</a></span>
   DOMString kty;
   DOMString use;
   sequence&lt;DOMString&gt; key_ops;
@@ -4237,7 +4237,7 @@ dictionary <dfn id="dfn-RsaHashedImportParams">RsaHashedImportParams</dfn> {
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or
+                            <a href="#RFC7517">JSON Web Key</a> or
                             does not contain all of the specified <var>usages</var> values,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -5560,7 +5560,7 @@ dictionary <dfn id="dfn-RsaPssParams">RsaPssParams</dfn> : <a href="#dfn-Algorit
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or
+                            <a href="#RFC7517">JSON Web Key</a> or
                             does not contain all of the specified <var>usages</var> values,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -7148,7 +7148,7 @@ BufferSource <dfn id="dfn-RsaOaepParams-label">label</dfn>;
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or
+                            <a href="#RFC7517">JSON Web Key</a> or
                             does not contain all of the specified <var>usages</var> values,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -8782,7 +8782,7 @@ required <a href="#dfn-NamedCurve">NamedCurve</a> <dfn id="dfn-EcKeyImportParams
                         <li>
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
-                            is invalid according to the requirements of <a href="#jwk">JSON Web
+                            is invalid according to the requirements of <a href="#RFC7517">JSON Web
                             Key</a>, or it does not contain all of the specified <var>usages</var>
                             values,
                             then <a href="#concept-throw">throw</a> a
@@ -8892,14 +8892,14 @@ required <a href="#dfn-NamedCurve">NamedCurve</a> <dfn id="dfn-EcKeyImportParams
                                         <li>
                                           <p>
                                             If <var>jwk</var> does not meet the requirements of Section
-                                            6.2.1 of <a href="#jwa">JSON Web Algorithms</a>, then <a href="#concept-throw">throw</a> a <a href="#dfn-DataError"><code>DataError</code></a>.
+                                            6.2.1 of <a href="#RFC7518">JSON Web Algorithms</a>, then <a href="#concept-throw">throw</a> a <a href="#dfn-DataError"><code>DataError</code></a>.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
                                             Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a> object that represents the
                                             Elliptic Curve public key identified by interpreting
-                                            <var>jwk</var> according to Section 6.2.1 of <a href="#jwa">JSON Web Algorithms</a>.
+                                            <var>jwk</var> according to Section 6.2.1 of <a href="#RFC7518">JSON Web Algorithms</a>.
                                           </p>
                                         </li>
                                         <li>
@@ -9360,14 +9360,14 @@ required <a href="#dfn-NamedCurve">NamedCurve</a> <dfn id="dfn-EcKeyImportParams
                                 <li>
                                   <p>
                                     Set the <code>x</code> attribute of <var>jwk</var> according to the
-                                    definition in Section 6.2.1.2 of <a href="#jwa">JSON Web
+                                    definition in Section 6.2.1.2 of <a href="#RFC7518">JSON Web
                                     Algorithms</a>.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the <code>y</code> attribute of <var>jwk</var> according to the
-                                    definition in Section 6.2.1.3 of <a href="#jwa">JSON Web
+                                    definition in Section 6.2.1.3 of <a href="#RFC7518">JSON Web
                                     Algorithms</a>.
                                   </p>
                                 </li>
@@ -9380,7 +9380,7 @@ required <a href="#dfn-NamedCurve">NamedCurve</a> <dfn id="dfn-EcKeyImportParams
                                     <dd>
                                       <p>
                                         Set the <code>d</code> attribute of <var>jwk</var> according to
-                                        the definition in Section 6.2.2.1 of <a href="#jwa">JSON Web
+                                        the definition in Section 6.2.2.1 of <a href="#RFC7518">JSON Web
                                         Algorithms</a>.
                                       </p>
                                     </dd>
@@ -10235,7 +10235,7 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                         <li>
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
-                            is invalid according to the requirements of <a href="#jwk">JSON Web
+                            is invalid according to the requirements of <a href="#RFC7517">JSON Web
                             Key</a>, or it does not contain all of the specified <var>usages</var>
                             values, then <a href="#concept-throw">throw</a> a <a href="#dfn-DataError"><code>DataError</code></a>.
                           </p>
@@ -10274,14 +10274,14 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                                     <li>
                                       <p>
                                         If <var>jwk</var> does not meet the requirements of Section
-                                        6.2.2 of <a href="#jwa">JSON Web Algorithms</a>, then <a href="#concept-throw">throw</a> a <a href="#dfn-DataError"><code>DataError</code></a>.
+                                        6.2.2 of <a href="#RFC7518">JSON Web Algorithms</a>, then <a href="#concept-throw">throw</a> a <a href="#dfn-DataError"><code>DataError</code></a>.
                                       </p>
                                     </li>
                                     <li>
                                       <p>
                                         Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a> object that represents the
                                         Elliptic Curve private key identified by interpreting
-                                        <var>jwk</var> according to Section 6.2.2 of <a href="#jwa">JSON Web Algorithms</a>.
+                                        <var>jwk</var> according to Section 6.2.2 of <a href="#RFC7518">JSON Web Algorithms</a>.
                                       </p>
                                     </li>
                                     <li>
@@ -10298,14 +10298,14 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                                     <li>
                                       <p>
                                         If <var>jwk</var> does not meet the requirements of Section
-                                        6.2.1 of <a href="#jwa">JSON Web Algorithms</a>, then <a href="#concept-throw">throw</a> a <a href="#dfn-DataError"><code>DataError</code></a>.
+                                        6.2.1 of <a href="#RFC7518">JSON Web Algorithms</a>, then <a href="#concept-throw">throw</a> a <a href="#dfn-DataError"><code>DataError</code></a>.
                                       </p>
                                     </li>
                                     <li>
                                       <p>
                                         Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a> object that represents the
                                         Elliptic Curve public key identified by interpreting
-                                        <var>jwk</var> according to Section 6.2.1 of <a href="#jwa">JSON Web Algorithms</a>.
+                                        <var>jwk</var> according to Section 6.2.1 of <a href="#RFC7518">JSON Web Algorithms</a>.
                                       </p>
                                     </li>
                                     <li>
@@ -10849,14 +10849,14 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                                 <li>
                                   <p>
                                     Set the <code>x</code> attribute of <var>jwk</var> according to the
-                                    definition in Section 6.2.1.2 of <a href="#jwa">JSON Web
+                                    definition in Section 6.2.1.2 of <a href="#RFC7518">JSON Web
                                     Algorithms</a>.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the <code>y</code> attribute of <var>jwk</var> according to the
-                                    definition in Section 6.2.1.3 of <a href="#jwa">JSON Web
+                                    definition in Section 6.2.1.3 of <a href="#RFC7518">JSON Web
                                     Algorithms</a>.
                                   </p>
                                 </li>
@@ -10869,7 +10869,7 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                                     <dd>
                                       <p>
                                         Set the <code>d</code> attribute of <var>jwk</var> according to the
-                                        definition in Section 6.2.2.1 of <a href="#jwa">JSON Web
+                                        definition in Section 6.2.2.1 of <a href="#RFC7518">JSON Web
                                         Algorithms</a>.
                                       </p>
                                     </dd>
@@ -11311,7 +11311,7 @@ dictionary <dfn id="dfn-AesDerivedKeyParams">AesDerivedKeyParams</dfn> : <a href
                         <li>
                           <p>
                             If <var>jwk</var> does not meet the requirements of
-                            Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>,
+                            Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
                           </p>
@@ -11357,7 +11357,7 @@ dictionary <dfn id="dfn-AesDerivedKeyParams">AesDerivedKeyParams</dfn> : <a href
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or
+                            <a href="#RFC7517">JSON Web Key</a> or
                             does not contain all of the specified <var>usages</var> values,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -11464,7 +11464,7 @@ dictionary <dfn id="dfn-AesDerivedKeyParams">AesDerivedKeyParams</dfn> : <a href
                           <p>
                             Set the <code>k</code> attribute of <var>jwk</var> to be a string
                             containing the raw octets of the key represented by [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>.
+                            <var>key</var>, encoded according to Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>.
                           </p>
                         </li>
                         <li>
@@ -11842,7 +11842,7 @@ required BufferSource <dfn id="dfn-AesCbcParams-iv">iv</dfn>;
                         <li>
                           <p>
                             If <var>jwk</var> does not meet the requirements of
-                            Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>,
+                            Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
                           </p>
@@ -11889,7 +11889,7 @@ required BufferSource <dfn id="dfn-AesCbcParams-iv">iv</dfn>;
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or                           
+                            <a href="#RFC7517">JSON Web Key</a> or                           
                             does not contain all of the specified <var>usages</var> values,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -11996,7 +11996,7 @@ required BufferSource <dfn id="dfn-AesCbcParams-iv">iv</dfn>;
                           <p>
                             Set the <code>k</code> attribute of <var>jwk</var> to be a string
                             containing the raw octets of the key represented by [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>.
+                            <var>key</var>, encoded according to Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>.
                           </p>
                         </li>
                         <li>
@@ -12455,7 +12455,7 @@ BufferSource <dfn id="dfn-AesGcmParams-additionalData">additionalData</dfn>;
                         <li>
                           <p>
                             If <var>jwk</var> does not meet the requirements of
-                            Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>,
+                            Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
                           </p>
@@ -12502,7 +12502,7 @@ BufferSource <dfn id="dfn-AesGcmParams-additionalData">additionalData</dfn>;
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or
+                            <a href="#RFC7517">JSON Web Key</a> or
                             does not contain all of the specified <var>usages</var> values,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -12609,7 +12609,7 @@ BufferSource <dfn id="dfn-AesGcmParams-additionalData">additionalData</dfn>;
                           <p>
                             Set the <code>k</code> attribute of <var>jwk</var> to be a string
                             containing the raw octets of the key represented by [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>.
+                            <var>key</var>, encoded according to Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>.
                           </p>
                         </li>
                         <li>
@@ -12924,7 +12924,7 @@ BufferSource <dfn id="dfn-AesGcmParams-additionalData">additionalData</dfn>;
                         <li>
                           <p>
                             If <var>jwk</var> does not meet the requirements of
-                            Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>, 
+                            Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>, 
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
                           </p>
@@ -12971,7 +12971,7 @@ BufferSource <dfn id="dfn-AesGcmParams-additionalData">additionalData</dfn>;
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or
+                            <a href="#RFC7517">JSON Web Key</a> or
                             does not contain all of the specified <var>usages</var> values,
                               then <a href="#concept-throw">throw</a> a
                               <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -13077,7 +13077,7 @@ BufferSource <dfn id="dfn-AesGcmParams-additionalData">additionalData</dfn>;
                           <p>
                             Set the <code>k</code> attribute of <var>jwk</var> to be a string
                             containing the raw octets of the key represented by [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>.
+                            <var>key</var>, encoded according to Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>.
                           </p>
                         </li>
                         <li>
@@ -13478,7 +13478,7 @@ required <a href="#dfn-HashAlgorithmIdentifier">HashAlgorithmIdentifier</a> <dfn
                         <li>
                           <p>
                             If <var>jwk</var> does not meet the requirements of
-                            Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>, 
+                            Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>, 
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
                           </p>
@@ -13643,7 +13643,7 @@ required <a href="#dfn-HashAlgorithmIdentifier">HashAlgorithmIdentifier</a> <dfn
                           <p>
                             If the <code>"key_ops"</code> field of <var>jwk</var> is present, and
                             is invalid according to the requirements of
-                            <a href="#jwk">JSON Web Key</a> or
+                            <a href="#RFC7517">JSON Web Key</a> or
                             does not contain all of the specified <var>usages</var> values,
                             then <a href="#concept-throw">throw</a> a
                             <a href="#dfn-DataError"><code>DataError</code></a>.
@@ -13806,7 +13806,7 @@ required <a href="#dfn-HashAlgorithmIdentifier">HashAlgorithmIdentifier</a> <dfn
                           <p>
                             Set the <code>k</code> attribute of <var>jwk</var> to be a string
                             containing the raw octets of the key represented by [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of <a href="#jwa">JSON Web Algorithms</a>.
+                            <var>key</var>, encoded according to Section 6.4 of <a href="#RFC7518">JSON Web Algorithms</a>.
                           </p>
                         </li>
                         <li>
@@ -14823,7 +14823,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
              <dt id="DOM4">DOM4</dt>
              <dd>
                <cite><a href="http://www.w3.org/TR/dom/">W3C DOM4</a></cite>,
-               A. Gregor, A. van Kesteren, Ms2ger, Alex Russell, Robin Berjon. W3C Recommendation 19 November 2015
+               A. Gregor, A. van Kesteren, Ms2ger, A. Russell, R. Berjon. W3C.
              </dd>
              <dt id="ECMA-262">ECMA262</dt>
              <dd>
@@ -14846,8 +14846,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
              </dd>
              <dt id="HTML">HTML</dt>
              <dd>
-               <cite><a href="http://dev.w3.org/html5/spec/Overview.html">HTML5: A vocabulary and
-               associated APIs for HTML and XHTML (work in progress)</a></cite>, I. Hickson. W3C.
+               <cite><a href="http://www.w3.org/TR/html5/">HTML5: A vocabulary and associated APIs for HTML and XHTML</a></cite>, I. Hickson, R. Berjon, S. Faulkner, T. Leithead, E. Navara, E. O'Connor, and S. Pfeiffer. W3C.
              </dd>
              <dt id="X690">ITU-T Recommendation X.690 (11/08)</dt>
              <dd>
@@ -14856,16 +14855,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
                  ASN.1 encoding rules: Specification of Basic Encoding Rules (BER), Canonical 
                  Encoding Rules (CER) and Distinguished Encoding Rules (DER)</a>
                </cite>, ITU-T.
-             </dd>
-             <dt id="jwk">JSON Web Key</dt>
-             <dd>
-                <cite><a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-key">JSON Web Key
-                (work in progress)</a></cite>, M. Jones, Microsoft.
-             </dd>
-             <dt id="jwa">JSON Web Algorithms</dt>
-             <dd>
-                <cite><a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms">JSON
-                Web Algorithms (work in progress)</a></cite>, M. Jones, Microsoft.
              </dd>
              <dt id="SP800-38A">NIST SP 800-38A</dt>
             <dd>
@@ -14911,12 +14900,12 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
              <dt id="RFC2315">RFC 2315</dt>
              <dd>
                <cite><a href="http://tools.ietf.org/html/rfc2315">PKCS #7: Cryptographic
-               Message Syntax, Version 1.5</a></cite>, B. Kaliski. RSA Laboratories.
+               Message Syntax, Version 1.5</a></cite>, B. Kaliski. IETF.
              </dd>
              <dt id="RFC2898">RFC 2898</dt>
              <dd>
                <cite><a href="http://tools.ietf.org/html/RFC2898">PKCS #5: Password-Based
-               Cryptography Specification, Version 2.0</a></cite>, B. Kaliski. RSA Laboratories
+               Cryptography Specification, Version 2.0</a></cite>, B. Kaliski. IETF
              </dd>
              <dt id="RFC3279">RFC 3279</dt>
              <dd>
@@ -14960,6 +14949,16 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
               </a></cite>,
               S. Turner, D. Brown. IETF.
              </dd>
+	      <dt id="RFC7517">RFC 7517</dt>
+             <dd>
+                <cite><a href="https://tools.ietf.org/html/rfc7517">JSON Web Key
+                </a></cite>, M. Jones. IETF.
+             </dd>
+             <dt id="RFC7518">RFC 7518</dt>
+             <dd>
+                <cite><a href="http://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms">JSON
+                Web Algorithms</a></cite>, M. Jones. IETF.
+             </dd>
              <dt id="WebIDL">Web IDL (Second Edition)</dt>
              <dd>
                <cite><a href="http://heycam.github.io/webidl/">Web IDL (Second Edition)</a></cite>,
@@ -14984,26 +14983,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <dd>
               <cite><a href="http://www.opengroup.org/security/cdsa.htm">Common Security: CDSA and
               CSSM, Version 2 (with corrigenda)</a></cite>, the Open Group.
-            </dd>
-            <dt id="CNG">CNG</dt>
-            <dd>
-              <cite><a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa376210(v=vs.85).aspx">
-              Cryptography API: Next Generation</a></cite>, Microsoft Corporation.
-            </dd>
-            <dt id="CryptoAPI">CryptoAPI</dt>
-            <dd>
-              <cite><a href="http://msdn.microsoft.com/en-us/library/aa380256.aspx">Cryptography
-              Reference</a></cite>, Microsoft Corporation.
-            </dd>
-            <dt id="draft-TLS-OBC">DRAFT-TLS-OBC</dt>
-            <dd>
-              <cite><a href="http://tools.ietf.org/html/draft-balfanz-tls-obc-01">TLS Origin-Bound
-              Certificates</a></cite>, D. Balfanz, D. Smetters, M. Upadhyay, A. Barth. IETF.
-            </dd>
-            <dt id="FileAPI">FileAPI</dt>
-            <dd>
-              <cite><a href="http://www.w3.org/TR/FileAPI/">File API</a></cite>,
-              A. Ranganathan, J. Sicking. W3C.
             </dd>
             <dt id="IndexedDB">Indexed Database API</dt>
             <dd>
@@ -15037,11 +15016,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <dd>
               <cite><a href="https://tools.ietf.org/html/rfc5958">Asymmetric Key Packages</a></cite>, 
               S. Turner. IETF.
-            </dd>
-            <dt id="StreamsAPI">StreamsAPI</dt>
-            <dd>
-              <cite><a href="https://dvcs.w3.org/hg/streams-api/raw-file/tip/Overview.htm">Streams
-              API</a> </cite>, F. Moussa. W3C.
             </dd>
           </dl>
         </div>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -6153,13 +6153,11 @@ dictionary <dfn id="dfn-RsaPssParams">RsaPssParams</dfn> : <a href="#dfn-Algorit
                                 RSA private key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
                                 <var>key</var>
                               </p>
-                              <div class="ednote"><div class="ednoteHeader">Editorial note</div>
                                 <a href="#RFC5208">RFC 5208</a> specifies that the encoding of
                                 this field should be <em>BER</em> encoded in Section 5 (as a "for
                                 example"). However, to avoid requiring WebCrypto implementations
                                 support BER-encoding and BER-decoding, only <em>DER</em> encodings
                                 are produced or accepted.
-                              </div>
                             </li>
                           </ul>
                         </li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14669,7 +14669,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "alg"</li>
             <li>JOSE Implementation Requirements: Optional+</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "RSA-OAEP-512"</li>
@@ -14677,7 +14678,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "alg"</li>
             <li>JOSE Implementation Requirements: Optional+</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A128CBC"</li>
@@ -14685,7 +14687,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A192CBC"</li>
@@ -14693,7 +14696,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>            
           <ul>
             <li>Algorithm Name: "A256CBC"</li>
@@ -14701,7 +14705,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>            
           <ul>
             <li>Algorithm Name: "A128CTR"</li>
@@ -14709,7 +14714,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>            
           <ul>
             <li>Algorithm Name: "A192CTR"</li>
@@ -14717,7 +14723,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A256CTR"</li>
@@ -14725,7 +14732,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A128CMAC"</li>
@@ -14733,7 +14741,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>          
           <ul>
             <li>Algorithm Name: "A192CMAC"</li>
@@ -14741,7 +14750,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A256CMAC"</li>
@@ -14749,7 +14759,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A128CFB8"</li>
@@ -14757,7 +14768,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A192CFB8"</li>
@@ -14765,7 +14777,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A256CFB8"</li>
@@ -14773,7 +14786,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "HS1"</li>
@@ -14781,7 +14795,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
         </div>
         <div id="iana-section-jwk" class="section">
@@ -14792,7 +14807,8 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Used with "kty" Value(s): *</li>
             <li>Parameter Information Class: Public</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document]]</li><li>Algorithm Analysis Document(s): n/a </li>
+            <li>Specification Document(s): [[ This Document]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
         </div>
       </div>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -515,7 +515,10 @@
             This specification includes descriptions for a variety of cryptographic operations, some
             of which have known weaknesses when used inappropriately. Application developers must
             take care and review appropriate and current cryptographic literature, to understand and
-            mitigate such issues. In general, application developers are <strong>strongly</strong>
+            mitigate such issues. Note that the security
+properties of particular algorithms in this specification are liable to
+change. Detailed questions can be asked to the IRTF CFRG (CryptoForum Research Group), who are maintaining a <a href="#irtf-cfrg-webcrypto">document</a> that outlines security
+guidelines for algorithms and key sizes given in this API. In general, application developers are <strong>strongly</strong>
             discouraged from inventing new cryptographic protocols; as with all applications, users
             of this specification will be best served through the use of existing protocols, of
             which this specification provides the necessary building blocks to implement.
@@ -15016,6 +15019,11 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <dd>
               <cite><a href="https://tools.ietf.org/html/rfc5958">Asymmetric Key Packages</a></cite>, 
               S. Turner. IETF.
+            </dd>
+          </dl>
+	    <dt id="irtf-cfrg-webcrypto">Security Guidelines for Cryptographic Algorithms in the W3C Web Cryptography API</dt>
+            <dd>
+              <cite><a href="https://www.ietf.org/id/draft-irtf-cfrg-webcrypto-algorithms">Security Guidelines for Cryptographic Algorithms in the W3C Web Cryptography API</a></cite>, H. Halpin, G. Steel. IRTF.
             </dd>
           </dl>
         </div>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14661,6 +14661,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
             <li>Specification Document(s): [[ This Document ]]</li>
+	    <li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "RSA-OAEP-384"</li>
@@ -14668,7 +14669,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "alg"</li>
             <li>JOSE Implementation Requirements: Optional+</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "RSA-OAEP-512"</li>
@@ -14676,7 +14677,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "alg"</li>
             <li>JOSE Implementation Requirements: Optional+</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A128CBC"</li>
@@ -14684,7 +14685,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A192CBC"</li>
@@ -14692,7 +14693,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>            
           <ul>
             <li>Algorithm Name: "A256CBC"</li>
@@ -14700,7 +14701,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>            
           <ul>
             <li>Algorithm Name: "A128CTR"</li>
@@ -14708,7 +14709,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>            
           <ul>
             <li>Algorithm Name: "A192CTR"</li>
@@ -14716,7 +14717,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A256CTR"</li>
@@ -14724,7 +14725,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A128CMAC"</li>
@@ -14732,7 +14733,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>          
           <ul>
             <li>Algorithm Name: "A192CMAC"</li>
@@ -14740,7 +14741,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A256CMAC"</li>
@@ -14748,7 +14749,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A128CFB8"</li>
@@ -14756,7 +14757,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A192CFB8"</li>
@@ -14764,7 +14765,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "A256CFB8"</li>
@@ -14772,7 +14773,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
           <ul>
             <li>Algorithm Name: "HS1"</li>
@@ -14780,7 +14781,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Algorithm Usage Location(s): "JWK"</li>
             <li>JOSE Implementation Requirements: Prohibited</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document ]]</li>
+            <li>Specification Document(s): [[ This Document ]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
         </div>
         <div id="iana-section-jwk" class="section">
@@ -14791,7 +14792,7 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
             <li>Used with "kty" Value(s): *</li>
             <li>Parameter Information Class: Public</li>
             <li>Change Controller: W3C Web Cryptography Working Group</li>
-            <li>Specification Document(s): [[ This Document]]</li>
+            <li>Specification Document(s): [[ This Document]]</li><li>Algorithm Analysis Document(s): n/a </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
In general, when we move to Proposed Recommendation status we want Editorial Notes removed. However, it seemed for most of these editorial notes that the point being made (such as BER encoding not being supported) was important and should be part of the spec. So removed the editorial notes and put it back into their text back into the main spec. text. 

The two exceptions were 1) Updating to W3C DOM4 and 2) Changing text around algorithms being 'features at risk'.

References were updated to normative versions. Added also (to resolve Akamai formal objection) was the sentence in this email (https://lists.w3.org/Archives/Public/public-webcrypto/2015Oct/0040.html) and a reference to the CFRG note on security guidelines.

Of course, the final call on this should be that of the editors. 