### PR TITLE
Fix HMAC's get key length operation by returning default length in bits

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14158,7 +14158,7 @@ dictionary HmacKeyGenParams : Algorithm {
                     </dt>
                     <dd>
                       <p>
-                        Let <var>length</var> be the block size in bytes of the hash function
+                        Let <var>length</var> be the block size in bits of the hash function
                         identified by the {{HmacImportParams/hash}} member
                         of <var>normalizedDerivedKeyAlgorithm</var>.
                       </p>


### PR DESCRIPTION
Fix #210.