### PR TITLE
Correctly get "hash" during RSA JWK export

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -4584,7 +4584,8 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             Let <var>hash</var> be the {{KeyAlgorithm/name}}
                             attribute of the {{RsaHashedKeyAlgorithm/hash}}
-                            attribute of <var>key</var>.
+                            attribute of the {{CryptoKey/[[algorithm]]}}
+                            internal slot of <var>key</var>.
                           </p>
                         </li>
                         <li>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lucacasonato/webcrypto/pull/302.html" title="Last updated on Dec 14, 2021, 12:01 PM UTC (eb101e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/302/bc446d4...lucacasonato:eb101e4.html" title="Last updated on Dec 14, 2021, 12:01 PM UTC (eb101e4)">Diff</a>