### PR TITLE
Define serialization and deserialization steps for CryptoKey objects

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -393,10 +393,10 @@
           <h3>Key Storage</h3>
           <p>
             This specification does not explicitly provide any new storage mechanisms for
-            {{CryptoKey}} objects. Instead, by allowing the
-            {{CryptoKey}} to be used with the structured clone algorithm,
-            any existing or future web storage mechanisms that support storing structured clonable
-            objects can be used to store {{CryptoKey}} objects.
+            {{CryptoKey}} objects. Instead, by defining
+            <a href="#cryptokey-interface-serializable">serialization and deserialization steps</a>
+            for {{CryptoKey}} objects, any existing or future web storage mechanisms that support
+            storing <a>serializable objects</a> can be used to store {{CryptoKey}} objects.
           </p>
           <p>
             In practice, it is expected that most authors will make use of the
@@ -566,8 +566,7 @@
               A [= conforming user agent =] MUST support at
               least the subset of the functionality defined in HTML that this specification relies
               upon; in particular, it MUST support the
-              {{ArrayBufferView}} typedef and the
-              <a>structured clone</a> algorithm.
+              {{ArrayBufferView}} typedef and <a>serializable objects</a>.
               [[HTML]]
             </p>
           </dd>
@@ -585,11 +584,10 @@
       <section id="terminology">
         <h2>Terminology</h2>
         <p>
-          The terms and algorithms
+          The terms
           {{ArrayBuffer}},
           {{ArrayBufferView}}, and
-          <!-- TODO: structured clone is no longer defined https://html.spec.whatwg.org/#structuredclone -->
-          <dfn id="dfn-structured-clone">structured clone</dfn>,
+          <dfn id="dfn-serializable-objects">serializable objects</dfn>,
           are defined by the HTML specification [[HTML]].
         </p>
         <p>
@@ -1069,7 +1067,7 @@ interface CryptoKey {
         <section id="cryptokey-interface-serializable">
           <h3>Serialization and deserialization steps</h3>
           <p>
-            {{CryptoKey}} objects are serializable objects. Their [= serialization steps =],
+            {{CryptoKey}} objects are <a>serializable objects</a>. Their [= serialization steps =],
             given <var>value</var> and <var>serialized</var>, are:
           </p>
           <ol>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1086,8 +1086,7 @@ interface CryptoKey {
               <a>[[\usages]]</a> internal slot of <var>value</var>.
             </li>
             <li>
-              Set <var>serialized</var>.[[\Key]] to a representation of the cryptographic key data
-              represented by the <a>[[\handle]]</a> internal slot of <var>value</var>.
+              Set <var>serialized</var>.[[\Handle]] to the <a>[[\handle]]</a> internal slot of <var>value</var>.
             </li>
           </ol>
           <p>
@@ -1109,8 +1108,7 @@ interface CryptoKey {
               [= sub-deserialization =] of <var>serialized</var>.[[\Usages]].
             </li>
             <li>
-              Initialize the <a>[[\handle]]</a> internal slot of <var>value</var> to refer to the
-              cryptographic key data represented by <var>serialized</var>.[[\Key]].
+              Initialize the <a>[[\handle]]</a> internal slot of <var>value</var> to <var>serialized</var>.[[\Handle]].
             </li>
           </ol>
           <div class=note>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1086,8 +1086,8 @@ interface CryptoKey {
               <a>[[\usages]]</a> internal slot of <var>value</var>.
             </li>
             <li>
-              Set <var>serialized</var>.[[\Key]] to a serialized representation of the
-              cryptographic key data represented by the <a>[[\handle]]</a> internal slot of <var>value</var>.
+              Set <var>serialized</var>.[[\Key]] to a representation of the cryptographic key data
+              represented by the <a>[[\handle]]</a> internal slot of <var>value</var>.
             </li>
           </ol>
           <p>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1066,43 +1066,61 @@ interface CryptoKey {
           </dl>
         </section>
 
-        <section id="cryptokey-interface-clone">
-          <h3>Structured clone algorithm</h3>
+        <section id="cryptokey-interface-serializable">
+          <h3>Serialization and deserialization steps</h3>
           <p>
-            When a user agent is required to obtain a [= structured clone =]
-            of a {{CryptoKey}} object, it must run the following steps.
+            {{CryptoKey}} objects are serializable objects. Their [= serialization steps =],
+            given <var>value</var> and <var>serialized</var>, are:
           </p>
           <ol>
             <li>
-              Let <var>input</var> and <var>memory</var> be the corresponding inputs defined by the
-              [= structured clone | internal structured cloning algorithm =], where
-              <var>input</var> represents a {{CryptoKey}} object to be
-              cloned.
+              Set <var>serialized</var>.[[\Type]] to the <a>[[\type]]</a> internal slot of <var>value</var>.
             </li>
             <li>
-              Let <var>output</var> be a newly constructed {{CryptoKey}}
-              object.
+              Set <var>serialized</var>.[[\Extractable]] to the <a>[[\extractable]]</a> internal slot of <var>value</var>.
             </li>
             <li>
-              Let the <a>[[\type]]</a>, <a>[[\extractable]]</a>, <a>[[\algorithm]]</a>, and <a>[[\usages]]</a> internal slots of <var>output</var>
-              be set to the result of invoking the internal structured clone algorithm recursively
-              on the corresponding internal slots of <var>input</var>, with the slot contents as the
-              new "<var>input</var>" argument and <var>memory</var> as the new "<var>memory</var>"
-              argument.
+              Set <var>serialized</var>.[[\Algorithm]] to the [= sub-serialization =] of the
+              <a>[[\algorithm]]</a> internal slot of <var>value</var>.
             </li>
             <li>
-              Let the <a>[[\handle]]</a> internal slot of
-              <var>output</var> refer to the same cryptographic key data represented by the
-              <a>[[\handle]]</a> internal slot of <var>input</var>.
+              Set <var>serialized</var>.[[\Usages]] to the [= sub-serialization =] of the
+              <a>[[\usages]]</a> internal slot of <var>value</var>.
+            </li>
+            <li>
+              Set <var>serialized</var>.[[\Key]] to a serialized representation of the
+              cryptographic key data represented by the <a>[[\handle]]</a> internal slot of <var>value</var>.
+            </li>
+          </ol>
+          <p>
+            Their [= deserialization steps =], given <var>serialized</var> and <var>value</var>, are:
+          </p>
+          <ol>
+            <li>
+              Initialize the <a>[[\type]]</a> internal slot of <var>value</var> to <var>serialized</var>.[[\Type]].
+            </li>
+            <li>
+              Initialize the <a>[[\extractable]]</a> internal slot of <var>value</var> to <var>serialized</var>.[[\Extractable]].
+            </li>
+            <li>
+              Initialize the <a>[[\algorithm]]</a> internal slot of <var>value</var> to the
+              [= sub-deserialization =] of <var>serialized</var>.[[\Algorithm]].
+            </li>
+            <li>
+              Initialize the <a>[[\usages]]</a> internal slot of <var>value</var> to the
+              [= sub-deserialization =] of <var>serialized</var>.[[\Usages]].
+            </li>
+            <li>
+              Initialize the <a>[[\handle]]</a> internal slot of <var>value</var> to refer to the
+              cryptographic key data represented by <var>serialized</var>.[[\Key]].
             </li>
           </ol>
           <div class=note>
-            When performing the structured clone algorithm in
-            order to serialize a {{CryptoKey}} object, implementations must not allow the
+            When deserializing a serialized {{CryptoKey}} object, implementations must not allow the
             object to be deserialized as a different type. This is normatively required by the
-            definition of structured clone, but it merits specific attention, as such
-            deserialization may expose the contents of the <a>[[\handle]]</a> internal slot, which in some
-            implementations may contain cryptographic key data that should not be exposed to
+            definition of the [= deserialization steps =], but it merits specific attention, as such
+            deserialization may expose the contents of the key material, which in some cases
+            (such as when the <a>[[\extractable]]</a> internal slot is false) should not be exposed to
             applications.
           </div>
         </section>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1114,12 +1114,12 @@ interface CryptoKey {
             </li>
           </ol>
           <div class=note>
-            When deserializing a serialized {{CryptoKey}} object, implementations must not allow the
-            object to be deserialized as a different type. This is normatively required by the
-            definition of the [= deserialization steps =], but it merits specific attention, as such
-            deserialization may expose the contents of the key material, which in some cases
-            (such as when the <a>[[\extractable]]</a> internal slot is false) should not be exposed to
-            applications.
+            When deserializing a serialized {{CryptoKey}} object, it is important that the
+            object is not deserialized as a different type. This is normatively required by the
+            definition of the [= deserialization steps =], but it merits specific attention, as
+            such deserialization may expose the contents of the key material, which in some
+            cases (such as when the <a>[[\extractable]]</a> internal slot is false) should not
+            be exposed to applications.
           </div>
         </section>
       </section>


### PR DESCRIPTION
Fix #260.

- This PR attempts to roughly define what implementations actually do, while still being concrete:
  - Blink and Gecko serialize the key material as SPKI for public keys, PKCS8 for private keys, and raw for symmetric keys.
    This PR mirrors this.
  - WebKit seems to use an internal format for RSA keys, and the raw format for EC public keys (it still uses PKCS8 for EC private keys).
    In my opinion, this can be viewed as an optimization that doesn't change the observable behavior as specified here. But let me know if you think that this should be allowed explicitly, or if we should have a note about this.
  - Similarly, Gecko serializes the "attributes" (type, extractable, and usages) as a bitmask, rather than separate elements, and in general there's some variety in how the different engines serialize the key metadata.
- This PR makes use of the internal export and import key operations for serialization and deserialization, respectively. The import key operation is not quite a perfect fit for this purpose, as it constructs a `CryptoKey` object itself (after doing various validation steps), whereas in the deserialization steps we already have one, so we have to do an extra step to copy the handle.
  In my opinion, this could be refactored later, e.g. by constructing a `CryptoKey` object in `subtle.importKey()` rather than the algorithm-specific import key operations. (The downside of this refactoring would be that, if the validation fails, `subtle.importKey()` would have constructed the `CryptoKey` object unnecessarily early - but this seems like an unimportant case to optimize for.)
- For that purpose, it defines the export key operation for HKDF and PBKDF2 keys (which didn't need it previously because they are always non-extractable) with a note that it is only invoked by the serialization steps.
- Because of that, the steps in `subtle.exportKey()` and `subtle.wrapKey()` that check whether the export key operation exists for the relevant algorithm have been removed, as this would now always be the case. They still check whether the key is extractable, so they will throw for HKDF and PBKDF2 keys either way, but this does change the specified error from `NotSupportedError` to `InvalidAccessError`. However, all three mentioned engines already throw an `InvalidAccessError` in this case, so it seems that none of them implemented this check, and so this PR brings the spec closer to their actual behavior on this point.

@annevk please let me know what you think :)