### PR TITLE
Allow passing a BigInt64Array/BigUint64Array to getRandomValues

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -831,9 +831,9 @@ interface Crypto {
             <ol>
               <li>
                 <p>
-                  If <var>array</var> is not an Int8Array, Uint8Array, Uint8ClampedArray,
-                  Int16Array, Uint16Array, Int32Array, Uint32Array,
-                  BigInt64Array or BigUint64Array, [= exception/throw =] a
+                  If <var>array</var> is not an {{Int8Array}}, {{Uint8Array}}, {{Uint8ClampedArray}},
+                  {{Int16Array}}, {{Uint16Array}}, {{Int32Array}}, {{Uint32Array}},
+                  {{BigInt64Array}} or {{BigUint64Array}}, [= exception/throw =] a
                   {{TypeMismatchError}} and
                   [= terminate the algorithm =].
                 </p>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -831,8 +831,9 @@ interface Crypto {
             <ol>
               <li>
                 <p>
-                  If <var>array</var> is not of an integer type (i.e., Int8Array, Uint8Array,
-                  Int16Array, Uint16Array, Int32Array, Uint32Array or Uint8ClampedArray), [= exception/throw =] a
+                  If <var>array</var> is not an Int8Array, Uint8Array, Uint8ClampedArray,
+                  Int16Array, Uint16Array, Int32Array, Uint32Array,
+                  BigInt64Array or BigUint64Array, [= exception/throw =] a
                   {{TypeMismatchError}} and
                   [= terminate the algorithm =].
                 </p>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -833,7 +833,7 @@ interface Crypto {
                 <p>
                   If <var>array</var> is not an {{Int8Array}}, {{Uint8Array}}, {{Uint8ClampedArray}},
                   {{Int16Array}}, {{Uint16Array}}, {{Int32Array}}, {{Uint32Array}},
-                  {{BigInt64Array}} or {{BigUint64Array}}, [= exception/throw =] a
+                  {{BigInt64Array}}, or {{BigUint64Array}}, then [= exception/throw =] a
                   {{TypeMismatchError}} and
                   [= terminate the algorithm =].
                 </p>


### PR DESCRIPTION
Fix #255 by adding BigInt64Array and BigUint64Array to the list of allowed types in `crypto.getRandomValues()`. In addition, don't refer to them as "integer type" but simply list all the allowed types, as per https://github.com/w3c/webcrypto/issues/255#issue-874738354.