### PR TITLE
Fix case typo of "I"  in "UInt8ClampedArray"

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -875,7 +875,7 @@ interface <dfn id="dfn-Crypto">Crypto</dfn> {
               <li>
                 <p>
                   If <var>array</var> is not of an integer type (i.e., Int8Array, Uint8Array,
-                  Int16Array, Uint16Array, Int32Array, Uint32Array or UInt8ClampedArray), <a href="#concept-throw">throw</a> a
+                  Int16Array, Uint16Array, Int32Array, Uint32Array or Uint8ClampedArray), <a href="#concept-throw">throw</a> a
                   <code>TypeMismatchError</code> and
                   <a href="#terminate-the-algorithm">terminate the algorithm</a>.
                 </p>


### PR DESCRIPTION
UInt8ClampedArray appears to contain a typo as the "I" (after the letter U) is incorrectly upper case, while it should instead be lower case "i" ,if I am not mistaken. 

Prposed Change: ```UInt8ClampedArray``` to ```Uint8ClampedArray```