### PR TITLE
PBKDF2 & HKDF derive bits should throw OperationError when length is zero

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14359,7 +14359,7 @@ dictionary HkdfParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>length</var> is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                    If <var>length</var> is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
@@ -14595,7 +14595,7 @@ dictionary Pbkdf2Params : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>length</var> is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                    If <var>length</var> is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>


### PR DESCRIPTION
Closes #274 