### PR TITLE
add randomUUID method

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -550,6 +550,16 @@
             underlying key data, such APIs may represent a real risk of being used as a permanent
             identifier against the user's wishes.
           </dd>
+          <dt>
+            Use of {{Crypto/randomUUID}} as user ID
+          </dt>
+          <dd>
+            {{Crypto/randomUUID}} is useful for generating <a href=
+            "https://w3cping.github.io/privacy-threat-model/#user-id">user
+            IDs</a>, but does not directly give any ability to generate <a href=
+            "https://w3cping.github.io/privacy-threat-model/#global-identifier">global
+            identifiers</a>.
+          </dd>
         </dl>
       </section>
 
@@ -804,6 +814,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 interface Crypto {
   [SecureContext] readonly attribute SubtleCrypto subtle;
   ArrayBufferView getRandomValues(ArrayBufferView array);
+  [SecureContext] DOMString randomUUID();
 };
         </pre>
 
@@ -869,6 +880,75 @@ interface Crypto {
                 instead.
               </p>
             </div>
+          </section>
+          <section id="Crypto-method-randomUUID">
+            <h4>The randomUUID method</h4>
+            <p>
+            The <dfn id="dfn-Crypto-method-randomUUID" data-dfn-for=Crypto>randomUUID</dfn>
+            method generates a new <a data-cite="RFC4122#section-4.4">version 4 UUID</a>
+            and returns its <a data-cite="RFC2141#section-2.2">namespace specific string representation</a>
+            as described in <a data-cite="RFC4122#section-3">section 3</a> of [[RFC4122]].
+            To <dfn data-local-lt="generating a random UUID" data-export=
+            "">generate a random UUID</dfn>:
+            </p>
+            <ol>
+              <li>Let |array| be a [=list=] with 16 elements of the type byte.
+              </li>
+              <li>Overwrite all elements of |array| with cryptographically secure
+              random values of the type byte.
+              </li>
+              <li>Set the 4 most significant bits of |array|[6], which represent the
+              UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to `0b0100`.
+              </li>
+              <li>Set the 2 most significant bits of |array|[8], which represent the
+              UUID <a data-cite="RFC4122#section-4.1.1">variant</a>, to `0b10`.
+              </li>
+              <li>
+                <p>
+                  Return the <a data-cite="INFRA#string-concatenate">concatenation</a> of «
+                </p>
+                <ol style="list-style-type: none">
+                  <li>[=hexadecimal representation=] of |array|[0], [=hexadecimal
+                  representation=] of |array|[1], [=hexadecimal representation=] of
+                  |array|[2], [=hexadecimal representation=] of |array|[3],
+                  </li>
+                  <li>`"-"`,
+                  </li>
+                  <li>[=hexadecimal representation=] of |array|[4], [=hexadecimal
+                  representation=] of |array|[5],
+                  </li>
+                  <li>`"-"`,
+                  </li>
+                  <li>[=hexadecimal representation=] of |array|[6], [=hexadecimal
+                  representation=] of |array|[7],
+                  </li>
+                  <li>`"-"`,
+                  </li>
+                  <li>[=hexadecimal representation=] of |array|[8], [=hexadecimal
+                  representation=] of |array|[9],
+                  </li>
+                  <li>`"-"`,
+                  </li>
+                  <li>[=hexadecimal representation=] of |array|[10], [=hexadecimal
+                  representation=] of |array|[11], [=hexadecimal representation=] of
+                  |array|[12], [=hexadecimal representation=] of |array|[13],
+                  [=hexadecimal representation=] of |array|[14], [=hexadecimal
+                  representation=] of |array|[15]
+                  </li>
+                </ol>
+                <p>
+                  ».
+                </p>
+              </li>
+            </ol>
+            <p>
+              For the steps described in the [=generate a random UUID=] algorithm,
+              the <dfn>hexadecimal representation</dfn> of a byte |value| is the
+              two-character string created by expressing |value| in hexadecimal using
+              <a data-cite="INFRA#ascii-lower-hex-digit">ASCII lower hex digits</a>,
+              left-padded with `"0"` to reach two
+              <a data-cite="INFRA#ascii-digit">ASCII digits</a>.
+            </p>
           </section>
         </section>
         <section id="Crypto-interface-attributes">
@@ -14812,6 +14892,12 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
        console.error.bind(console, "Unable to encrypt"));
 </pre>
       </section>
+      <section id="examples-random-uuid">
+        <h3>Generate unique name for download</h3>
+        <pre class=js>
+const filename = `${crypto.randomUUID()}.txt`;
+// do something with filename.
+</pre>
     </section>
     <section id="iana-section">
     <h2>IANA Considerations</h2>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -892,7 +892,7 @@ interface Crypto {
             "">generate a random UUID</dfn>:
             </p>
             <ol>
-              <li>Let |array| be a [=list=] with 16 elements of the type byte.
+              <li>Let |array| be a 16 element of <a data-cite="INFRA#byte-sequences">sequence of bytes.</a>
               </li>
               <li>Overwrite all elements of |array| with cryptographically secure
               random values of the type byte.
@@ -905,7 +905,7 @@ interface Crypto {
               </li>
               <li>
                 <p>
-                  Return the <a data-cite="INFRA#string-concatenate">concatenation</a> of «
+                  Return the <a data-cite="INFRA#string-concatenate">string concatenation</a> of «
                 </p>
                 <ol style="list-style-type: none">
                   <li>[=hexadecimal representation=] of |array|[0], [=hexadecimal

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -27,7 +27,7 @@
         github: "https://github.com/w3c/webcrypto",
         shortName: "WebCryptoAPI",
         group: "webappsec",
-        xref: ['html', 'dom', 'webidl'],
+        xref: ['html', 'dom', 'webidl', 'infra'],
         localBiblio: {
         "JWA": {
         aliasOf: "RFC7518"
@@ -884,56 +884,67 @@ interface Crypto {
           <section id="Crypto-method-randomUUID">
             <h4>The randomUUID method</h4>
             <p>
-            The <dfn id="dfn-Crypto-method-randomUUID" data-dfn-for=Crypto>randomUUID</dfn>
-            method generates a new <a data-cite="RFC4122#section-4.4">version 4 UUID</a>
-            and returns its <a data-cite="RFC2141#section-2.2">namespace specific string representation</a>
-            as described in <a data-cite="RFC4122#section-3">section 3</a> of [[RFC4122]].
-            To <dfn data-local-lt="generating a random UUID" data-export=
-            "">generate a random UUID</dfn>:
+              The <dfn id="dfn-Crypto-method-randomUUID" data-dfn-for=Crypto>randomUUID</dfn>
+              method generates a new <a data-cite="RFC4122#section-4.4">version 4 UUID</a>
+              and returns its <a data-cite="RFC2141#section-2.2">namespace specific string representation</a>
+              as described in <a data-cite="RFC4122#section-3">section 3</a> of [[RFC4122]].
+              To <dfn data-export="">generate a random UUID</dfn>:
             </p>
             <ol>
-              <li>Let |array| be a 16 element of <a data-cite="INFRA#byte-sequences">sequence of bytes.</a>
+              <li>
+                Let |bytes| be a [= byte sequence =] of length 16.
               </li>
-              <li>Overwrite all elements of |array| with cryptographically secure
-              random values of the type byte.
+              <li>
+                Fill |bytes| with cryptographically secure random bytes.
               </li>
-              <li>Set the 4 most significant bits of |array|[6], which represent the
-              UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to `0b0100`.
+              <li>
+                Set the 4 most significant bits of |bytes|[6], which represent the
+                UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to `0b0100`.
               </li>
-              <li>Set the 2 most significant bits of |array|[8], which represent the
-              UUID <a data-cite="RFC4122#section-4.1.1">variant</a>, to `0b10`.
+              <li>
+                Set the 2 most significant bits of |bytes|[8], which represent the
+                UUID <a data-cite="RFC4122#section-4.1.1">variant</a>, to `0b10`.
               </li>
               <li>
                 <p>
-                  Return the <a data-cite="INFRA#string-concatenate">string concatenation</a> of «
+                  Return the [= string/concatenate | string concatenation =] of «
                 </p>
                 <ol style="list-style-type: none">
-                  <li>[=hexadecimal representation=] of |array|[0], [=hexadecimal
-                  representation=] of |array|[1], [=hexadecimal representation=] of
-                  |array|[2], [=hexadecimal representation=] of |array|[3],
+                  <li>
+                    [= hexadecimal representation =] of |bytes|[0], [= hexadecimal
+                    representation =] of |bytes|[1], [= hexadecimal representation =] of
+                    |bytes|[2], [= hexadecimal representation =] of |bytes|[3],
                   </li>
-                  <li>`"-"`,
+                  <li>
+                    `"-"`,
                   </li>
-                  <li>[=hexadecimal representation=] of |array|[4], [=hexadecimal
-                  representation=] of |array|[5],
+                  <li>
+                    [= hexadecimal representation =] of |bytes|[4], [= hexadecimal
+                    representation =] of |bytes|[5],
                   </li>
-                  <li>`"-"`,
+                  <li>
+                    `"-"`,
                   </li>
-                  <li>[=hexadecimal representation=] of |array|[6], [=hexadecimal
-                  representation=] of |array|[7],
+                  <li>
+                    [= hexadecimal representation =] of |bytes|[6], [= hexadecimal
+                    representation =] of |bytes|[7],
                   </li>
-                  <li>`"-"`,
+                  <li>
+                    `"-"`,
                   </li>
-                  <li>[=hexadecimal representation=] of |array|[8], [=hexadecimal
-                  representation=] of |array|[9],
+                  <li>
+                    [= hexadecimal representation =] of |bytes|[8], [= hexadecimal
+                    representation =] of |bytes|[9],
                   </li>
-                  <li>`"-"`,
+                  <li>
+                    `"-"`,
                   </li>
-                  <li>[=hexadecimal representation=] of |array|[10], [=hexadecimal
-                  representation=] of |array|[11], [=hexadecimal representation=] of
-                  |array|[12], [=hexadecimal representation=] of |array|[13],
-                  [=hexadecimal representation=] of |array|[14], [=hexadecimal
-                  representation=] of |array|[15]
+                  <li>
+                    [= hexadecimal representation =] of |bytes|[10], [= hexadecimal
+                    representation =] of |bytes|[11], [= hexadecimal representation =] of
+                    |bytes|[12], [= hexadecimal representation =] of |bytes|[13],
+                    [= hexadecimal representation =] of |bytes|[14], [= hexadecimal
+                    representation =] of |bytes|[15]
                   </li>
                 </ol>
                 <p>
@@ -942,12 +953,11 @@ interface Crypto {
               </li>
             </ol>
             <p>
-              For the steps described in the [=generate a random UUID=] algorithm,
+              For the steps described in the algorithm to [= generate a random UUID =],
               the <dfn>hexadecimal representation</dfn> of a byte |value| is the
               two-character string created by expressing |value| in hexadecimal using
-              <a data-cite="INFRA#ascii-lower-hex-digit">ASCII lower hex digits</a>,
-              left-padded with `"0"` to reach two
-              <a data-cite="INFRA#ascii-digit">ASCII digits</a>.
+              [= ASCII lower hex digits =], left-padded with `"0"` to reach two
+              [= ASCII digits =].
             </p>
           </section>
         </section>
@@ -14896,7 +14906,6 @@ window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
         <h3>Generate unique name for download</h3>
         <pre class=js>
 const filename = `${crypto.randomUUID()}.txt`;
-// do something with filename.
 </pre>
     </section>
     <section id="iana-section">

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -957,7 +957,7 @@ interface Crypto {
               the <dfn>hexadecimal representation</dfn> of a byte |value| is the
               two-character string created by expressing |value| in hexadecimal using
               [= ASCII lower hex digits =], left-padded with `"0"` to reach two
-              [= ASCII digits =].
+              [= ASCII lower hex digits =].
             </p>
           </section>
         </section>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -899,11 +899,11 @@ interface Crypto {
               </li>
               <li>
                 Set the 4 most significant bits of |bytes|[6], which represent the
-                UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to `0b0100`.
+                UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to `0100`.
               </li>
               <li>
                 Set the 2 most significant bits of |bytes|[8], which represent the
-                UUID <a data-cite="RFC4122#section-4.1.1">variant</a>, to `0b10`.
+                UUID <a data-cite="RFC4122#section-4.1.1">variant</a>, to `10`.
               </li>
               <li>
                 <p>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -916,28 +916,28 @@ interface Crypto {
                     |bytes|[2], [= hexadecimal representation =] of |bytes|[3],
                   </li>
                   <li>
-                    `"-"`,
+                    "`-`",
                   </li>
                   <li>
                     [= hexadecimal representation =] of |bytes|[4], [= hexadecimal
                     representation =] of |bytes|[5],
                   </li>
                   <li>
-                    `"-"`,
+                    "`-`",
                   </li>
                   <li>
                     [= hexadecimal representation =] of |bytes|[6], [= hexadecimal
                     representation =] of |bytes|[7],
                   </li>
                   <li>
-                    `"-"`,
+                    "`-`",
                   </li>
                   <li>
                     [= hexadecimal representation =] of |bytes|[8], [= hexadecimal
                     representation =] of |bytes|[9],
                   </li>
                   <li>
-                    `"-"`,
+                    "`-`",
                   </li>
                   <li>
                     [= hexadecimal representation =] of |bytes|[10], [= hexadecimal


### PR DESCRIPTION
Merge sections from https://github.com/WICG/uuid describing randomUUID()
method.

Refs: https://github.com/WICG/uuid/issues/27


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bcoe/webcrypto/pull/285.html" title="Last updated on Jan 26, 2022, 3:56 PM UTC (beaaad2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/285/28de415...bcoe:beaaad2.html" title="Last updated on Jan 26, 2022, 3:56 PM UTC (beaaad2)">Diff</a>