### PR TITLE
Fix error names when parsing pkcs8 RSA params

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -5338,7 +5338,7 @@ dictionary RsaPssParams : Algorithm {
                                     the <code>RSASSA-PSS-params</code> ASN.1 type defined in
                                     [[RFC3447]],
                                     [= exception/throw =] a
-                                    {{NotSupportedError}}.
+                                    {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
@@ -6974,7 +6974,7 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     If <var>params</var> is not defined, or is not an instance of
-                                    the <code>RSAES-OAEP-params</code> ASN.1 type defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
+                                    the <code>RSAES-OAEP-params</code> ASN.1 type defined in [[RFC3447]], [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>


### PR DESCRIPTION
When importing an `RSA-PSS` or `RSA-OAEP` key from pkcs8, and the OID is `id-RSASSA-PSS` or `id-RSAES-OAEP`, respectively, but the parameters are null or not an instance of `RSASSA-PSS-params` or `RSAES-OAEP-params`, respectively, throw a `DataError` instead of a `NotSupportedError`, to be consistent with spki import and with most implementations' behavior.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/299.html" title="Last updated on Dec 10, 2021, 6:58 PM UTC (ef325b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/299/b718080...ef325b0.html" title="Last updated on Dec 10, 2021, 6:58 PM UTC (ef325b0)">Diff</a>