### PR TITLE
window.crypto returns the same object

### DIFF
--- a/spec/Overview-WebCryptoAPI.xml
+++ b/spec/Overview-WebCryptoAPI.xml
@@ -828,7 +828,7 @@ of contents, section numbers, certain processing instructions).
         <h2>Crypto interface</h2>
         <x:codeblock language="idl">
 partial interface mixin WindowOrWorkerGlobalScope {
-  readonly attribute <a href="#dfn-Crypto">Crypto</a> crypto;
+  [SameObject] readonly attribute <a href="#dfn-Crypto">Crypto</a> crypto;
 };
 
 [Exposed=(Window,Worker)]


### PR DESCRIPTION
Fixes #179.

All implementations are doing so it seems.

