### PR TITLE
Update ReSpec usage

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -2838,7 +2838,7 @@ dictionary CryptoKeyPair {
             <h4>Internal State Objects</h4>
             <p>
               This specification makes use of an internal object,
-              <dfn id="dfn-supportedAlgorithms" data-dfn-for=SubtleCrypto>[[\supportedAlgorithms]]</dfn>. This internal object is
+              <dfn id="dfn-supportedAlgorithms">supportedAlgorithms</dfn>. This internal object is
               not exposed to applications.
             </p>
             <p>
@@ -2853,7 +2853,7 @@ dictionary CryptoKeyPair {
               <li>
                 <p>
                   For each value, <var>v</var> in the List of <a href="#supported-operation">supported operations</a>, set the <var>v</var> key of
-                   the internal object {{SubtleCrypto/[[supportedAlgorithms]]}}
+                   the internal object {{supportedAlgorithms}}
                    to a new associative container.
                 </p>
               </li>
@@ -2872,7 +2872,7 @@ dictionary CryptoKeyPair {
             <ol>
               <li>
                 Let <var>registeredAlgorithms</var> be the associative container stored at the
-                <var>op</var> key of {{SubtleCrypto/[[supportedAlgorithms]]}}.
+                <var>op</var> key of {{supportedAlgorithms}}.
               </li>
               <li>
                 Set the <var>alg</var> key of <var>registeredAlgorithms</var> to the IDL dictionary
@@ -2906,7 +2906,7 @@ dictionary CryptoKeyPair {
                 <ol>
                   <li>
                     Let <var>registeredAlgorithms</var> be the associative container stored at the
-                    <code>op</code> key of {{SubtleCrypto/[[supportedAlgorithms]]}}.
+                    <code>op</code> key of {{supportedAlgorithms}}.
                   </li>
                   <li>
                     Let <var>initialAlg</var> be the result of converting the ECMAScript object


### PR DESCRIPTION
This updates the usage of ReSpec from respec-w3c-common to respec-w3c, as per [these guidelines](https://github.com/w3c/respec/wiki/respec-w3c-common-migration-guide), and then fixes all the things it complained about, most notably properly marking the internal slots of `CryptoKey` objects as belonging to `CryptoKey` in WebIDL.

The most non-mechanical change here is that the `[[supportedAlgorithms]]` internal object, which is sort of "free-floating" and not connected to any object (which respec-w3c complains about, which is fair enough), is now an internal slot of the `SubtleCrypto` interface. (This is purely an internal WebIDL change, it's not mentioned in the text.) Hopefully this makes sense to people.

And finally, it marks the spec as belonging to the webappsec group.