### PR TITLE
Switch to RFC 6090 for reference

### DIFF
--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -8760,7 +8760,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                                 <a href="#dfn-DataError"><code>DataError</code></a>.
                                 The uncompressed point format MUST be supported.
                                 If the implementation does not support the compressed point format and
-                                a compressed point is decoded, 
+                                a compressed point is provided, 
                                 <a href="#concept-throw">throw</a> a
                                 <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                               </p>
@@ -9353,7 +9353,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                                     <a href="#dfn-DataError"><code>DataError</code></a>.
                                     The uncompressed point format MUST be supported.
                                     If the implementation does not support the compressed point format and
-                                    a compressed point is decoded, 
+                                    a compressed point is provided, 
                                     <a href="#concept-throw">throw</a> a
                                     <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                                   </p>
@@ -10464,7 +10464,7 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                                 <a href="#dfn-DataError"><code>DataError</code></a>.
                                 The uncompressed point format MUST be supported.
                                 If the implementation does not support the compressed point format and
-                                a compressed point is decoded, 
+                                a compressed point is provided, 
                                 <a href="#concept-throw">throw</a> a
                                 <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                               </p>
@@ -11010,7 +11010,7 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                                     <a href="#dfn-DataError"><code>DataError</code></a>.
                                     The uncompressed point format MUST be supported.
                                     If the implementation does not support the compressed point format and
-                                    a compressed point is decoded, 
+                                    a compressed point is provided, 
                                     <a href="#concept-throw">throw</a> a
                                     <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                                   </p>

--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -8172,7 +8172,7 @@ dictionary <dfn id="dfn-RsaOaepParams">RsaOaepParams</dfn> : <a href="#dfn-Algor
           <p>
             The <code>"ECDSA"</code> algorithm identifier is used to perform signing
             and verification using the ECDSA algorithm specified in
-            [<cite><a href="#X9.62">X9.62</a></cite>] and using the SHA hash functions and elliptic
+            [<cite><a href="#RFC6090">RFC6090</a></cite>] and using the SHA hash functions and elliptic
             curves defined in this specification.
           </p>
           <p>
@@ -8338,8 +8338,8 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                       <ol>
                         <li>
                           <p>
-                            Perform the ECDSA signing process, as specified in <a href="#X9.62">X9.62</a>,
-                            Section 7.3, with <var>M</var> as the message, using <var>params</var> as the
+                            Perform the ECDSA signing process, as specified in <a href="#RFC6090">RFC6090</a>,
+                            Section 5.4, with <var>M</var> as the message, using <var>params</var> as the
                             EC domain parameters, and with <var>d</var> as the private key.
                           </p>
                         </li>
@@ -8443,7 +8443,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                     <dd>
                       <p>
                         Perform the ECDSA verifying process, as specified in <a
-                        href="#X9.62">X9.62</a>, Section 7.4, with <var>M</var> as the received
+                        href="#RFC6090">RFC6090</a>, Section 5.3, with <var>M</var> as the received
                         message, <var>signature</var> as the received signature and using
                         <var>params</var> as the EC domain parameters, and 
                         <var>Q</var> as the public key.
@@ -8498,7 +8498,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                     </dt>
                     <dd>
                       <p>
-                        Generate an Elliptic Curve key pair, as defined in [<a href="#X9.62">X9.62</a>]
+                        Generate an Elliptic Curve key pair, as defined in [<a href="#RFC6090">RFC6090</a>]
                         with domain parameters for the curve identified by
                         the <a href="#dfn-EcKeyGenParams-namedCurve">namedCurve</a> member of
                         <var>normalizedAlgorithm</var>.
@@ -8753,8 +8753,16 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                               <p>
                                 Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
                                 object that represents the Elliptic Curve public key identified by
-                                performing the conversion steps defined in Section 2.2 of <a
-                                href="#RFC5480">RFC 5480</a>.
+                                performing the conversion steps defined in Section 2.3.4 of <a
+                                href="#SEC1">SEC 1</a>.
+                                If a decode error occurs or an identity point is found,
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-DataError"><code>DataError</code></a>.
+                                The uncompressed point format MUST be supported.
+                                If the implementation does not support the compressed point format and
+                                a compressed point is decoded, 
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -9336,16 +9344,18 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>Q</var> be the elliptic curve point on the curve identified
-                                    by the <a href="#dfn-EcKeyImportParams-namedCurve">namedCurve</a>
-                                    member of <var>normalizedAlgorithm</var> identified by interpreting
-                                    <var>keyData</var> according to <a href="#X9.62">X9.62</a> Annex A.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
                                     Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
-                                    object that represents <var>Q</var>
+                                    object that represents the Elliptic Curve public key identified by
+                                    performing the conversion steps defined in Section 2.3.4 of <a
+                                    href="#SEC1">SEC 1</a>.
+                                    If a decode error occurs or an identity point is found,
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-DataError"><code>DataError</code></a>.
+                                    The uncompressed point format MUST be supported.
+                                    If the implementation does not support the compressed point format and
+                                    a compressed point is decoded, 
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                                   </p>
                                 </li>
                               </ol>
@@ -9926,7 +9936,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                                 Let <var>data</var> be an <a href="#dfn-octet-string">octet string</a> representing the Elliptic Curve
                                 point <var>Q</var> represented by [[<a
                                 href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                                <var>key</var> according to <a href="#X9.62">X9.62</a> Annex A.
+                                <var>key</var> according to <a href="#SEC1">SEC 1</a> 2.3.3 using the uncompressed format.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -10447,8 +10457,16 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                               <p>
                                 Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
                                 object that represents the Elliptic Curve public key identified by
-                                performing the conversion steps defined in Section 2.2 of <a
-                                href="#RFC5480">RFC 5480</a>.
+                                performing the conversion steps defined in Section 2.3.4 of <a
+                                href="#SEC1">SEC 1</a>.
+                                If a decode error occurs or an identity point is found,
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-DataError"><code>DataError</code></a>.
+                                The uncompressed point format MUST be supported.
+                                If the implementation does not support the compressed point format and
+                                a compressed point is decoded, 
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -10983,16 +11001,18 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>Q</var> be the elliptic curve point on the curve identified
-                                    by the <a href="#dfn-EcKeyImportParams-namedCurve">namedCurve</a>
-                                    member of <var>normalizedAlgorithm</var> identified by interpreting
-                                    <var>keyData</var> according to <a href="#X9.62">X9.62</a> Annex A.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
                                     Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
-                                    object that represents <var>Q</var>
+                                    object that represents the Elliptic Curve public key identified by
+                                    performing the conversion steps defined in Section 2.3.4 of <a
+                                    href="#SEC1">SEC 1</a>.
+                                    If a decode error occurs or an identity point is found,
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-DataError"><code>DataError</code></a>.
+                                    The uncompressed point format MUST be supported.
+                                    If the implementation does not support the compressed point format and
+                                    a compressed point is decoded, 
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                                   </p>
                                 </li>
                               </ol>
@@ -11136,7 +11156,7 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                                         represents the Elliptic Curve public key represented by the [[<a
                                         href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
                                         <var>key</var> according to the encoding rules specified in
-                                        Section 2.2 of <a href="#RFC5480">RFC 5480</a> and using the
+                                        Section 2.3.3 of <a href="#SEC1">SEC 1</a> and using the
                                         uncompressed form.
                                       </p>
                                       <dl class="switch">
@@ -11550,10 +11570,12 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                             </dt>
                             <dd>
                               <p>
-                                Let <var>data</var> be an <a href="#dfn-octet-string">octet string</a> representing the Elliptic Curve
-                                point <var>Q</var> represented by [[<a
+                                Let <var>data</var> be the <a href="#dfn-octet-string">octet string</a> that
+                                represents the Elliptic Curve public key represented by the [[<a
                                 href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                                <var>key</var> according to <a href="#X9.62">X9.62</a> Annex A.
+                                <var>key</var> according to the encoding rules specified in
+                                Section 2.3.3 of <a href="#SEC1">SEC 1</a> and using the
+                                uncompressed form.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -15442,6 +15464,11 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
              <dd>
                <cite><a href="http://www.ietf.org/rfc/rfc6090.txt">Fundamental Elliptic Curve Cryptography
                Algorithms</a></cite>, D. McGrew, K. Igoe, M.Salter. IETF.
+             </dd>
+             <dt id="SEC1">SEC 1</dt>
+             <dd>
+               <cite><a href="http://www.secg.org/sec1-v2.pdf">SEC 1: Elliptic Curve Cryptography</a></cite>,
+               Certicom Research
              </dd>
              <dt id="WebIDL">Web IDL (Second Edition)</dt>
              <dd>

--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -10084,15 +10084,16 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                         <li>
                           <p>
                             Perform the ECDH primitive specified in <a href="#RFC6090">RFC6090</a> Section
-                            3 with <var>key</var> as the EC private key <var>d</var> and the EC public
+                            4 with <var>key</var> as the EC private key <var>d</var> and the EC public
                             key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]]
-                            internal slot of <var>publicKey</var> as the EC public key <var>Q</var>.
+                            internal slot of <var>publicKey</var> as the EC public key.
                           </p>
                         </li>
                         <li>
                           <p>
                             Let <var>secret</var> be the result of applying the field element to
-                            <a href="#dfn-octet-string">octet string</a> conversion defined in Section 6.2 of <a href="#RFC6090">RFC6090</a>
+                            <a href="#dfn-octet-string">octet string</a> conversion defined in Section
+                            6.2 of <a href="#RFC6090">RFC6090</a>
                             to the output of the ECDH primitive.
                           </p>
                         </li>

--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -9807,7 +9807,7 @@ required <a href="#dfn-NamedCurve">NamedCurve</a> <dfn id="dfn-EcKeyImportParams
           <h4>Description</h4>
           <p>
             This describes using Elliptic Curve Diffie-Hellman (ECDH) for key generation and key
-            agreement, as specified by <a href="#X9.63">X9.63</a>.
+            agreement, as specified by <a href="#RFC6090">RFC6090</a>.
           </p>
           <p>
             <a href="#dfn-applicable-specification">Other specifications</a>
@@ -9891,7 +9891,7 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                     <dd>
                       <p>
                         Generate an Elliptic Curve key pair, as defined in [<a
-                        href="#X9.63">X9.63</a>] with domain parameters for the curve identified by
+                        href="#RFC6090">RFC6090</a>] with domain parameters for the curve identified by
                         the <a href="#dfn-EcKeyGenParams-namedCurve">namedCurve</a> member of
                         <var>normalizedAlgorithm</var>.
                       </p>
@@ -10083,8 +10083,8 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                       <ol>
                         <li>
                           <p>
-                            Perform the ECDH primitive specified in <a href="#X9.63">X9.63</a> Section
-                            5.4.1 with <var>key</var> as the EC private key <var>d</var> and the EC public
+                            Perform the ECDH primitive specified in <a href="#RFC6090">RFC6090</a> Section
+                            3 with <var>key</var> as the EC private key <var>d</var> and the EC public
                             key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]]
                             internal slot of <var>publicKey</var> as the EC public key <var>Q</var>.
                           </p>
@@ -10092,7 +10092,7 @@ required <a href="#dfn-CryptoKey">CryptoKey</a> <dfn id="dfn-EcdhKeyDeriveParams
                         <li>
                           <p>
                             Let <var>secret</var> be the result of applying the field element to
-                            <a href="#dfn-octet-string">octet string</a> conversion defined in Section ? of <a href="#X9.63">X9.63</a>
+                            <a href="#dfn-octet-string">octet string</a> conversion defined in Section 6.2 of <a href="#RFC6090">RFC6090</a>
                             to the output of the ECDH primitive.
                           </p>
                         </li>
@@ -15429,6 +15429,11 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
               </a></cite>,
               S. Turner, D. Brown. IETF.
              </dd>
+             <dt id="RFC6090">RFC6090</dt>
+             <dd>
+               <cite><a href="http://www.ietf.org/rfc/rfc6090.txt">Fundamental Elliptic Curve Cryptography
+               Algorithms</a></cite>, D. McGrew, K. Igoe, M.Salter. IETF.
+             </dd>
              <dt id="WebIDL">Web IDL (Second Edition)</dt>
              <dd>
                <cite><a href="http://heycam.github.io/webidl/">Web IDL (Second Edition)</a></cite>,
@@ -15438,11 +15443,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
              <dd>
                <cite>ANS X9.62–2005: Public Key Cryptography for the Financial Services Industry,
                The Elliptic Curve Digital Signature Algorithm (ECDSA)</cite>, ANSI.
-             </dd>
-             <dt id="X9.63">X9.63</dt>
-             <dd>
-               <cite>ANS X9.63–2001: Public Key Cryptography for the Financial Services Industry,
-               Key Agreement and Key Transport Using Elliptic Curve Cryptography</cite>, ANSI.
              </dd>
             </dl>
         </div>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -28,7 +28,7 @@
   <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/W3C-ED" type="text/css" /></head>
 
   <body>
-    <div class="head"><p><a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48" alt="W3C" /></a></p><h1>Web Cryptography API</h1><h2>W3C Editor’s Draft <em>8 September 2016</em></h2><dl><dt>Latest Editor’s Draft:</dt><dd><a href="http://w3c.github.io/webcrypto/Overview.html">http://w3c.github.io/webcrypto/Overview.html</a></dd><dt>Latest Published Version:</dt><dd><a href="http://www.w3.org/TR/WebCryptoAPI/">http://www.w3.org/TR/WebCryptoAPI/</a></dd><dt>Previous Version(s):</dt><dd><a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html">https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html</a></dd><dt>Editor:</dt><dd><a href="http://www.netflix.com/">Mark Watson</a>, Netflix &lt;watsonm@netflix.com&gt;</dd><dt>Participate:</dt><dd><a href="https://github.com/w3c/webcrypto">We are on GitHub</a>.
+    <div class="head"><p><a class="logo" href="http://www.w3.org/"><img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48" alt="W3C" /></a></p><h1>Web Cryptography API</h1><h2>W3C Editor’s Draft <em>NaN October '010</em></h2><dl><dt>Latest Editor’s Draft:</dt><dd><a href="http://w3c.github.io/webcrypto/Overview.html">http://w3c.github.io/webcrypto/Overview.html</a></dd><dt>Latest Published Version:</dt><dd><a href="http://www.w3.org/TR/WebCryptoAPI/">http://www.w3.org/TR/WebCryptoAPI/</a></dd><dt>Previous Version(s):</dt><dd><a href="https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html">https://dvcs.w3.org/hg/webcrypto-api/raw-file/0fe9b34c13fb/spec/Overview.html</a></dd><dt>Editor:</dt><dd><a href="http://www.netflix.com/">Mark Watson</a>, Netflix &lt;watsonm@netflix.com&gt;</dd><dt>Participate:</dt><dd><a href="https://github.com/w3c/webcrypto">We are on GitHub</a>.
           </dd><dd>
           Send feedback to <a href="mailto:public-webcrypto@w3.org?subject=%5BWebCryptoAPI%5D">public-webcrypto@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/public-webcrypto/">archives</a>).
           </dd><dd><a href="https://github.com/w3c/webcrypto/issues/new">File a bug</a>
@@ -60,7 +60,7 @@
         report can be found in the <a href="http://www.w3.org/TR/">W3C technical
           reports index</a> at http://www.w3.org/TR/.
       </em></p><p>
-        This document is the 8 September 2016 <b>Editor’s Draft</b> of the
+        This document is the NaN October '010 <b>Editor’s Draft</b> of the
         <cite>Web Cryptography API</cite> specification.
       
       Please send comments about this document to
@@ -7931,7 +7931,7 @@ dictionary <dfn id="dfn-RsaOaepParams">RsaOaepParams</dfn> : <a href="#dfn-Algor
           <p>
             The <code>"ECDSA"</code> algorithm identifier is used to perform signing
             and verification using the ECDSA algorithm specified in
-            [<cite><a href="#X9.62">X9.62</a></cite>] and using the SHA hash functions and elliptic
+            [<cite><a href="#RFC6090">RFC6090</a></cite>] and using the SHA hash functions and elliptic
             curves defined in this specification.
           </p>
           <p>
@@ -8095,8 +8095,8 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                       <ol>
                         <li>
                           <p>
-                            Perform the ECDSA signing process, as specified in <a href="#X9.62">X9.62</a>,
-                            Section 7.3, with <var>M</var> as the message, using <var>params</var> as the
+                            Perform the ECDSA signing process, as specified in <a href="#RFC6090">RFC6090</a>,
+                            Section 5.4, with <var>M</var> as the message, using <var>params</var> as the
                             EC domain parameters, and with <var>d</var> as the private key.
                           </p>
                         </li>
@@ -8197,7 +8197,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                     </dt>
                     <dd>
                       <p>
-                        Perform the ECDSA verifying process, as specified in <a href="#X9.62">X9.62</a>, Section 7.4, with <var>M</var> as the received
+                        Perform the ECDSA verifying process, as specified in <a href="#RFC6090">RFC6090</a>, Section 5.3, with <var>M</var> as the received
                         message, <var>signature</var> as the received signature and using
                         <var>params</var> as the EC domain parameters, and 
                         <var>Q</var> as the public key.
@@ -8252,7 +8252,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                     </dt>
                     <dd>
                       <p>
-                        Generate an Elliptic Curve key pair, as defined in [<a href="#X9.62">X9.62</a>]
+                        Generate an Elliptic Curve key pair, as defined in [<a href="#RFC6090">RFC6090</a>]
                         with domain parameters for the curve identified by
                         the <a href="#dfn-EcKeyGenParams-namedCurve">namedCurve</a> member of
                         <var>normalizedAlgorithm</var>.
@@ -8505,7 +8505,15 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                               <p>
                                 Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
                                 object that represents the Elliptic Curve public key identified by
-                                performing the conversion steps defined in Section 2.2 of <a href="#RFC5480">RFC 5480</a>.
+                                performing the conversion steps defined in Section 2.3.4 of <a href="#SEC1">SEC 1</a>.
+                                If a decode error occurs or an identity point is found,
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-DataError"><code>DataError</code></a>.
+                                The uncompressed point format MUST be supported.
+                                If the implementation does not support the compressed point format and
+                                a compressed point is decoded, 
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -9052,16 +9060,17 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>Q</var> be the elliptic curve point on the curve identified
-                                    by the <a href="#dfn-EcKeyImportParams-namedCurve">namedCurve</a>
-                                    member of <var>normalizedAlgorithm</var> identified by interpreting
-                                    <var>keyData</var> according to <a href="#X9.62">X9.62</a> Annex A.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
                                     Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
-                                    object that represents <var>Q</var>
+                                    object that represents the Elliptic Curve public key identified by
+                                    performing the conversion steps defined in Section 2.3.4 of <a href="#SEC1">SEC 1</a>.
+                                    If a decode error occurs or an identity point is found,
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-DataError"><code>DataError</code></a>.
+                                    The uncompressed point format MUST be supported.
+                                    If the implementation does not support the compressed point format and
+                                    a compressed point is decoded, 
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                                   </p>
                                 </li>
                               </ol>
@@ -9606,7 +9615,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
                               <p>
                                 Let <var>data</var> be an <a href="#dfn-octet-string">octet string</a> representing the Elliptic Curve
                                 point <var>Q</var> represented by [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                                <var>key</var> according to <a href="#X9.62">X9.62</a> Annex A.
+                                <var>key</var> according to <a href="#SEC1">SEC 1</a> 2.3.3 using the uncompressed format.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -9657,7 +9666,7 @@ dictionary <dfn id="dfn-EcKeyImportParams">EcKeyImportParams</dfn> : <a href="#d
           <h4>24.1. Description</h4>
           <p>
             This describes using Elliptic Curve Diffie-Hellman (ECDH) for key generation and key
-            agreement, as specified by <a href="#X9.63">X9.63</a>.
+            agreement, as specified by <a href="#RFC6090">RFC6090</a>.
           </p>
           <p>
             <a href="#dfn-applicable-specification">Other specifications</a>
@@ -9740,7 +9749,7 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                     </dt>
                     <dd>
                       <p>
-                        Generate an Elliptic Curve key pair, as defined in [<a href="#X9.63">X9.63</a>] with domain parameters for the curve identified by
+                        Generate an Elliptic Curve key pair, as defined in [<a href="#RFC6090">RFC6090</a>] with domain parameters for the curve identified by
                         the <a href="#dfn-EcKeyGenParams-namedCurve">namedCurve</a> member of
                         <var>normalizedAlgorithm</var>.
                       </p>
@@ -9932,16 +9941,17 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                       <ol>
                         <li>
                           <p>
-                            Perform the ECDH primitive specified in <a href="#X9.63">X9.63</a> Section
-                            5.4.1 with <var>key</var> as the EC private key <var>d</var> and the EC public
+                            Perform the ECDH primitive specified in <a href="#RFC6090">RFC6090</a> Section
+                            4 with <var>key</var> as the EC private key <var>d</var> and the EC public
                             key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]]
-                            internal slot of <var>publicKey</var> as the EC public key <var>Q</var>.
+                            internal slot of <var>publicKey</var> as the EC public key.
                           </p>
                         </li>
                         <li>
                           <p>
                             Let <var>secret</var> be the result of applying the field element to
-                            <a href="#dfn-octet-string">octet string</a> conversion defined in Section ? of <a href="#X9.63">X9.63</a>
+                            <a href="#dfn-octet-string">octet string</a> conversion defined in Section
+                            6.2 of <a href="#RFC6090">RFC6090</a>
                             to the output of the ECDH primitive.
                           </p>
                         </li>
@@ -10111,7 +10121,15 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                               <p>
                                 Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
                                 object that represents the Elliptic Curve public key identified by
-                                performing the conversion steps defined in Section 2.2 of <a href="#RFC5480">RFC 5480</a>.
+                                performing the conversion steps defined in Section 2.3.4 of <a href="#SEC1">SEC 1</a>.
+                                If a decode error occurs or an identity point is found,
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-DataError"><code>DataError</code></a>.
+                                The uncompressed point format MUST be supported.
+                                If the implementation does not support the compressed point format and
+                                a compressed point is decoded, 
+                                <a href="#concept-throw">throw</a> a
+                                <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -10614,16 +10632,17 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>Q</var> be the elliptic curve point on the curve identified
-                                    by the <a href="#dfn-EcKeyImportParams-namedCurve">namedCurve</a>
-                                    member of <var>normalizedAlgorithm</var> identified by interpreting
-                                    <var>keyData</var> according to <a href="#X9.62">X9.62</a> Annex A.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
                                     Let <var>key</var> be a new <a href="#dfn-CryptoKey">CryptoKey</a>
-                                    object that represents <var>Q</var>
+                                    object that represents the Elliptic Curve public key identified by
+                                    performing the conversion steps defined in Section 2.3.4 of <a href="#SEC1">SEC 1</a>.
+                                    If a decode error occurs or an identity point is found,
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-DataError"><code>DataError</code></a>.
+                                    The uncompressed point format MUST be supported.
+                                    If the implementation does not support the compressed point format and
+                                    a compressed point is decoded, 
+                                    <a href="#concept-throw">throw</a> a
+                                    <a href="#dfn-NotSupportedError"><code>NotSupportedError</code></a>.
                                   </p>
                                 </li>
                               </ol>
@@ -10759,7 +10778,7 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                                         Let <var>keyData</var> be the <a href="#dfn-octet-string">octet string</a> that
                                         represents the Elliptic Curve public key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
                                         <var>key</var> according to the encoding rules specified in
-                                        Section 2.2 of <a href="#RFC5480">RFC 5480</a> and using the
+                                        Section 2.3.3 of <a href="#SEC1">SEC 1</a> and using the
                                         uncompressed form.
                                       </p>
                                       <dl class="switch">
@@ -11147,9 +11166,11 @@ dictionary <dfn id="dfn-EcdhKeyDeriveParams">EcdhKeyDeriveParams</dfn> : <a href
                             </dt>
                             <dd>
                               <p>
-                                Let <var>data</var> be an <a href="#dfn-octet-string">octet string</a> representing the Elliptic Curve
-                                point <var>Q</var> represented by [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
-                                <var>key</var> according to <a href="#X9.62">X9.62</a> Annex A.
+                                Let <var>data</var> be the <a href="#dfn-octet-string">octet string</a> that
+                                represents the Elliptic Curve public key represented by the [[<a href="#dfn-CryptoKey-slot-handle">handle</a>]] internal slot of
+                                <var>key</var> according to the encoding rules specified in
+                                Section 2.3.3 of <a href="#SEC1">SEC 1</a> and using the
+                                uncompressed form.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -14950,6 +14971,16 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
               </a></cite>,
               S. Turner, D. Brown. IETF.
              </dd>
+             <dt id="RFC6090">RFC6090</dt>
+             <dd>
+               <cite><a href="http://www.ietf.org/rfc/rfc6090.txt">Fundamental Elliptic Curve Cryptography
+               Algorithms</a></cite>, D. McGrew, K. Igoe, M.Salter. IETF.
+             </dd>
+             <dt id="SEC1">SEC 1</dt>
+             <dd>
+               <cite><a href="http://www.secg.org/sec1-v2.pdf">SEC 1: Elliptic Curve Cryptography</a></cite>,
+               Certicom Research
+             </dd>
              <dt id="WebIDL">Web IDL (Second Edition)</dt>
              <dd>
                <cite><a href="http://heycam.github.io/webidl/">Web IDL (Second Edition)</a></cite>,
@@ -14959,11 +14990,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
              <dd>
                <cite>ANS X9.62–2005: Public Key Cryptography for the Financial Services Industry,
                The Elliptic Curve Digital Signature Algorithm (ECDSA)</cite>, ANSI.
-             </dd>
-             <dt id="X9.63">X9.63</dt>
-             <dd>
-               <cite>ANS X9.63–2001: Public Key Cryptography for the Financial Services Industry,
-               Key Agreement and Key Transport Using Elliptic Curve Cryptography</cite>, ANSI.
              </dd>
             </dl>
         </div>


### PR DESCRIPTION
These edits move from using X9.63 to RFC 6090 for the ECDH algorithm
definition.

This allows for a reference to an openly available specification as well as resolving the section reference in section 24.4