### PR TITLE
Throw an OperationError in the PBKDF2 derive bits operation if iterations is zero

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14598,6 +14598,11 @@ dictionary Pbkdf2Params : Algorithm {
                     If <var>length</var> is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
+		<li>
+		  <p>
+		   If the {{Pbkdf2Params/iterations}} member of <var>normalizedAlgorithm</var> is zero, then [= exception/throw =] an {{OperationError}}.
+		  </p>
+		</li>
                 <li>
                   <p>
                     Let <var>prf</var> be the MAC Generation function described in Section 4 of

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14598,11 +14598,11 @@ dictionary Pbkdf2Params : Algorithm {
                     If <var>length</var> is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
-		<li>
-		  <p>
-		   If the {{Pbkdf2Params/iterations}} member of <var>normalizedAlgorithm</var> is zero, then [= exception/throw =] an {{OperationError}}.
-		  </p>
-		</li>
+                <li>
+                  <p>
+                   If the {{Pbkdf2Params/iterations}} member of <var>normalizedAlgorithm</var> is zero, then [= exception/throw =] an {{OperationError}}.
+                  </p>
+                </li>
                 <li>
                   <p>
                     Let <var>prf</var> be the MAC Generation function described in Section 4 of

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14600,7 +14600,8 @@ dictionary Pbkdf2Params : Algorithm {
                 </li>
                 <li>
                   <p>
-                   If the {{Pbkdf2Params/iterations}} member of <var>normalizedAlgorithm</var> is zero, then [= exception/throw =] an {{OperationError}}.
+                    If the {{Pbkdf2Params/iterations}} member of <var>normalizedAlgorithm</var> is zero,
+                    then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>


### PR DESCRIPTION
WPT has a test for this in https://github.com/web-platform-tests/wpt/blob/0bc996384524028f8608c311d35ee7ebdf29afca/WebCryptoAPI/derive_bits_keys/pbkdf2.js#L169