### PR TITLE
Fix reference to `plaintext` variable in AES-GCM decrypt algorithm description

### DIFF
--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -12502,7 +12502,7 @@ dictionary <dfn id="dfn-AesCbcParams">AesCbcParams</dfn> : <a href="#dfn-Algorit
                 <li>
                   <p>
                     Let <var>paddedPlaintext</var> be the result of adding padding octets to
-                    the <a href="#concept-contents-of-arraybuffer">contents of <var>ciphertext</var></a>
+                    the <a href="#concept-contents-of-arraybuffer">contents of <var>plaintext</var></a>
                     according to the procedure defined in Section 10.3
                     of [<a href="#RFC2315">RFC2315</a>], step 2, with a value of
                     <var>k</var> of 16.

--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -13147,7 +13147,7 @@ dictionary <dfn id="dfn-AesGcmParams">AesGcmParams</dfn> : <a href="#dfn-Algorit
                 </li>
                 <li>
                   <p>
-                    If <var>plaintext</var> has a length less than <var>tagLength</var> bits,
+                    If <var>ciphertext</var> has a length less than <var>tagLength</var> bits,
                     then <a href="#concept-throw">throw</a> an
                     <a href="#dfn-OperationError"><code>OperationError</code></a>.
                   </p>


### PR DESCRIPTION
This reference to a `plaintext` variable in step 2 of the AES-GCM decrypt algorithm is incorrect, as that variable doesn't exist yet in the step listed. The intended variable name is likely `ciphertext`, which is the salient parameter to the decrypt algorithm.