### PR TITLE
Fix cached internal slots being interpreted as references

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1018,9 +1018,9 @@ interface CryptoKey {
             <dfn id="dfn-CryptoKey-slot-type">[[\type]]</dfn>,
             <dfn id="dfn-CryptoKey-slot-extractable">[[\extractable]]</dfn>,
             <dfn id="dfn-CryptoKey-slot-algorithm">[[\algorithm]]</dfn>,
-            <dfn id="dfn-CryptoKey-slot-algorithm_cached">[[algorithm_cached]]</dfn>,
+            <dfn id="dfn-CryptoKey-slot-algorithm_cached">[[\algorithm_cached]]</dfn>,
             <dfn id="dfn-CryptoKey-slot-usages">[[\usages]]</dfn>,
-            <dfn id="dfn-CryptoKey-slot-usages_cached">[[usages_cached]]</dfn>, and
+            <dfn id="dfn-CryptoKey-slot-usages_cached">[[\usages_cached]]</dfn>, and
             <dfn id="dfn-CryptoKey-slot-handle">[[\handle]]</dfn>.
           </p>
           <p>


### PR DESCRIPTION
Previously, these internal slots would display as `[algorithm_cached]` rather than `[[algorithm_cached]]`, for example, and would show up in the references (and ReSpec would complain about bad references).