### PR TITLE
Use shorthand forms instead of <var> and <code> elements

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -616,18 +616,18 @@
           integers, each in the range 0 to 255 inclusive.
         </p>
         <p>
-          An <dfn id="dfn-octet-string-containing" data-lt="octet string containing">octet string containing a bit string</dfn> <var>b</var> is the
+          An <dfn id="dfn-octet-string-containing" data-lt="octet string containing">octet string containing a bit string</dfn> |b| is the
           [= octet string =] obtained by first appending zero or more
-          bits of value zero to <var>b</var> such that the length of the resulting bit string is minimal and an integer multiple of 8
+          bits of value zero to |b| such that the length of the resulting bit string is minimal and an integer multiple of 8
           and then considering each consecutive sequence of 8 bits in that string as a binary integer, most significant
           bit first.
         </p>
         <p>
           When this specification says to <dfn id="dfn-convert-integer-to-octet-string">convert a non-negative
-          integer <var>i</var> to an octet string of length <var>n</var></dfn>, where <var>n</var> * 8
-          is greater than the logarithm to base 2 of <var>i</var>, the user agent must
-          first calculate the binary representation of <var>i</var>, most significant bit first,
-          prefix this with sufficient zero bits to form a bit string of length <var>n</var> * 8, and
+          integer |i| to an octet string of length |n|</dfn>, where |n| * 8
+          is greater than the logarithm to base 2 of |i|, the user agent must
+          first calculate the binary representation of |i|, most significant bit first,
+          prefix this with sufficient zero bits to form a bit string of length |n| * 8, and
           then return the [= octet string =] formed by considering each consecutive
           sequence of 8 bits in that bit string as a binary integer, most significant bit first.
         </p>
@@ -655,30 +655,30 @@
         <ol>
           <li>
             <p>
-              Let <var>data</var> be a sequence of bytes to be parsed.
+              Let |data| be a sequence of bytes to be parsed.
             </p>
           </li>
           <li>
             <p>
-              Let <var>structure</var> be the ASN.1 structure to be parsed.
+              Let |structure| be the ASN.1 structure to be parsed.
             </p>
           </li>
           <li>
             <p>
-              Let <var>exactData</var> be an optional boolean value. If it is not supplied,
+              Let |exactData| be an optional boolean value. If it is not supplied,
               let it be initialized to `true`.
             </p>
           </li>
           <li>
             <p>
-              Parse <var>data</var> according to the Distinguished Encoding Rules of
-              [[X690]], using <var>structure</var> as the ASN.1 structure
+              Parse |data| according to the Distinguished Encoding Rules of
+              [[X690]], using |structure| as the ASN.1 structure
               to be decoded.
             </p>
           </li>
           <li>
             <p>
-              If <var>exactData</var> was specified, and all of the bytes of <var>data</var> were
+              If |exactData| was specified, and all of the bytes of |data| were
               not consumed during the parsing phase, then
               [= exception/throw =] a
               {{DataError}}.
@@ -694,16 +694,16 @@
           When this specification says to <dfn id="concept-parse-a-spki">parse a
           subjectPublicKeyInfo</dfn>, the user agent must
           [= parse an ASN.1 structure =], with
-          <var>data</var> set to the sequence of bytes to be parsed, <var>structure</var> as the
+          |data| set to the sequence of bytes to be parsed, |structure| as the
           ASN.1 structure of subjectPublicKeyInfo, as specified in [[RFC5280]],
-          and <var>exactData</var> set to `true`.
+          and |exactData| set to `true`.
         </p>
         <p>
           When this specification says to <dfn id="concept-parse-a-privateKeyInfo">parse a
           PrivateKeyInfo</dfn>, the user agent must [= parse
-          an ASN.1 structure =] with <var>data</var> set to the sequence of bytes to be parsed,
-          <var>structure</var> as the ASN.1 structure of PrivateKeyInfo, as specified in
-          [[RFC5208]], and <var>exactData</var> set to `true`.
+          an ASN.1 structure =] with |data| set to the sequence of bytes to be parsed,
+          |structure| as the ASN.1 structure of PrivateKeyInfo, as specified in
+          [[RFC5208]], and |exactData| set to `true`.
         </p>
         <p>
           When this specification says to <dfn id="concept-parse-a-jwk">parse a JWK</dfn>, the user
@@ -712,88 +712,88 @@
         <ol>
           <li>
             <p>
-              Let <var>data</var> be the sequence of bytes to be parsed.
+              Let |data| be the sequence of bytes to be parsed.
             </p>
           </li>
           <li>
             <p>
-              Let <var>json</var> be the Unicode string that results from interpreting
-              <var>data</var> according to UTF-8.
+              Let |json| be the Unicode string that results from interpreting
+              |data| according to UTF-8.
             </p>
           </li>
           <li>
             <p>
-              Convert <var>json</var> to UTF-16.
+              Convert |json| to UTF-16.
             </p>
           </li>
           <li>
             <p>
-              Let <var>result</var> be the object literal that results from executing the
+              Let |result| be the object literal that results from executing the
               `JSON.parse` internal function in the context of a new global object,
-              with `text` argument set to a JavaScript String containing <var>json</var>.
+              with `text` argument set to a JavaScript String containing |json|.
             </p>
           </li>
           <li>
             <p>
-              Let <var>key</var> be the result of converting <var>result</var> to the IDL dictionary
+              Let |key| be the result of converting |result| to the IDL dictionary
               type of {{JsonWebKey}}.
             </p>
           </li>
           <li>
             <p>
-              If the {{JsonWebKey/kty}} field of <var>key</var> is not defined, then [= exception/throw =] a {{DataError}}.
+              If the {{JsonWebKey/kty}} field of |key| is not defined, then [= exception/throw =] a {{DataError}}.
             </p>
           </li>
           <li>
             <p>
-              Return <var>key</var>.
+              Return |key|.
             </p>
           </li>
         </ol>
         <p>
           When this specification states to supply the <dfn id="concept-contents-of-arraybuffer">
-          contents of an ArrayBuffer</dfn> named <var>data</var> to an underlying cryptographic
+          contents of an ArrayBuffer</dfn> named |data| to an underlying cryptographic
           implementation, the User Agent shall supply a contiguous sequence of bytes that is equal
           to the result of
           [= get a copy of the buffer source | getting a copy of the bytes =]
-          held <var>data</var>.
+          held |data|.
         </p>
         <p>
           When this specification says to calculate the <dfn id="concept-usage-intersection">usage
-          intersection</dfn> of two sequences, <var>a</var> and <var>b</var> the result shall be a
+          intersection</dfn> of two sequences, |a| and |b| the result shall be a
           sequence containing each [= recognized key usage value =]
-          that appears in both <var>a</var> and <var>b</var>, in the order listed in the list of
+          that appears in both |a| and |b|, in the order listed in the list of
           [= recognized key usage value=]s, where a value is said
           to appear in a sequence if an element of the sequence exists that is a case-sensitive string
           match for that value.
         </p>
         <p>
           When this specification says to calculate the <dfn id="concept-normalized-usages" data-local-lt="normalized value">
-          normalized value of a usages list</dfn>, <var>usages</var> the result shall be the
-          [= usage intersection =] of <var>usages</var> and a
+          normalized value of a usages list</dfn>, |usages| the result shall be the
+          [= usage intersection =] of |usages| and a
           sequence containing all [= recognized key usage value =]s.
         </p>
         <p>
           When this specification refers to the <dfn id="concept-cached-object">cached ECMAScript
-          object</dfn> associated with an internal slot [[<var>slot</var>]] of <var>object</var>,
+          object</dfn> associated with an internal slot [[|slot|]] of |object|,
           the user agent must run the following steps:
         </p>
         <ol>
           <li>
             <dl class="switch">
               <dt>
-                If the [[<var>slot</var>_cached]] internal slot of <var>object</var> is undefined:
+                If the [[|slot|_cached]] internal slot of |object| is undefined:
               </dt>
               <dd>
-                Set the [[<var>slot</var>_cached]] internal slot of <var>object</var> to the result
+                Set the [[|slot|_cached]] internal slot of |object| to the result
                 of performing type conversion to an ECMAScript object as defined in
-                [[WebIDL]] to the contents of the [[<var>slot</var>]]
-                internal slot of <var>object</var>.
+                [[WebIDL]] to the contents of the [[|slot|]]
+                internal slot of |object|.
               </dd>
             </dl>
           </li>
           <li>
-            Return the contents of the [[<var>slot</var>_cached]] internal slot of <var>object</var>.
+            Return the contents of the [[|slot|_cached]] internal slot of |object|.
           </li>
         </ol>
       </section>
@@ -847,7 +847,7 @@ interface Crypto {
             <ol>
               <li>
                 <p>
-                  If <var>array</var> is not an {{Int8Array}}, {{Uint8Array}}, {{Uint8ClampedArray}},
+                  If |array| is not an {{Int8Array}}, {{Uint8Array}}, {{Uint8ClampedArray}},
                   {{Int16Array}}, {{Uint16Array}}, {{Int32Array}}, {{Uint32Array}},
                   {{BigInt64Array}}, or {{BigUint64Array}}, then [= exception/throw =] a
                   {{TypeMismatchError}} and
@@ -856,20 +856,20 @@ interface Crypto {
               </li>
               <li>
                 <p>
-                  If the `byteLength` of <var>array</var> is greater than 65536, [= exception/throw =] a
+                  If the `byteLength` of |array| is greater than 65536, [= exception/throw =] a
                   {{QuotaExceededError}} and
                   [= terminate the algorithm =].
                 </p>
               </li>
               <li>
                 <p>
-                  Overwrite all elements of <var>array</var> with cryptographically strong random values of
+                  Overwrite all elements of |array| with cryptographically strong random values of
                   the appropriate type.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>array</var>.
+                  Return |array|.
                 </p>
               </li>
             </ol>
@@ -1166,47 +1166,47 @@ interface CryptoKey {
           <h3>Serialization and deserialization steps</h3>
           <p>
             {{CryptoKey}} objects are <a>serializable objects</a>. Their [= serialization steps =],
-            given <var>value</var> and <var>serialized</var>, are:
+            given |value| and |serialized|, are:
           </p>
           <ol>
             <li>
-              Set <var>serialized</var>.[[\Type]] to the {{CryptoKey/[[type]]}} internal slot of <var>value</var>.
+              Set |serialized|.[[\Type]] to the {{CryptoKey/[[type]]}} internal slot of |value|.
             </li>
             <li>
-              Set <var>serialized</var>.[[\Extractable]] to the {{CryptoKey/[[extractable]]}} internal slot of <var>value</var>.
+              Set |serialized|.[[\Extractable]] to the {{CryptoKey/[[extractable]]}} internal slot of |value|.
             </li>
             <li>
-              Set <var>serialized</var>.[[\Algorithm]] to the [= sub-serialization =] of the
-              {{CryptoKey/[[algorithm]]}} internal slot of <var>value</var>.
+              Set |serialized|.[[\Algorithm]] to the [= sub-serialization =] of the
+              {{CryptoKey/[[algorithm]]}} internal slot of |value|.
             </li>
             <li>
-              Set <var>serialized</var>.[[\Usages]] to the [= sub-serialization =] of the
-              {{CryptoKey/[[usages]]}} internal slot of <var>value</var>.
+              Set |serialized|.[[\Usages]] to the [= sub-serialization =] of the
+              {{CryptoKey/[[usages]]}} internal slot of |value|.
             </li>
             <li>
-              Set <var>serialized</var>.[[\Handle]] to the {{CryptoKey/[[handle]]}} internal slot of <var>value</var>.
+              Set |serialized|.[[\Handle]] to the {{CryptoKey/[[handle]]}} internal slot of |value|.
             </li>
           </ol>
           <p>
-            Their [= deserialization steps =], given <var>serialized</var> and <var>value</var>, are:
+            Their [= deserialization steps =], given |serialized| and |value|, are:
           </p>
           <ol>
             <li>
-              Initialize the {{CryptoKey/[[type]]}} internal slot of <var>value</var> to <var>serialized</var>.[[\Type]].
+              Initialize the {{CryptoKey/[[type]]}} internal slot of |value| to |serialized|.[[\Type]].
             </li>
             <li>
-              Initialize the {{CryptoKey/[[extractable]]}} internal slot of <var>value</var> to <var>serialized</var>.[[\Extractable]].
+              Initialize the {{CryptoKey/[[extractable]]}} internal slot of |value| to |serialized|.[[\Extractable]].
             </li>
             <li>
-              Initialize the {{CryptoKey/[[algorithm]]}} internal slot of <var>value</var> to the
-              [= sub-deserialization =] of <var>serialized</var>.[[\Algorithm]].
+              Initialize the {{CryptoKey/[[algorithm]]}} internal slot of |value| to the
+              [= sub-deserialization =] of |serialized|.[[\Algorithm]].
             </li>
             <li>
-              Initialize the {{CryptoKey/[[usages]]}} internal slot of <var>value</var> to the
-              [= sub-deserialization =] of <var>serialized</var>.[[\Usages]].
+              Initialize the {{CryptoKey/[[usages]]}} internal slot of |value| to the
+              [= sub-deserialization =] of |serialized|.[[\Usages]].
             </li>
             <li>
-              Initialize the {{CryptoKey/[[handle]]}} internal slot of <var>value</var> to <var>serialized</var>.[[\Handle]].
+              Initialize the {{CryptoKey/[[handle]]}} internal slot of |value| to |serialized|.[[\Handle]].
             </li>
           </ol>
           <div class=note>
@@ -1350,7 +1350,7 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var> and <var>key</var> be the
+                  Let |algorithm| and |key| be the
                   `algorithm` and `key` parameters
                   passed to the {{SubtleCrypto/encrypt()}} method,
                   respectively.
@@ -1358,7 +1358,7 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>data</var> be the result of
+                  Let |data| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes =] held by the `data` parameter passed to the
                   {{SubtleCrypto/encrypt()}} method.
@@ -1366,33 +1366,33 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`encrypt`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -1400,28 +1400,28 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>key</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is "`encrypt`", then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| does not contain an entry that is "`encrypt`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>ciphertext</var> be the result of performing the encrypt
-                  operation specified by <var>normalizedAlgorithm</var> using <var>algorithm</var>
-                  and <var>key</var> and with <var>data</var> as <var>plaintext</var>.
+                  Let |ciphertext| be the result of performing the encrypt
+                  operation specified by |normalizedAlgorithm| using |algorithm|
+                  and |key| and with |data| as |plaintext|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with <var>ciphertext</var>.
+                  Resolve |promise| with |ciphertext|.
                 </p>
               </li>
             </ol>
@@ -1439,7 +1439,7 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var> and <var>key</var> be the
+                  Let |algorithm| and |key| be the
                   `algorithm` and `key`parameters
                   passed to the {{SubtleCrypto/decrypt()}} method,
                   respectively.
@@ -1447,7 +1447,7 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>data</var> be the result of
+                  Let |data| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/decrypt()}} method.
@@ -1455,33 +1455,33 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`decrypt`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and the remaining steps [= in parallel =].
+                  Return |promise| and the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -1489,30 +1489,30 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>key</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is "`decrypt`", then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| does not contain an entry that is "`decrypt`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>plaintext</var> be the result of performing the decrypt
-                  operation specified by <var>normalizedAlgorithm</var> using <var>key</var>
-                  and <var>algorithm</var>
-                  and with <var>data</var> as <var>ciphertext</var>.
+                  Let |plaintext| be the result of performing the decrypt
+                  operation specified by |normalizedAlgorithm| using |key|
+                  and |algorithm|
+                  and with |data| as |ciphertext|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>plaintext</var>.
+                  Resolve |promise| with
+                  |plaintext|.
                 </p>
               </li>
             </ol>
@@ -1528,7 +1528,7 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var> and <var>key</var> be the
+                  Let |algorithm| and |key| be the
                   `algorithm` and `key` parameters
                   passed to the {{SubtleCrypto/sign()}} method,
                   respectively.
@@ -1536,7 +1536,7 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>data</var> be the result of
+                  Let |data| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/sign()}} method.
@@ -1544,33 +1544,33 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`sign`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -1578,29 +1578,29 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>key</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is "`sign`", then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| does not contain an entry that is "`sign`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the result of performing the sign operation
-                  specified by <var>normalizedAlgorithm</var> using <var>key</var> and
-                  <var>algorithm</var> and with <var>data</var> as <var>message</var>.
+                  Let |result| be the result of performing the sign operation
+                  specified by |normalizedAlgorithm| using |key| and
+                  |algorithm| and with |data| as |message|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -1616,14 +1616,14 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var> and <var>key</var>
+                  Let |algorithm| and |key|
                   be the `algorithm` and `key` parameters passed to the
                   {{SubtleCrypto/verify()}} method, respectively.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>signature</var> be the result of
+                  Let |signature| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the `signature` parameter passed to the
                   {{SubtleCrypto/verify()}} method.
@@ -1631,7 +1631,7 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>data</var> be the result of
+                  Let |data| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/verify()}} method.
@@ -1639,34 +1639,34 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`verify`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
 
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps[= in parallel =].
+                  Return |promise| and perform the remaining steps[= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -1674,30 +1674,30 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>key</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is "`verify`", then [= exception/throw =] an {{InvalidAccessError}}.
+                  |key| does not contain an entry that is "`verify`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the result of performing the verify operation
-                  specified by <var>normalizedAlgorithm</var> using <var>key</var>,
-                  <var>algorithm</var> and
-                  <var>signature</var> and with <var>data</var> as <var>message</var>.
+                  Let |result| be the result of performing the verify operation
+                  specified by |normalizedAlgorithm| using |key|,
+                  |algorithm| and
+                  |signature| and with |data| as |message|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -1714,13 +1714,13 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var> be the `algorithm` parameter passed to the
+                  Let |algorithm| be the `algorithm` parameter passed to the
                   {{SubtleCrypto/digest()}} method.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>data</var> be the result of
+                  Let |data| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/digest()}} method.
@@ -1728,49 +1728,49 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`digest`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the result of performing the digest
-                  operation specified by <var>normalizedAlgorithm</var> using
-                  <var>algorithm</var>, with <var>data</var>
-                  as <var>message</var>.
+                  Let |result| be the result of performing the digest
+                  operation specified by |normalizedAlgorithm| using
+                  |algorithm|, with |data|
+                  as |message|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -1785,7 +1785,7 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var>, <var>extractable</var> and <var>usages</var>
+                  Let |algorithm|, |extractable| and |usages|
                   be the `algorithm`, `extractable` and `keyUsages`
                   parameters passed to the
                   {{SubtleCrypto/generateKey()}} method,
@@ -1794,60 +1794,60 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`generateKey`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the result of performing the generate key operation
-                  specified by <var>normalizedAlgorithm</var> using
-                  <var>algorithm</var>, <var>extractable</var> and <var>usages</var>.
+                  Let |result| be the result of performing the generate key operation
+                  specified by |normalizedAlgorithm| using
+                  |algorithm|, |extractable| and |usages|.
                 </p>
               </li>
               <li>
                 <dl class="switch">
-                  <dt>If <var>result</var> is a {{CryptoKey}} object:</dt>
+                  <dt>If |result| is a {{CryptoKey}} object:</dt>
                   <dd>
                     <p>
                       If the {{CryptoKey/[[type]]}} internal slot of
-                      <var>result</var> is {{KeyType/"secret"}} or {{KeyType/"private"}} and
-                      <var>usages</var> is empty, then [= exception/throw =] a {{SyntaxError}}.
+                      |result| is {{KeyType/"secret"}} or {{KeyType/"private"}} and
+                      |usages| is empty, then [= exception/throw =] a {{SyntaxError}}.
                     </p>
                   </dd>
-                  <dt>If <var>result</var> is a {{CryptoKeyPair}} object:</dt>
+                  <dt>If |result| is a {{CryptoKeyPair}} object:</dt>
                   <dd>
                     <p>
                       If the {{CryptoKey/[[usages]]}} internal slot of the
                       {{CryptoKeyPair/privateKey}} attribute of
-                      <var>result</var> is the empty sequence, then
+                      |result| is the empty sequence, then
                       [= exception/throw =] a {{SyntaxError}}.
                     </p>
                   </dd>
@@ -1855,8 +1855,8 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -1871,69 +1871,69 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var>, <var>baseKey</var>, <var>derivedKeyType</var>,
-                  <var>extractable</var> and <var>usages</var> be the `algorithm`,
+                  Let |algorithm|, |baseKey|, |derivedKeyType|,
+                  |extractable| and |usages| be the `algorithm`,
                   `baseKey`, `derivedKeyType`, `extractable` and
                   `keyUsages` parameters passed to the {{SubtleCrypto/deriveKey()}} method, respectively.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`deriveBits`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>normalizedDerivedKeyAlgorithmImport</var> be the result of
+                  Let |normalizedDerivedKeyAlgorithmImport| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>derivedKeyType</var> and `op` set to
+                  `alg` set to |derivedKeyType| and `op` set to
                   "`importKey`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedDerivedKeyAlgorithmImport</var>.
+                  |normalizedDerivedKeyAlgorithmImport|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>normalizedDerivedKeyAlgorithmLength</var> be the result of
+                  Let |normalizedDerivedKeyAlgorithmLength| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>derivedKeyType</var> and `op` set to
+                  `alg` set to |derivedKeyType| and `op` set to
                   "`get key length`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedDerivedKeyAlgorithmLength</var>.
+                  |normalizedDerivedKeyAlgorithmLength|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -1941,53 +1941,53 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>baseKey</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |baseKey| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>baseKey</var> does not contain an entry that is "`deriveKey`",
+                  |baseKey| does not contain an entry that is "`deriveKey`",
                   then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>length</var> be the result of performing the get key length
-                  algorithm specified by <var>normalizedDerivedKeyAlgorithmLength</var> using
-                  <var>derivedKeyType</var>.
+                  Let |length| be the result of performing the get key length
+                  algorithm specified by |normalizedDerivedKeyAlgorithmLength| using
+                  |derivedKeyType|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>secret</var> be the result of performing the derive bits operation
-                  specified by <var>normalizedAlgorithm</var> using
-                  <var>key</var>, <var>algorithm</var> and <var>length</var>.
+                  Let |secret| be the result of performing the derive bits operation
+                  specified by |normalizedAlgorithm| using
+                  |key|, |algorithm| and |length|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the result of performing the import key operation
-                  specified by <var>normalizedDerivedKeyAlgorithmImport</var> using "`raw`" as
-                  <var>format</var>, <var>secret</var> as <var>keyData</var>,
-                  <var>derivedKeyType</var> as <var>algorithm</var> and using
-                  <var>extractable</var> and <var>usages</var>.
+                  Let |result| be the result of performing the import key operation
+                  specified by |normalizedDerivedKeyAlgorithmImport| using "`raw`" as
+                  |format|, |secret| as |keyData|,
+                  |derivedKeyType| as |algorithm| and using
+                  |extractable| and |usages|.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[type]]}} internal slot of
-                  <var>result</var> is {{KeyType/"secret"}} or {{KeyType/"private"}} and
-                  <var>usages</var> is empty, then [= exception/throw =] a {{SyntaxError}}.
+                  |result| is {{KeyType/"secret"}} or {{KeyType/"private"}} and
+                  |usages| is empty, then [= exception/throw =] a {{SyntaxError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -2002,7 +2002,7 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var>, <var>baseKey</var> and <var>length</var>,
+                  Let |algorithm|, |baseKey| and |length|,
                   be the `algorithm`,
                   `baseKey` and `length`
                   parameters passed to the
@@ -2012,33 +2012,33 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`deriveBits`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise object.
+                  Let |promise| be a new Promise object.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -2046,34 +2046,34 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>baseKey</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |baseKey| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>baseKey</var> does not contain an entry that is "`deriveBits`",
+                  |baseKey| does not contain an entry that is "`deriveBits`",
                   then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be a new {{ArrayBuffer}}
+                  Let |result| be a new {{ArrayBuffer}}
                   associated with the
                   [= relevant global object =]
                   of `this` [[HTML]], and
                   containing the result of performing the derive bits operation
-                  specified by <var>normalizedAlgorithm</var> using <var>baseKey</var>,
-                  <var>algorithm</var> and <var>length</var>.
+                  specified by |normalizedAlgorithm| using |baseKey|,
+                  |algorithm| and |length|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -2087,15 +2087,15 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>format</var>, <var>algorithm</var>, <var>extractable</var> and
-                  <var>usages</var>, be the `format`, `algorithm`,
+                  Let |format|, |algorithm|, |extractable| and
+                  |usages|, be the `format`, `algorithm`,
                   `extractable` and `keyUsages` parameters passed to the {{SubtleCrypto/importKey()}} method, respectively.
                 </p>
               </li>
               <li>
                 <dl class="switch">
                   <dt>
-                    If <var>format</var> is equal to the string {{KeyFormat/"raw"}},
+                    If |format| is equal to the string {{KeyFormat/"raw"}},
                     {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
                   </dt>
                   <dd>
@@ -2110,7 +2110,7 @@ interface SubtleCrypto {
                       </li>
                       <li>
                         <p>
-                          Let <var>keyData</var> be the result of
+                          Let |keyData| be the result of
                           [= get a copy of the buffer source |
                           getting a copy of the bytes held by =] the
                           `keyData` parameter passed to the
@@ -2120,7 +2120,7 @@ interface SubtleCrypto {
                     </ol>
                   </dd>
                   <dt>
-                    If <var>format</var> is equal to the string {{KeyFormat/"jwk"}}:
+                    If |format| is equal to the string {{KeyFormat/"jwk"}}:
                   </dt>
                   <dd>
                     <ol>
@@ -2134,7 +2134,7 @@ interface SubtleCrypto {
                       </li>
                       <li>
                         <p>
-                          Let <var>keyData</var> be the `keyData` parameter passed to the
+                          Let |keyData| be the `keyData` parameter passed to the
                           {{SubtleCrypto/importKey()}} method.
                         </p>
                       </li>
@@ -2144,70 +2144,70 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`importKey`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the {{CryptoKey}} object that
+                  Let |result| be the {{CryptoKey}} object that
                   results from performing the import key operation specified by
-                  <var>normalizedAlgorithm</var> using <var>keyData</var>,
-                  <var>algorithm</var>,
-                  <var>format</var>, <var>extractable</var> and <var>usages</var>.
+                  |normalizedAlgorithm| using |keyData|,
+                  |algorithm|,
+                  |format|, |extractable| and |usages|.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[type]]}} internal slot of
-                  <var>result</var> is {{KeyType/"secret"}} or {{KeyType/"private"}} and
-                  <var>usages</var> is empty, then [= exception/throw =] a {{SyntaxError}}.
+                  |result| is {{KeyType/"secret"}} or {{KeyType/"private"}} and
+                  |usages| is empty, then [= exception/throw =] a {{SyntaxError}}.
                 </p>
               </li>
               <li>
                 <p>
                   Set the {{CryptoKey/[[extractable]]}} internal
-                  slot of <var>result</var> to <var>extractable</var>.
+                  slot of |result| to |extractable|.
                 </p>
               </li>
               <li>
                 <p>
                   Set the {{CryptoKey/[[usages]]}} internal
-                  slot of <var>result</var> to the [= normalized
-                    value =] of <var>usages</var>.
+                  slot of |result| to the [= normalized
+                    value =] of |usages|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -2234,25 +2234,25 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>format</var> and <var>key</var> be the `format` and
+                  Let |format| and |key| be the `format` and
                   `key` parameters passed to the {{SubtleCrypto/exportKey()}} method, respectively.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -2260,27 +2260,27 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of the {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>key</var> does not identify a <a href="#algorithms">registered algorithm</a>
+                  |key| does not identify a <a href="#algorithms">registered algorithm</a>
                   that supports the export key operation, then [= exception/throw =] a {{NotSupportedError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[extractable]]}} internal slot
-                  of <var>key</var> is false, then [= exception/throw =] an {{InvalidAccessError}}.
+                  of |key| is false, then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the result of performing the export key operation
+                  Let |result| be the result of performing the export key operation
                   specified by the {{CryptoKey/[[algorithm]]}}
-                  internal slot of <var>key</var> using <var>key</var> and <var>format</var>.
+                  internal slot of |key| using |key| and |format|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -2300,8 +2300,8 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>format</var>, <var>key</var>, <var>wrappingKey</var> and
-                  <var>algorithm</var> be the `format`, `key`,
+                  Let |format|, |key|, |wrappingKey| and
+                  |algorithm| be the `format`, `key`,
                   `wrappingKey` and `wrapAlgorithm` parameters passed to the
                   {{SubtleCrypto/wrapKey()}} method,
                   respectively.
@@ -2309,41 +2309,41 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`wrapKey`".
                 </p>
               </li>
               <li>
                 <p>
-                  If an error occurred, let <var>normalizedAlgorithm</var> be the result of
+                  If an error occurred, let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`encrypt`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -2351,29 +2351,29 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>wrappingKey</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |wrappingKey| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>wrappingKey</var> does not contain an entry that is "`wrapKey`",
+                  |wrappingKey| does not contain an entry that is "`wrapKey`",
                   then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the algorithm identified by the {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>key</var> does not support the export key operation, then [= exception/throw =] a  {{NotSupportedError}}.
+                  |key| does not support the export key operation, then [= exception/throw =] a  {{NotSupportedError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[extractable]]}} internal slot
-                  of <var>key</var> is false, then [= exception/throw =] an {{InvalidAccessError}}.
+                  of |key| is false, then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
                 <div class=note>
                   <p>
@@ -2390,35 +2390,35 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>key</var> be the result of performing the export key operation specified
+                  Let |key| be the result of performing the export key operation specified
                   the {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>key</var> using <var>key</var> and <var>format</var>.
+                  |key| using |key| and |format|.
                 </p>
               </li>
               <li>
                 <dl class="switch">
                   <dt>
-                    If <var>format</var> is equal to the strings {{KeyFormat/"raw"}},
+                    If |format| is equal to the strings {{KeyFormat/"raw"}},
                     {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
                   </dt>
                   <dd>
-                    Set <var>bytes</var> be set to <var>key</var>.
+                    Set |bytes| be set to |key|.
                   </dd>
                   <dt>
-                    If <var>format</var> is equal to the string {{KeyFormat/"jwk"}}:
+                    If |format| is equal to the string {{KeyFormat/"jwk"}}:
                   </dt>
                   <dd>
                     <ol>
                       <li>
                         <p>
-                          Convert <var>key</var> to an ECMAScript Object, as specified in [[WEBIDL]],
+                          Convert |key| to an ECMAScript Object, as specified in [[WEBIDL]],
                           performing the conversion in the
                           context of a new global object.
                         </p>
                       </li>
                       <li>
                         <p>
-                          Let <var>json</var> be the result of representing <var>key</var> as a
+                          Let |json| be the result of representing |key| as a
                           UTF-16 string conforming to the JSON grammar; for example, by executing
                           the `JSON.stringify` algorithm specified in
                           [[ECMA-262]] in the context of a new global object.
@@ -2426,8 +2426,8 @@ interface SubtleCrypto {
                       </li>
                       <li>
                         <p>
-                          Let <var>bytes</var> be the byte sequence the results from converting
-                          <var>json</var>, a JavaScript String comprised of UTF-16 code points, to
+                          Let |bytes| be the byte sequence the results from converting
+                          |json|, a JavaScript String comprised of UTF-16 code points, to
                           UTF-8 code points.
                         </p>
                       </li>
@@ -2449,22 +2449,22 @@ interface SubtleCrypto {
               </li>
               <li>
                 <dl class="switch">
-                  <dt>If <var>normalizedAlgorithm</var> supports the wrap key operation:</dt>
+                  <dt>If |normalizedAlgorithm| supports the wrap key operation:</dt>
                   <dd>
                     <p>
-                      Let <var>result</var> be the result of performing the wrap key operation
-                      specified by <var>normalizedAlgorithm</var> using <var>algorithm</var>,
-                      <var>wrappingKey</var> as <var>key</var> and <var>bytes</var> as
-                      <var>plaintext</var>.
+                      Let |result| be the result of performing the wrap key operation
+                      specified by |normalizedAlgorithm| using |algorithm|,
+                      |wrappingKey| as |key| and |bytes| as
+                      |plaintext|.
                     </p>
                   </dd>
-                  <dt>Otherwise, if <var>normalizedAlgorithm</var> supports the encrypt operation:</dt>
+                  <dt>Otherwise, if |normalizedAlgorithm| supports the encrypt operation:</dt>
                   <dd>
                     <p>
-                      Let <var>result</var> be the result of performing the encrypt operation
-                      specified by <var>normalizedAlgorithm</var> using <var>algorithm</var>,
-                      <var>wrappingKey</var> as <var>key</var> and <var>bytes</var> as
-                      <var>plaintext</var>.
+                      Let |result| be the result of performing the encrypt operation
+                      specified by |normalizedAlgorithm| using |algorithm|,
+                      |wrappingKey| as |key| and |bytes| as
+                      |plaintext|.
                     </p>
                   </dd>
                   <dt>Otherwise:</dt>
@@ -2476,8 +2476,8 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -2498,9 +2498,9 @@ interface SubtleCrypto {
             <ol>
             <li>
                 <p>
-                  Let <var>format</var>, <var>unwrappingKey</var>,
-                  <var>algorithm</var>, <var>unwrappedKeyAlgorithm</var>,
-                  <var>extractable</var> and <var>usages</var>,
+                  Let |format|, |unwrappingKey|,
+                  |algorithm|, |unwrappedKeyAlgorithm|,
+                  |extractable| and |usages|,
                   be the `format`, `unwrappingKey`,
                   `unwrapAlgorithm`, `unwrappedKeyAlgorithm`,
                   `extractable` and `keyUsages`
@@ -2511,7 +2511,7 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>wrappedKey</var> be the result of
+                  Let |wrappedKey| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the
                   `wrappedKey` parameter passed to the
@@ -2520,54 +2520,54 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let <var>normalizedAlgorithm</var> be the result of
+                  Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`unwrapKey`".
                 </p>
               </li>
               <li>
                 <p>
-                  If an error occurred, let <var>normalizedAlgorithm</var> be the result of
+                  If an error occurred, let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>algorithm</var> and `op` set to
+                  `alg` set to |algorithm| and `op` set to
                   "`decrypt`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedAlgorithm</var>.
+                  |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>normalizedKeyAlgorithm</var> be the result of <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to <var>unwrappedKeyAlgorithm</var> and `op` set
+                  Let |normalizedKeyAlgorithm| be the result of <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
+                  `alg` set to |unwrappedKeyAlgorithm| and `op` set
                   to "`importKey`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, return a Promise rejected with
-                  <var>normalizedKeyAlgorithm</var>.
+                  |normalizedKeyAlgorithm|.
                 </p>
               </li>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise.
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and perform the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject <var>promise</var> with
+                  reject |promise| with
                   the returned error and then
                   [= terminate the algorithm =].
                 </p>
@@ -2575,37 +2575,37 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{Algorithm/name}} member of
-                  <var>normalizedAlgorithm</var> is not equal to the
+                  |normalizedAlgorithm| is not equal to the
                   {{KeyAlgorithm/name}} attribute of the
                   {{CryptoKey/[[algorithm]]}} internal slot of
-                  <var>unwrappingKey</var> then [= exception/throw =] an {{InvalidAccessError}}.
+                  |unwrappingKey| then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>unwrappingKey</var> does not contain an entry that is
+                  |unwrappingKey| does not contain an entry that is
                   "`unwrapKey`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
                 <dl class="switch">
-                  <dt>If <var>normalizedAlgorithm</var> supports an unwrap key operation:</dt>
+                  <dt>If |normalizedAlgorithm| supports an unwrap key operation:</dt>
                   <dd>
-                    Let <var>key</var> be the result of performing the unwrap key operation
-                    specified by <var>normalizedAlgorithm</var> using <var>algorithm</var>,
-                    <var>unwrappingKey</var> as <var>key</var> and <var>wrappedKey</var> as
-                    <var>ciphertext</var>.
+                    Let |key| be the result of performing the unwrap key operation
+                    specified by |normalizedAlgorithm| using |algorithm|,
+                    |unwrappingKey| as |key| and |wrappedKey| as
+                    |ciphertext|.
                   </dd>
                   <dt>
-                    Otherwise, if <var>normalizedAlgorithm</var> supports a decrypt
+                    Otherwise, if |normalizedAlgorithm| supports a decrypt
                     operation:
                   </dt>
                   <dd>
-                    Let <var>key</var> be the result of performing the decrypt operation specified
-                    by <var>normalizedAlgorithm</var> using <var>algorithm</var>,
-                    <var>unwrappingKey</var> as <var>key</var> and <var>wrappedKey</var> as
-                    <var>ciphertext</var>.
+                    Let |key| be the result of performing the decrypt operation specified
+                    by |normalizedAlgorithm| using |algorithm|,
+                    |unwrappingKey| as |key| and |wrappedKey| as
+                    |ciphertext|.
                   </dd>
                   <dt>Otherwise:</dt>
                   <dd>
@@ -2617,56 +2617,56 @@ interface SubtleCrypto {
               <li>
                 <dl class="switch">
                   <dt>
-                    If <var>format</var> is equal to the strings {{KeyFormat/"raw"}},
+                    If |format| is equal to the strings {{KeyFormat/"raw"}},
                     {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
                   </dt>
                   <dd>
-                    Set <var>bytes</var> be set to <var>key</var>.
+                    Set |bytes| be set to |key|.
                   </dd>
                   <dt>
-                    If <var>format</var> is equal to the string {{KeyFormat/"jwk"}}:
+                    If |format| is equal to the string {{KeyFormat/"jwk"}}:
                   </dt>
                   <dd>
-                    Let <var>bytes</var> be the result of executing the
-                    [= parse a JWK =] algorithm, with <var>key</var>
+                    Let |bytes| be the result of executing the
+                    [= parse a JWK =] algorithm, with |key|
                     as the `data` to be parsed.
                   </dd>
                 </dl>
               </li>
               <li>
                 <p>
-                  Let <var>result</var> be the result of performing the import key operation
-                  specified by <var>normalizedKeyAlgorithm</var> using
-                  <var>unwrappedKeyAlgorithm</var> as <var>algorithm</var>, <var>format</var>,
-                  <var>usages</var>
-                  and <var>extractable</var> and with
-                  <var>bytes</var> as <var>keyData</var>.
+                  Let |result| be the result of performing the import key operation
+                  specified by |normalizedKeyAlgorithm| using
+                  |unwrappedKeyAlgorithm| as |algorithm|, |format|,
+                  |usages|
+                  and |extractable| and with
+                  |bytes| as |keyData|.
                 </p>
               </li>
               <li>
                 <p>
                   If the {{CryptoKey/[[type]]}} internal slot of
-                  <var>result</var> is {{KeyType/"secret"}} or {{KeyType/"private"}} and
-                  <var>usages</var> is empty, then [= exception/throw =] a {{SyntaxError}}.
+                  |result| is {{KeyType/"secret"}} or {{KeyType/"private"}} and
+                  |usages| is empty, then [= exception/throw =] a {{SyntaxError}}.
                 </p>
               </li>
               <li>
                 <p>
                   Set the {{CryptoKey/[[extractable]]}} internal
-                  slot of <var>result</var> to <var>extractable</var>.
+                  slot of |result| to |extractable|.
                 </p>
               </li>
               <li>
                 <p>
                   Set the {{CryptoKey/[[usages]]}} internal
-                  slot of <var>result</var> to the [= normalized
-                    value =] of <var>usages</var>.
+                  slot of |result| to the [= normalized
+                    value =] of |usages|.
                 </p>
               </li>
               <li>
                 <p>
-                  Resolve <var>promise</var> with
-                  <var>result</var>.
+                  Resolve |promise| with
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -2942,7 +2942,7 @@ dictionary CryptoKeyPair {
             <ol>
               <li>
                 <p>
-                  For each value, <var>v</var> in the List of <a href="#supported-operation">supported operations</a>, set the <var>v</var> key of
+                  For each value, |v| in the List of <a href="#supported-operation">supported operations</a>, set the |v| key of
                    the internal object {{supportedAlgorithms}}
                    to a new associative container.
                 </p>
@@ -2955,18 +2955,18 @@ dictionary CryptoKeyPair {
             <p>
               The <dfn id="concept-define-an-algorithm">define an algorithm</dfn> algorithm is used
               by specification authors to indicate how a user agent should normalize arguments for a
-              particular algorithm. Its input is an algorithm name <var>alg</var>, represented as a
-              DOMString, operation name <var>op</var>, represented as a DOMString, and desired IDL
-              dictionary type <var>type</var>. The algorithm behaves as follows:
+              particular algorithm. Its input is an algorithm name |alg|, represented as a
+              DOMString, operation name |op|, represented as a DOMString, and desired IDL
+              dictionary type |type|. The algorithm behaves as follows:
             </p>
             <ol>
               <li>
-                Let <var>registeredAlgorithms</var> be the associative container stored at the
-                <var>op</var> key of {{supportedAlgorithms}}.
+                Let |registeredAlgorithms| be the associative container stored at the
+                |op| key of {{supportedAlgorithms}}.
               </li>
               <li>
-                Set the <var>alg</var> key of <var>registeredAlgorithms</var> to the IDL dictionary
-                type <var>type</var>.
+                Set the |alg| key of |registeredAlgorithms| to the IDL dictionary
+                type |type|.
               </li>
             </ol>
           </section>
@@ -2978,55 +2978,55 @@ dictionary CryptoKeyPair {
               a process for coercing inputs to a targeted IDL dictionary type, after Web IDL
               conversion has occurred. It is designed to be extensible, to allow future specifications
               to define additional algorithms, as well as safe for use with Promises. Its input is an
-              operation name <var>op</var> and an {{AlgorithmIdentifier}} <var>alg</var>. Its output is
+              operation name |op| and an {{AlgorithmIdentifier}} |alg|. Its output is
               either an IDL dictionary type or an error. It behaves as follows:
             </p>
             <dl class="switch">
-              <dt>If <var>alg</var> is an instance of a DOMString:</dt>
+              <dt>If |alg| is an instance of a DOMString:</dt>
               <dd>
                 <p>
                   Return the result of running the <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a> algorithm, with
                   the `alg` set to a new {{Algorithm}}
                   dictionary whose {{KeyAlgorithm/name}} attribute is
-                  <var>alg</var>, and with the `op` set to <var>op</var>.
+                  |alg|, and with the `op` set to |op|.
                 </p>
               </dd>
-              <dt>If <var>alg</var> is an object:</dt>
+              <dt>If |alg| is an object:</dt>
               <dd>
                 <ol>
                   <li>
-                    Let <var>registeredAlgorithms</var> be the associative container stored at the
+                    Let |registeredAlgorithms| be the associative container stored at the
                     `op` key of {{supportedAlgorithms}}.
                   </li>
                   <li>
-                    Let <var>initialAlg</var> be the result of converting the ECMAScript object
-                    represented by <var>alg</var> to the IDL dictionary type {{Algorithm}}, as defined by [[WebIDL]].
+                    Let |initialAlg| be the result of converting the ECMAScript object
+                    represented by |alg| to the IDL dictionary type {{Algorithm}}, as defined by [[WebIDL]].
                   </li>
                   <li>
                     If an error occurred, return the error and terminate this algorithm.
                   </li>
                   <li>
-                    Let <var>algName</var> be the value of the {{Algorithm/name}}
-                    attribute of <var>initialAlg</var>.
+                    Let |algName| be the value of the {{Algorithm/name}}
+                    attribute of |initialAlg|.
                   </li>
                   <li>
                     <dl class="switch">
                       <dt>
-                        If <var>registeredAlgorithms</var> contains a key that is a
+                        If |registeredAlgorithms| contains a key that is a
                         [= case-insensitive =] string match for
-                        <var>algName</var>:
+                        |algName|:
                       </dt>
                       <dd>
                         <ol>
                           <li>
                             <p>
-                              Set <var>algName</var> to the value of the matching key.
+                              Set |algName| to the value of the matching key.
                             </p>
                           </li>
                           <li>
                             <p>
-                              Let <var>desiredType</var> be the IDL dictionary type stored at
-                              <var>algName</var> in <var>registeredAlgorithms</var>.
+                              Let |desiredType| be the IDL dictionary type stored at
+                              |algName| in |registeredAlgorithms|.
                             </p>
                           </li>
                         </ol>
@@ -3038,76 +3038,76 @@ dictionary CryptoKeyPair {
                     </dl>
                   </li>
                   <li>
-                    Let <var>normalizedAlgorithm</var> be the result of converting the ECMAScript
-                    object represented by <var>alg</var> to the IDL dictionary type
-                    <var>desiredType</var>, as defined by [[WebIDL]].
+                    Let |normalizedAlgorithm| be the result of converting the ECMAScript
+                    object represented by |alg| to the IDL dictionary type
+                    |desiredType|, as defined by [[WebIDL]].
                   </li>
                   <li>
                     Set the {{Algorithm/name}} attribute of
-                    <var>normalizedAlgorithm</var> to <var>algName</var>.
+                    |normalizedAlgorithm| to |algName|.
                   </li>
                   <li>
                     If an error occurred, return the error and terminate this algorithm.
                   </li>
                   <li>
-                    Let <var>dictionaries</var> be a list consisting of the IDL dictionary type
-                    <var>desiredType</var> and all of <var>desiredType</var>'s inherited dictionaries,
+                    Let |dictionaries| be a list consisting of the IDL dictionary type
+                    |desiredType| and all of |desiredType|'s inherited dictionaries,
                     in order from least to most derived.
                   </li>
                   <li>
                     <p>
-                      For each dictionary <var>dictionary</var> in <var>dictionaries</var>:
+                      For each dictionary |dictionary| in |dictionaries|:
                     </p>
                     <ol>
                       <li>
                         <p>
-                          For each dictionary member <var>member</var> declared on
-                          <var>dictionary</var>, in order:
+                          For each dictionary member |member| declared on
+                          |dictionary|, in order:
                         </p>
                         <ol>
                           <li>
-                            Let <var>key</var> be the identifier of <var>member</var>.
+                            Let |key| be the identifier of |member|.
                           </li>
                           <li>
-                            Let <var>idlValue</var> be the value of the dictionary member with
-                            key name of <var>key</var> on <var>normalizedAlgorithm</var>.
+                            Let |idlValue| be the value of the dictionary member with
+                            key name of |key| on |normalizedAlgorithm|.
                           </li>
                           <li>
                             <dl class="switch">
                               <dt>
-                                If <var>member</var> is of the type
+                                If |member| is of the type
                                 {{BufferSource}} and is
                                 present:
                               </dt>
                               <dd>
-                                Set the dictionary member on <var>normalizedAlgorithm</var> with key
-                                name <var>key</var> to the result of
+                                Set the dictionary member on |normalizedAlgorithm| with key
+                                name |key| to the result of
                                 [= get a copy of the buffer source |
                                 getting a copy of the bytes held by =]
-                                <var>idlValue</var>, replacing the current value.
+                                |idlValue|, replacing the current value.
                               </dd>
                               <dt>
-                                If <var>member</var> is of the type
+                                If |member| is of the type
                                 {{HashAlgorithmIdentifier}}:
                               </dt>
                               <dd>
-                                Set the dictionary member on <var>normalizedAlgorithm</var> with key
-                                name <var>key</var> to the result of
+                                Set the dictionary member on |normalizedAlgorithm| with key
+                                name |key| to the result of
                                 <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>,
-                                with the `alg` set to <var>idlValue</var> and the
+                                with the `alg` set to |idlValue| and the
                                 `op` set to "`digest`".
                               </dd>
                               <dt>
-                                If <var>member</var> is of the type
+                                If |member| is of the type
                                 {{AlgorithmIdentifier}}:
                               </dt>
                               <dd>
-                                Set the dictionary member on <var>normalizedAlgorithm</var> with key
-                                name <var>key</var> to the result of
+                                Set the dictionary member on |normalizedAlgorithm| with key
+                                name |key| to the result of
                                 <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>,
-                                with the `alg` set to <var>idlValue</var> and the
+                                with the `alg` set to |idlValue| and the
                                 `op` set to the operation defined by the specification
-                                that defines the algorithm identified by <var>algName</var>.
+                                that defines the algorithm identified by |algName|.
                               </dd>
                             </dl>
                           </li>
@@ -3119,7 +3119,7 @@ dictionary CryptoKeyPair {
                     </ol>
                   </li>
                   <li>
-                    Return <var>normalizedAlgorithm</var>.
+                    Return |normalizedAlgorithm|.
                   </li>
                 </ol>
               </dd>
@@ -3639,15 +3639,15 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Perform the signature generation operation defined in Section 8.2 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
-                    as the signer's private key and the <a href="#concept-contents-of-arraybuffer">contents of <var>message</var></a> as
-                    <var>M</var> and using the hash function specified in the {{RsaHashedKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
+                    Perform the signature generation operation defined in Section 8.2 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                    as the signer's private key and the <a href="#concept-contents-of-arraybuffer">contents of |message|</a> as
+                    |M| and using the hash function specified in the {{RsaHashedKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key| as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
                   </p>
                 </li>
                 <li>
@@ -3659,7 +3659,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>signature</var> be the value <var>S</var> that results from
+                    Let |signature| be the value |S| that results from
                     performing the operation.
                   </p>
                 </li>
@@ -3668,7 +3668,7 @@ dictionary RsaHashedImportParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and containing the
-                    bytes of <var>signature</var>.
+                    bytes of |signature|.
                   </p>
                 </li>
               </ol>
@@ -3680,7 +3680,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
@@ -3688,23 +3688,23 @@ dictionary RsaHashedImportParams : Algorithm {
                     Perform the signature verification operation defined in Section 8.2 of
                     [[RFC3447]] with the key represented by the
                     {{CryptoKey/[[handle]]}} internal slot of
-                    <var>key</var> as the signer's RSA public key and the <a href="#concept-contents-of-arraybuffer">contents of <var>message</var></a> as
-                    <var>M</var> and the <a href="#concept-contents-of-arraybuffer">contents of
-                    <var>signature</var></a> as <var>S</var> and using the hash function specified
+                    |key| as the signer's RSA public key and the <a href="#concept-contents-of-arraybuffer">contents of |message|</a> as
+                    |M| and the <a href="#concept-contents-of-arraybuffer">contents of
+                    |signature|</a> as |S| and using the hash function specified
                     in the {{RsaHashedKeyAlgorithm/hash}} attribute of the
                     {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
+                    |key| as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a boolean with value true if the
+                    Let |result| be a boolean with value true if the
                     result of the operation was "valid signature" and the value
                     false otherwise.
                   </p>
                 </li>
                 <li>
-                  <p>Return <var>result</var>.</p>
+                  <p>Return |result|.</p>
                 </li>
               </ol>
             </dd>
@@ -3713,7 +3713,7 @@ dictionary RsaHashedImportParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                      "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
@@ -3723,9 +3723,9 @@ dictionary RsaHashedImportParams : Algorithm {
                   <p>
                     Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
                     {{RsaKeyGenParams/modulusLength}} attribute of
-                    <var>normalizedAlgorithm</var> and RSA public exponent equal to the
+                    |normalizedAlgorithm| and RSA public exponent equal to the
                     {{RsaKeyGenParams/publicExponent}} attribute of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
@@ -3737,7 +3737,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{RsaHashedKeyAlgorithm}}
                     dictionary.
                   </p>
@@ -3745,38 +3745,38 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`RSASSA-PKCS1-v1_5`".
+                    |algorithm| to "`RSASSA-PKCS1-v1_5`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the
                     {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{RsaKeyGenParams/modulusLength}}
-                    attribute of <var>normalizedAlgorithm</var>.
+                    attribute of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the
                     {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{RsaKeyGenParams/publicExponent}}
-                    attribute of <var>normalizedAlgorithm</var>.
+                    attribute of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaHashedKeyAlgorithm/hash}} attribute
-                    of <var>algorithm</var> to equal the
+                    of |algorithm| to equal the
                     {{RsaHashedKeyGenParams/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>publicKey</var> be a new {{CryptoKey}}
+                    Let |publicKey| be a new {{CryptoKey}}
                     object, associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and representing the public key of the generated key pair.
@@ -3785,31 +3785,31 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to "`public`"
+                    |publicKey| to "`public`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>publicKey</var> to <var>algorithm</var>.
+                    slot of |publicKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>publicKey</var> to true.
+                    slot of |publicKey| to true.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>publicKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and `[ "verify" ]`.
+                    |publicKey| to be the [= usage
+                    intersection =] of |usages| and `[ "verify" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
+                    Let |privateKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the private key of the generated key pair.
@@ -3818,49 +3818,49 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>privateKey</var> to {{KeyType/"private"}}
+                    |privateKey| to {{KeyType/"private"}}
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>privateKey</var> to <var>algorithm</var>.
+                    slot of |privateKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>privateKey</var> to <var>extractable</var>.
+                    slot of |privateKey| to |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>privateKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and `[ "sign" ]`.
+                    |privateKey| to be the [= usage
+                    intersection =] of |usages| and `[ "sign" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a new {{CryptoKeyPair}}
+                    Let |result| be a new {{CryptoKeyPair}}
                     dictionary.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/publicKey}} attribute
-                    of <var>result</var> to be <var>publicKey</var>.
+                    of |result| to be |publicKey|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/privateKey}} attribute
-                    of <var>result</var> to be <var>privateKey</var>.
+                    of |result| to be |privateKey|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -3870,16 +3870,16 @@ dictionary RsaHashedImportParams : Algorithm {
             <dd>
               <ol>
                 <li>
-                  <p>Let <var>keyData</var> be the key data to be imported.</p>
+                  <p>Let |keyData| be the key data to be imported.</p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains an entry which is not
+                            If |usages| contains an entry which is not
                             "`verify`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -3887,9 +3887,9 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>spki</var> be the result of running the
+                            Let |spki| be the result of running the
                             [= parse a subjectPublicKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -3901,65 +3901,65 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be undefined.
+                            Let |hash| be undefined.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the `algorithm` object identifier
+                            Let |alg| be the `algorithm` object identifier
                             field of the `algorithm` AlgorithmIdentifier field of
-                            <var>spki</var>.
+                            |spki|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the `rsaEncryption`
+                              If |alg| is equivalent to the `rsaEncryption`
                               OID defined in Section 2.3.1 of [[RFC3279]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha1WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3279]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-1`".
+                                Let |hash| be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha256WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-256`".
+                                Let |hash| be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha384WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-384`".
+                                Let |hash| be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha512WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-512`".
+                                Let |hash| be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -3970,8 +3970,8 @@ dictionary RsaHashedImportParams : Algorithm {
                                     Perform any [= RSASSA-PKCS1-v1_5 key import steps |key
                                     import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>spki</var>
-                                    and obtaining <var>hash</var>.
+                                    specifications</a>, passing |format|, |spki|
+                                    and obtaining |hash|.
                                   </p>
                                 </li>
                                 <li>
@@ -3990,23 +3990,23 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -4015,17 +4015,17 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>publicKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with <var>data</var> as the
-                            `subjectPublicKeyInfo` field of <var>spki</var>,
-                            <var>structure</var> as the `RSAPublicKey` structure
+                            Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
+                            algorithm, with |data| as the
+                            `subjectPublicKeyInfo` field of |spki|,
+                            |structure| as the `RSAPublicKey` structure
                             specified in Section A.1.1 of [[RFC3447]], and
-                            <var>exactData</var> set to true.
+                            |exactData| set to true.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If an error occurred while parsing, or it can be determined that <var>publicKey</var>
+                            If an error occurred while parsing, or it can be determined that |publicKey|
                             is not a valid public key according to [[RFC3447]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -4033,27 +4033,27 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>key</var> be a new {{CryptoKey}} associated with the
+                            Let |key| be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and
                             that represents the RSA public key identified by
-                            <var>publicKey</var>.
+                            |publicKey|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to "`public`"
+                            of |key| to "`public`"
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains an entry which is not
+                            If |usages| contains an entry which is not
                              "`sign`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -4061,9 +4061,9 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>privateKeyInfo</var> be the result of running the
+                            Let |privateKeyInfo| be the result of running the
                             [= parse a privateKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -4075,65 +4075,65 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be undefined.
+                            Let |hash| be undefined.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the `algorithm` object identifier
+                            Let |alg| be the `algorithm` object identifier
                             field of the `privateKeyAlgorithm`
-                            PrivateKeyAlgorithmIdentifier field of <var>privateKeyInfo</var>.
+                            PrivateKeyAlgorithmIdentifier field of |privateKeyInfo|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the `rsaEncryption`
+                              If |alg| is equivalent to the `rsaEncryption`
                               OID defined in Section 2.3.1 of [[RFC3279]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha1WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3279]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-1`".
+                                Let |hash| be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha256WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-256`".
+                                Let |hash| be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha384WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-384`".
+                                Let |hash| be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `sha512WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-512`".
+                                Let |hash| be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -4144,8 +4144,8 @@ dictionary RsaHashedImportParams : Algorithm {
                                     Perform any [= RSASSA-PKCS1-v1_5 key import steps | key
                                     import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>privateKeyInfo</var>
-                                    and obtaining <var>hash</var>.
+                                    specifications</a>, passing |format|, |privateKeyInfo|
+                                    and obtaining |hash|.
                                   </p>
                                 </li>
                                 <li>
@@ -4164,23 +4164,23 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -4189,17 +4189,17 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>rsaPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with <var>data</var> as the
-                            `privateKey` field of <var>privateKeyInfo</var>,
-                            <var>structure</var> as the `RSAPrivateKey` structure
+                            Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                            algorithm, with |data| as the
+                            `privateKey` field of |privateKeyInfo|,
+                            |structure| as the `RSAPrivateKey` structure
                             specified in Section A.1.2 of [[RFC3447]], and
-                            <var>exactData</var> set to true.
+                            |exactData| set to true.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If an error occurred while parsing, or if <var>rsaPrivateKey</var> is not
+                            If an error occurred while parsing, or if |rsaPrivateKey| is not
                             a valid RSA private key according to [[RFC3447]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -4207,39 +4207,39 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>key</var> be a new {{CryptoKey}} associated with the
+                            Let |key| be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and
                             that represents the RSA private key identified by
-                            <var>rsaPrivateKey</var>.
+                            |rsaPrivateKey|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to {{KeyType/"private"}}
+                            of |key| to {{KeyType/"private"}}
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/d}} field of <var>jwk</var> is present and
-                            <var>usages</var> contains an entry which is not
-                            "`sign`", or, if the {{JsonWebKey/d}} field of <var>jwk</var>
+                            If the {{JsonWebKey/d}} field of |jwk| is present and
+                            |usages| contains an entry which is not
+                            "`sign`", or, if the {{JsonWebKey/d}} field of |jwk|
                             is not present and
-                            <var>usages</var> contains an entry which is not
+                            |usages| contains an entry which is not
                             "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -4247,7 +4247,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not a
+                            If the {{JsonWebKey/kty}} field of |jwk| is not a
                             case-sensitive string match to "`RSA`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -4255,7 +4255,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not a case-sensitive string match to "`sig`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -4263,37 +4263,37 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be a be a string whose initial value is
+                            Let |hash| be a be a string whose initial value is
                             undefined.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is not
+                              If the {{JsonWebKey/alg}} field of |jwk| is not
                               present:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
@@ -4302,7 +4302,7 @@ dictionary RsaHashedImportParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-1`".
+                                Let |hash| be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
@@ -4311,7 +4311,7 @@ dictionary RsaHashedImportParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-256`".
+                                Let |hash| be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
@@ -4320,7 +4320,7 @@ dictionary RsaHashedImportParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-384`".
+                                Let |hash| be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
@@ -4329,7 +4329,7 @@ dictionary RsaHashedImportParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-512`".
+                                Let |hash| be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -4340,8 +4340,8 @@ dictionary RsaHashedImportParams : Algorithm {
                                     Perform any [= RSASSA-PKCS1-v1_5 key import steps | key
                                     import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>jwk</var>
-                                    and obtaining <var>hash</var>.
+                                    specifications</a>, passing |format|, |jwk|
+                                    and obtaining |hash|.
                                   </p>
                                 </li>
                                 <li>
@@ -4360,23 +4360,23 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -4385,12 +4385,12 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field of <var>jwk</var> is present:</dt>
+                            <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    If <var>jwk</var> does not meet the requirements of
+                                    If |jwk| does not meet the requirements of
                                     Section 6.3.2 of JSON Web Algorithms [[JWA]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -4398,15 +4398,15 @@ dictionary RsaHashedImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>privateKey</var> represents the
-                                    RSA private key identified by interpreting <var>jwk</var>
+                                    Let |privateKey| represents the
+                                    RSA private key identified by interpreting |jwk|
                                     according to Section 6.3.2 of JSON Web
                                     Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>privateKey</var> is not a valid RSA private key
+                                    If |privateKey| is not a valid RSA private key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -4414,14 +4414,14 @@ dictionary RsaHashedImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} object that represents
-                                    <var>privateKey</var>.
+                                    Let |key| be a new {{CryptoKey}} object that represents
+                                    |privateKey|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}}
-                                    internal slot of <var>key</var> to {{KeyType/"private"}}
+                                    internal slot of |key| to {{KeyType/"private"}}
                                   </p>
                                 </li>
                               </ol>
@@ -4431,20 +4431,20 @@ dictionary RsaHashedImportParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    If <var>jwk</var> does not meet the requirements of Section
+                                    If |jwk| does not meet the requirements of Section
                                     6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>publicKey</var> represent the
-                                    RSA public key identified by interpreting <var>jwk</var>
+                                    Let |publicKey| represent the
+                                    RSA public key identified by interpreting |jwk|
                                     according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>publicKey</var> can be determined to not be a valid RSA public key
+                                    If |publicKey| can be determined to not be a valid RSA public key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -4452,13 +4452,13 @@ dictionary RsaHashedImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} representing <var>publicKey</var>.
+                                    Let |key| be a new {{CryptoKey}} representing |publicKey|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}}
-                                    internal slot of <var>key</var> to "`public`"
+                                    internal slot of |key| to "`public`"
                                   </p>
                                 </li>
                               </ol>
@@ -4476,45 +4476,45 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{RsaHashedKeyAlgorithm}} dictionary.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`RSASSA-PKCS1-v1_5`"
+                    |algorithm| to "`RSASSA-PKCS1-v1_5`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of <var>algorithm</var> to the length, in bits, of the RSA public
+                    attribute of |algorithm| to the length, in bits, of the RSA public
                     modulus.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the <a href="#dfn-RsaKeyAlgorithm-publicExponent">publicExponent</a>
-                    attribute of <var>algorithm</var> to the <a href="#dfn-BigInteger">BigInteger</a>
+                    attribute of |algorithm| to the <a href="#dfn-BigInteger">BigInteger</a>
                     representation of the RSA public exponent.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
-                    <var>algorithm</var> to the {{RsaHashedImportParams/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |algorithm| to the {{RsaHashedImportParams/hash}} member of
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
-                  <p>Return <var>key</var>.</p>
+                  <p>Return |key|.</p>
                 </li>
               </ol>
             </dd>
@@ -4524,122 +4524,122 @@ dictionary RsaHashedImportParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>key</var> be the key to be exported.
+                    Let |key| be the key to be exported.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>algorithm</var> field to an
+                                Set the |algorithm| field to an
                                 `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>params</var> field to the ASN.1 type NULL.
+                                    Set the |params| field to the ASN.1 type NULL.
                                   </p>
                                 </li>
                               </ul>
                             </li>
                             <li>
                               <p>
-                                Set the <var>subjectPublicKey</var> field to the result of
+                                Set the |subjectPublicKey| field to the result of
                                 DER-encoding an `RSAPublicKey` ASN.1 type, as defined
                                 in [[RFC3447]], Appendix A.1.1, that
                                 represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var>
+                                |key|
                               </p>
                             </li>
                           </ul>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the result of encoding a privateKeyInfo structure
+                            Let |data| be the result of encoding a privateKeyInfo structure
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>version</var> field to 0.
+                                Set the |version| field to 0.
                               </p>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKeyAlgorithm</var> field to a
+                                Set the |privateKeyAlgorithm| field to a
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>params</var> field to the ASN.1 type NULL.
+                                    Set the |params| field to the ASN.1 type NULL.
                                   </p>
                                 </li>
                               </ul>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKey</var> field to the result of DER-encoding
+                                Set the |privateKey| field to the result of DER-encoding
                                 an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
                                 RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var>
+                                |key|
                               </p>
                               <div class=note>
                                 [[RFC5208]] specifies that the encoding of
@@ -4653,60 +4653,60 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
-                          <p>Let <var>jwk</var> be a new {{JsonWebKey}}
+                          <p>Let |jwk| be a new {{JsonWebKey}}
                           dictionary.</p>
                         </li>
                         <li>
-                          <p>Set the `kty` attribute of <var>jwk</var> to the string
+                          <p>Set the `kty` attribute of |jwk| to the string
                           "`RSA`".</p>
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be the {{KeyAlgorithm/name}}
+                            Let |hash| be the {{KeyAlgorithm/name}}
                             attribute of the {{RsaHashedKeyAlgorithm/hash}}
                             attribute of the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var>.
+                            internal slot of |key|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>hash</var> is "`SHA-1`":</dt>
+                            <dt>If |hash| is "`SHA-1`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RS1`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is "`SHA-256`":</dt>
+                            <dt>If |hash| is "`SHA-256`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RS256`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is "`SHA-384`":</dt>
+                            <dt>If |hash| is "`SHA-384`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RS384`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is "`SHA-512`":</dt>
+                            <dt>If |hash| is "`SHA-512`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RS512`".
                               </p>
                             </dd>
@@ -4718,8 +4718,8 @@ dictionary RsaHashedImportParams : Algorithm {
                                     Perform any [= RSASSA-PKCS1-v1_5 key import steps | key
                                     export steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>key</var>
-                                    and obtaining <var>alg</var>.
+                                    specifications</a>, passing |format|, |key|
+                                    and obtaining |alg|.
                                   </p>
                                 </li>
                                 <li>
@@ -4733,7 +4733,7 @@ dictionary RsaHashedImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the `alg` attribute of <var>jwk</var> to <var>alg</var>.
+                                    Set the `alg` attribute of |jwk| to |alg|.
                                   </p>
                                 </li>
                               </ol>
@@ -4742,7 +4742,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of <var>jwk</var>
+                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
                             according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
                           </p>
                         </li>
@@ -4750,7 +4750,7 @@ dictionary RsaHashedImportParams : Algorithm {
                           <dl class="switch">
                             <dt>
                               If the {{CryptoKey/[[type]]}} internal slot
-                              of <var>key</var> is {{KeyType/"private"}}:
+                              of |key| is {{KeyType/"private"}}:
                             </dt>
                             <dd>
                               <ol>
@@ -4758,15 +4758,15 @@ dictionary RsaHashedImportParams : Algorithm {
                                   <p>
                                     Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
                                     {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
-                                    {{JsonWebKey/qi}} of <var>jwk</var> according to the
+                                    {{JsonWebKey/qi}} of |jwk| according to the
                                     corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                    of <var>key</var> is represented by more than two primes, set
-                                    the attribute named {{JsonWebKey/oth}} of <var>jwk</var>
+                                    of |key| is represented by more than two primes, set
+                                    the attribute named {{JsonWebKey/oth}} of |jwk|
                                     according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
                                   </p>
                                 </li>
@@ -4776,18 +4776,18 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to the <a href="#dfn-CryptoKey-usages">usages</a> attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to the <a href="#dfn-CryptoKey-usages">usages</a> attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -4804,7 +4804,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -4893,18 +4893,18 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Perform the signature generation operation defined in Section 8.1 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
-                    as the signer's private key, <var>K</var>, and the <a href="#concept-contents-of-arraybuffer">contents of <var>message</var></a> as
-                    the message to be signed, <var>M</var>, and using the hash function specified
+                    Perform the signature generation operation defined in Section 8.1 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                    as the signer's private key, |K|, and the <a href="#concept-contents-of-arraybuffer">contents of |message|</a> as
+                    the message to be signed, |M|, and using the hash function specified
                     by the {{RsaHashedKeyAlgorithm/hash}} attribute of the
                     {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
-                    <var>normalizedAlgorithm</var> as the salt length option for the
+                    |key| as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
+                    |normalizedAlgorithm| as the salt length option for the
                     EMSA-PSS-ENCODE operation.
                   </p>
                 </li>
@@ -4917,7 +4917,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>signature</var> be the
+                    Let |signature| be the
                     signature, S, that results from performing the operation.
                   </p>
                 </li>
@@ -4926,7 +4926,7 @@ dictionary RsaPssParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and containing the
-                    bytes of <var>signature</var>.
+                    bytes of |signature|.
                   </p>
                 </li>
               </ol>
@@ -4938,7 +4938,7 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
@@ -4946,19 +4946,19 @@ dictionary RsaPssParams : Algorithm {
                     Perform the signature verification operation defined in Section 8.1 of
                     [[RFC3447]] with the key represented by the
                     {{CryptoKey/[[handle]]}} internal slot of
-                    <var>key</var> as the signer's RSA public key and the <a href="#concept-contents-of-arraybuffer">contents of <var>message</var></a> as
-                    <var>M</var> and <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>signature</var></a> as <var>S</var> and using the hash function specified
+                    |key| as the signer's RSA public key and the <a href="#concept-contents-of-arraybuffer">contents of |message|</a> as
+                    |M| and <a href="#concept-contents-of-arraybuffer">the contents of
+                    |signature|</a> as |S| and using the hash function specified
                     by the {{RsaHashedKeyAlgorithm/hash}} attribute of the
                     {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
-                    <var>normalizedAlgorithm</var> as the salt length option for the
+                    |key| as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
+                    |normalizedAlgorithm| as the salt length option for the
                     EMSA-PSS-VERIFY operation.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a boolean with the value true if the
+                    Let |result| be a boolean with the value true if the
                     result of the operation was "valid signature" and the value
                     false otherwise.
                   </p>
@@ -4971,7 +4971,7 @@ dictionary RsaPssParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                     "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
@@ -4981,9 +4981,9 @@ dictionary RsaPssParams : Algorithm {
                   <p>
                     Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
                     {{RsaKeyGenParams/modulusLength}} member of
-                    <var>normalizedAlgorithm</var> and RSA public exponent equal to the
+                    |normalizedAlgorithm| and RSA public exponent equal to the
                     {{RsaKeyGenParams/publicExponent}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
@@ -4995,7 +4995,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{RsaHashedKeyAlgorithm}}
                     dictionary.
                   </p>
@@ -5003,38 +5003,38 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`RSA-PSS`".
+                    |algorithm| to "`RSA-PSS`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the
                     {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{RsaKeyGenParams/modulusLength}}
-                    member of <var>normalizedAlgorithm</var>.
+                    member of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the
                     {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{RsaKeyGenParams/publicExponent}}
-                    member of <var>normalizedAlgorithm</var>.
+                    member of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaHashedKeyAlgorithm/hash}} attribute
-                    of <var>algorithm</var> to equal the
+                    of |algorithm| to equal the
                     {{RsaHashedKeyGenParams/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
+                    Let |publicKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the public key of the generated key pair.
@@ -5043,31 +5043,31 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to "`public`"
+                    |publicKey| to "`public`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>publicKey</var> to <var>algorithm</var>.
+                    slot of |publicKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>publicKey</var> to true.
+                    slot of |publicKey| to true.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>publicKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and `[ "verify" ]`.
+                    |publicKey| to be the [= usage
+                    intersection =] of |usages| and `[ "verify" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
+                    Let |privateKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the private key of the generated key pair.
@@ -5076,49 +5076,49 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>privateKey</var> to {{KeyType/"private"}}
+                    |privateKey| to {{KeyType/"private"}}
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>privateKey</var> to <var>algorithm</var>.
+                    slot of |privateKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>privateKey</var> to <var>extractable</var>.
+                    slot of |privateKey| to |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>privateKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and `[ "sign" ]`.
+                    |privateKey| to be the [= usage
+                    intersection =] of |usages| and `[ "sign" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a new {{CryptoKeyPair}}
+                    Let |result| be a new {{CryptoKeyPair}}
                     dictionary.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/publicKey}} attribute
-                    of <var>result</var> to <var>publicKey</var>.
+                    of |result| to |publicKey|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/privateKey}} attribute
-                    of <var>result</var> to <var>privateKey</var>.
+                    of |result| to |privateKey|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return the result of converting <var>result</var> to an ECMAScript Object,
+                    Return the result of converting |result| to an ECMAScript Object,
                     as defined by [[WebIDL]].
                   </p>
                 </li>
@@ -5129,16 +5129,16 @@ dictionary RsaPssParams : Algorithm {
             <dd>
               <ol>
                 <li>
-                  <p>Let <var>keyData</var> be the key data to be imported.</p>
+                  <p>Let |keyData| be the key data to be imported.</p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains an entry which is not
+                            If |usages| contains an entry which is not
                             "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -5146,9 +5146,9 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>spki</var> be the result of running the
+                            Let |spki| be the result of running the
                             [= parse a subjectPublicKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -5160,29 +5160,29 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be undefined.
+                            Let |hash| be undefined.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the `algorithm` object identifier
+                            Let |alg| be the `algorithm` object identifier
                             field of the `algorithm` AlgorithmIdentifier field of
-                            <var>spki</var>.
+                            |spki|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the `rsaEncryption`
+                              If |alg| is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the
+                              If |alg| is equivalent to the
                               `id-RSASSA-PSS` OID defined in
                               [[RFC3447]]:
                             </dt>
@@ -5190,14 +5190,14 @@ dictionary RsaPssParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>params</var> be the ASN.1 structure contained within
+                                    Let |params| be the ASN.1 structure contained within
                                     the `parameters` field of the `algorithm`
-                                    AlgorithmIdentifier field of <var>spki</var>.
+                                    AlgorithmIdentifier field of |spki|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>params</var> is not defined, or is not an instance of
+                                    If |params| is not defined, or is not an instance of
                                     the `RSASSA-PSS-params` ASN.1 type defined in
                                     [[RFC3447]],
                                     [= exception/throw =] a
@@ -5206,50 +5206,50 @@ dictionary RsaPssParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
-                                    within the `hashAlgorithm` field of <var>params</var>.
+                                    Let |hashAlg| be the AlgorithmIdentifier ASN.1 type
+                                    within the `hashAlgorithm` field of |params|.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha1`
+                                      |hashAlg| is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-1`".
+                                        Set |hash| to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha256`
+                                      |hashAlg| is equivalent to the `id-sha256`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-256`".
+                                        Set |hash| to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha384`
+                                      |hashAlg| is equivalent to the `id-sha384`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-384`".
+                                        Set |hash| to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha512`
+                                      |hashAlg| is equivalent to the `id-sha512`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-512`".
+                                        Set |hash| to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -5259,8 +5259,8 @@ dictionary RsaPssParams : Algorithm {
                                           <p>
                                             Perform any [= RSA-PSS key import steps | key import steps =] defined by
                                             <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var>, <var>spki</var>
-                                            and obtaining <var>hash</var>.
+                                            specifications</a>, passing |format|, |spki|
+                                            and obtaining |hash|.
                                           </p>
                                         </li>
                                         <li>
@@ -5280,17 +5280,17 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     If the `algorithm` object identifier field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If the `parameters` field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     an instance of the `HashAlgorithm` ASN.1 type that is
                                     identical in content to the `hashAlgorithm` field of
-                                    <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
+                                    |params|, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -5307,23 +5307,23 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -5332,17 +5332,17 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>publicKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with <var>data</var> as the
-                            `subjectPublicKeyInfo` field of <var>spki</var>,
-                            <var>structure</var> as the `RSAPublicKey` structure
+                            Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
+                            algorithm, with |data| as the
+                            `subjectPublicKeyInfo` field of |spki|,
+                            |structure| as the `RSAPublicKey` structure
                             specified in Section A.1.1 of [[RFC3447]], and
-                            <var>exactData</var> set to true.
+                            |exactData| set to true.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If an error occurred while parsing, or it can be determined that <var>publicKey</var>
+                            If an error occurred while parsing, or it can be determined that |publicKey|
                             is not a valid public key according to [[RFC3447]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -5350,27 +5350,27 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>key</var> be a new {{CryptoKey}} associated with the
+                            Let |key| be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and
                             that represents the RSA public key identified by
-                            <var>publicKey</var>.
+                            |publicKey|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to "`public`"
+                            of |key| to "`public`"
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains an entry which is not
+                            If |usages| contains an entry which is not
                             "`sign`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -5378,9 +5378,9 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>privateKeyInfo</var> be the result of running the
+                            Let |privateKeyInfo| be the result of running the
                             [= parse a privateKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -5390,44 +5390,44 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be undefined.
+                            Let |hash| be undefined.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the `algorithm` object identifier
+                            Let |alg| be the `algorithm` object identifier
                             field of the `privateKeyAlgorithm`
-                            PrivateKeyAlgorithmIdentifier field of <var>privateKeyInfo</var>.
+                            PrivateKeyAlgorithmIdentifier field of |privateKeyInfo|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the `rsaEncryption`
+                              If |alg| is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the `id-RSASSA-PSS` OID
+                              If |alg| is equivalent to the `id-RSASSA-PSS` OID
                               defined in [[RFC3447]]:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>params</var> be the ASN.1 structure contained within
+                                    Let |params| be the ASN.1 structure contained within
                                     the `parameters` field of the
                                     `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier
-                                    field of <var>privateKeyInfo</var>.
+                                    field of |privateKeyInfo|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>params</var> is not defined, or is not an instance of
+                                    If |params| is not defined, or is not an instance of
                                     the `RSASSA-PSS-params` ASN.1 type defined in
                                     [[RFC3447]],
                                     [= exception/throw =] a
@@ -5436,50 +5436,50 @@ dictionary RsaPssParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
-                                    within the `hashAlgorithm` field of <var>params</var>.
+                                    Let |hashAlg| be the AlgorithmIdentifier ASN.1 type
+                                    within the `hashAlgorithm` field of |params|.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha1`
+                                      |hashAlg| is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-1`".
+                                        Set |hash| to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha256`
+                                      |hashAlg| is equivalent to the `id-sha256`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-256`".
+                                        Set |hash| to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha384`
+                                      |hashAlg| is equivalent to the `id-sha384`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-384`".
+                                        Set |hash| to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha512`
+                                      |hashAlg| is equivalent to the `id-sha512`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-512`".
+                                        Set |hash| to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -5489,8 +5489,8 @@ dictionary RsaPssParams : Algorithm {
                                           <p>
                                             Perform any [= RSA-PSS key import steps | key import steps =] defined by
                                             <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var>, <var>privateKeyInfo</var>
-                                            and obtaining <var>hash</var>.
+                                            specifications</a>, passing |format|, |privateKeyInfo|
+                                            and obtaining |hash|.
                                           </p>
                                         </li>
                                         <li>
@@ -5509,17 +5509,17 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     If the `algorithm` object identifier field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If the `parameters` field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     an instance of the `HashAlgorithm` ASN.1 type that is
                                     identical in content to the `hashAlgorithm` field of
-                                    <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
+                                    |params|, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -5536,23 +5536,23 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -5561,17 +5561,17 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>rsaPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with <var>data</var> as the
-                            `privateKey` field of <var>privateKeyInfo</var>,
-                            <var>structure</var> as the `RSAPrivateKey` structure
+                            Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                            algorithm, with |data| as the
+                            `privateKey` field of |privateKeyInfo|,
+                            |structure| as the `RSAPrivateKey` structure
                             specified in Section A.1.2 of [[RFC3447]], and
-                            <var>exactData</var> set to true.
+                            |exactData| set to true.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If an error occurred while parsing, or if <var>rsaPrivateKey</var> is not
+                            If an error occurred while parsing, or if |rsaPrivateKey| is not
                             a valid RSA private key according to [[RFC3447]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -5579,39 +5579,39 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>key</var> be a new {{CryptoKey}} associated with the
+                            Let |key| be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and
                             that represents the RSA private key identified by
-                            <var>rsaPrivateKey</var>.
+                            |rsaPrivateKey|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to {{KeyType/"private"}}
+                            of |key| to {{KeyType/"private"}}
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/d}} field of <var>jwk</var> is present and
-                            <var>usages</var> contains an entry which is not
-                            "`sign`", or, if the {{JsonWebKey/d}} field of <var>jwk</var>
+                            If the {{JsonWebKey/d}} field of |jwk| is present and
+                            |usages| contains an entry which is not
+                            "`sign`", or, if the {{JsonWebKey/d}} field of |jwk|
                             is not present and
-                            <var>usages</var> contains an entry which is not
+                            |usages| contains an entry which is not
                             "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -5619,7 +5619,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not a
+                            If the {{JsonWebKey/kty}} field of |jwk| is not a
                             case-sensitive string match to "`RSA`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -5627,7 +5627,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not a case-sensitive string match to "`sig`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -5635,18 +5635,18 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -5654,12 +5654,12 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is not
+                              If the {{JsonWebKey/alg}} field of |jwk| is not
                               present:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
@@ -5668,7 +5668,7 @@ dictionary RsaPssParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-1`".
+                                Let |hash| be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
@@ -5677,7 +5677,7 @@ dictionary RsaPssParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-256`".
+                                Let |hash| be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
@@ -5686,7 +5686,7 @@ dictionary RsaPssParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-384`".
+                                Let |hash| be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
@@ -5695,7 +5695,7 @@ dictionary RsaPssParams : Algorithm {
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string "`SHA-512`".
+                                Let |hash| be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -5705,8 +5705,8 @@ dictionary RsaPssParams : Algorithm {
                                   <p>
                                     Perform any [= RSA-PSS key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>jwk</var>
-                                    and obtaining <var>hash</var>.
+                                    specifications</a>, passing |format|, |jwk|
+                                    and obtaining |hash|.
                                   </p>
                                 </li>
                                 <li>
@@ -5725,23 +5725,23 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -5750,12 +5750,12 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field of <var>jwk</var> is present:</dt>
+                            <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    If <var>jwk</var> does not meet the requirements of
+                                    If |jwk| does not meet the requirements of
                                     Section 6.3.2 of JSON Web Algorithms [[JWA]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -5763,15 +5763,15 @@ dictionary RsaPssParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>privateKey</var> represent the
-                                    RSA public key identified by interpreting <var>jwk</var>
+                                    Let |privateKey| represent the
+                                    RSA public key identified by interpreting |jwk|
                                     according to Section 6.3.1 of JSON Web
                                     Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>privateKey</var> can be determined to not be a valid RSA public key
+                                    If |privateKey| can be determined to not be a valid RSA public key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -5779,13 +5779,13 @@ dictionary RsaPssParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} representing <var>privateKey</var>.
+                                    Let |key| be a new {{CryptoKey}} representing |privateKey|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}}
-                                    internal slot of <var>key</var> to {{KeyType/"private"}}
+                                    internal slot of |key| to {{KeyType/"private"}}
                                   </p>
                                 </li>
                               </ol>
@@ -5795,20 +5795,20 @@ dictionary RsaPssParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    If <var>jwk</var> does not meet the requirements of Section
+                                    If |jwk| does not meet the requirements of Section
                                     6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>publicKey</var> represent the
-                                    RSA public key identified by interpreting <var>jwk</var>
+                                    Let |publicKey| represent the
+                                    RSA public key identified by interpreting |jwk|
                                     according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>publicKey</var> can be determined to not be a valid RSA public key
+                                    If |publicKey| can be determined to not be a valid RSA public key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -5816,13 +5816,13 @@ dictionary RsaPssParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} representing <var>publicKey</var>.
+                                    Let |key| be a new {{CryptoKey}} representing |publicKey|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}}
-                                    internal slot of <var>key</var> to "`public`"
+                                    internal slot of |key| to "`public`"
                                   </p>
                                 </li>
                               </ol>
@@ -5840,45 +5840,45 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{RsaHashedKeyAlgorithm}} dictionary.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`RSA-PSS`"
+                    |algorithm| to "`RSA-PSS`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of <var>algorithm</var> to the length, in bits, of the RSA public
+                    attribute of |algorithm| to the length, in bits, of the RSA public
                     modulus.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of <var>algorithm</var> to the {{BigInteger}}
+                    attribute of |algorithm| to the {{BigInteger}}
                     representation of the RSA public exponent.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
-                    <var>algorithm</var> to the {{RsaHashedImportParams/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |algorithm| to the {{RsaHashedImportParams/hash}} member of
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>
+                    slot of |key| to |algorithm|
                   </p>
                 </li>
                 <li>
-                  <p>Return <var>key</var>.</p>
+                  <p>Return |key|.</p>
                 </li>
               </ol>
             </dd>
@@ -5888,122 +5888,122 @@ dictionary RsaPssParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>key</var> be the key to be exported.
+                    Let |key| be the key to be exported.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>algorithm</var> field to an
+                                Set the |algorithm| field to an
                                 `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>params</var> field to the ASN.1 type NULL.
+                                    Set the |params| field to the ASN.1 type NULL.
                                   </p>
                                 </li>
                               </ul>
                             </li>
                             <li>
                               <p>
-                                Set the <var>subjectPublicKey</var> field to the result of
+                                Set the |subjectPublicKey| field to the result of
                                 DER-encoding an `RSAPublicKey` ASN.1 type, as defined
                                 in [[RFC3447]], Appendix A.1.1, that
                                 represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var>
+                                |key|
                               </p>
                             </li>
                           </ul>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the result of encoding a privateKeyInfo structure
+                            Let |data| be the result of encoding a privateKeyInfo structure
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>version</var> field to 0.
+                                Set the |version| field to 0.
                               </p>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKeyAlgorithm</var> field to an
+                                Set the |privateKeyAlgorithm| field to an
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>params</var> field to the ASN.1 type NULL.
+                                    Set the |params| field to the ASN.1 type NULL.
                                   </p>
                                 </li>
                               </ul>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKey</var> field to the result of DER-encoding
+                                Set the |privateKey| field to the result of DER-encoding
                                 an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
                                 RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var>
+                                |key|
                               </p>
                               <div class=note>
                                 [[RFC5208]] specifies that the encoding of
@@ -6017,59 +6017,59 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
-                          <p>Let <var>jwk</var> be a new {{JsonWebKey}} dictionary.</p>
+                          <p>Let |jwk| be a new {{JsonWebKey}} dictionary.</p>
                         </li>
                         <li>
-                          <p>Set the `kty` attribute of <var>jwk</var> to the string
+                          <p>Set the `kty` attribute of |jwk| to the string
                           "`RSA`".</p>
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be the {{KeyAlgorithm/name}}
+                            Let |hash| be the {{KeyAlgorithm/name}}
                             attribute of the {{RsaHashedKeyAlgorithm/hash}}
                             attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                            <var>key</var>.
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>hash</var> is "`SHA-1`":</dt>
+                            <dt>If |hash| is "`SHA-1`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`PS1`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is "`SHA-256`":</dt>
+                            <dt>If |hash| is "`SHA-256`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`PS256`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is "`SHA-384`":</dt>
+                            <dt>If |hash| is "`SHA-384`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`PS384`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is "`SHA-512`":</dt>
+                            <dt>If |hash| is "`SHA-512`":</dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`PS512`".
                               </p>
                             </dd>
@@ -6080,16 +6080,16 @@ dictionary RsaPssParams : Algorithm {
                                   <p>
                                     Perform any [= RSA-PSS key export steps | key export steps =]
                                     defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var> and the
+                                    specifications</a>, passing |format| and the
                                     {{RsaHashedKeyAlgorithm/hash}} attribute of
                                     the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of <var>key</var>
-                                    and obtaining <var>alg</var>.
+                                    internal slot of |key|
+                                    and obtaining |alg|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the `alg` attribute of <var>jwk</var> to <var>alg</var>.
+                                    Set the `alg` attribute of |jwk| to |alg|.
                                   </p>
                                 </li>
                               </ol>
@@ -6098,7 +6098,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of <var>jwk</var>
+                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
                             according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
                           </p>
                         </li>
@@ -6106,7 +6106,7 @@ dictionary RsaPssParams : Algorithm {
                           <dl class="switch">
                             <dt>
                               If the {{CryptoKey/[[type]]}} internal slot of
-                              <var>key</var> is {{KeyType/"private"}}:
+                              |key| is {{KeyType/"private"}}:
                             </dt>
                             <dd>
                               <ol>
@@ -6114,15 +6114,15 @@ dictionary RsaPssParams : Algorithm {
                                   <p>
                                     Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
                                     {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
-                                    {{JsonWebKey/qi}} of <var>jwk</var> according to the
+                                    {{JsonWebKey/qi}} of |jwk| according to the
                                     corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                    of <var>key</var> is represented by more than two primes, set
-                                    the attribute named {{JsonWebKey/oth}} of <var>jwk</var>
+                                    of |key| is represented by more than two primes, set
+                                    the attribute named {{JsonWebKey/oth}} of |jwk|
                                     according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
                                   </p>
                                 </li>
@@ -6132,18 +6132,18 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -6160,7 +6160,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -6249,7 +6249,7 @@ dictionary RsaOaepParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of <var>key</var>
+                    If the {{CryptoKey/[[type]]}} internal slot of |key|
                     is not "`public`",
                     then [= exception/throw =] an
                     {{InvalidAccessError}}.
@@ -6257,21 +6257,21 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>label</var> be the <a href="#concept-contents-of-arraybuffer">contents of</a> the {{RsaOaepParams/label}} member of
-                    <var>normalizedAlgorithm</var> or the empty octet string if the
+                    Let |label| be the <a href="#concept-contents-of-arraybuffer">contents of</a> the {{RsaOaepParams/label}} member of
+                    |normalizedAlgorithm| or the empty octet string if the
                     {{RsaOaepParams/label}} member of
-                    <var>normalizedAlgorithm</var> is not present.
+                    |normalizedAlgorithm| is not present.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Perform the encryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by <var>key</var>
-                    as the recipient's RSA public key, the <a href="#concept-contents-of-arraybuffer">contents of <var>plaintext</var></a>
-                    as the message to be encrypted, <var>M</var> and <var>label</var>
-                    as the label, <var>L</var>, and with the hash
+                    Perform the encryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by |key|
+                    as the recipient's RSA public key, the <a href="#concept-contents-of-arraybuffer">contents of |plaintext|</a>
+                    as the message to be encrypted, |M| and |label|
+                    as the label, |L|, and with the hash
                     function specified by the {{RsaHashedKeyAlgorithm/hash}}
                     attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> as the Hash option and MGF1 (defined in Section B.2.1 of
+                    |key| as the Hash option and MGF1 (defined in Section B.2.1 of
                     [[RFC3447]]) as the MGF option.
                   </p>
                 </li>
@@ -6284,7 +6284,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>ciphertext</var> be the value <var>C</var> that results from performing the
+                    Let |ciphertext| be the value |C| that results from performing the
                     operation.
                   </p>
                 </li>
@@ -6293,7 +6293,7 @@ dictionary RsaOaepParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>ciphertext</var>.
+                    containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -6303,7 +6303,7 @@ dictionary RsaOaepParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of <var>key</var>
+                    If the {{CryptoKey/[[type]]}} internal slot of |key|
                     is not {{KeyType/"private"}},
                     then [= exception/throw =] an
                     {{InvalidAccessError}}.
@@ -6311,21 +6311,21 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>label</var> be the <a href="#concept-contents-of-arraybuffer">contents of</a> the {{RsaOaepParams/label}} member of
-                    <var>normalizedAlgorithm</var> or the empty octet string if the
+                    Let |label| be the <a href="#concept-contents-of-arraybuffer">contents of</a> the {{RsaOaepParams/label}} member of
+                    |normalizedAlgorithm| or the empty octet string if the
                     {{RsaOaepParams/label}} member of
-                    <var>normalizedAlgorithm</var> is not present.
+                    |normalizedAlgorithm| is not present.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Perform the decryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by <var>key</var>
-                    as the recipient's RSA private key, the <a href="#concept-contents-of-arraybuffer">contents of <var>ciphertext</var></a>
-                    as the ciphertext to be decrypted, C, and <var>label</var>
-                    as the label, <var>L</var>, and with the hash
+                    Perform the decryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by |key|
+                    as the recipient's RSA private key, the <a href="#concept-contents-of-arraybuffer">contents of |ciphertext|</a>
+                    as the ciphertext to be decrypted, C, and |label|
+                    as the label, |L|, and with the hash
                     function specified by the {{RsaHashedKeyAlgorithm/hash}}
                     attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> as the Hash option and MGF1 (defined in Section B.2.1 of
+                    |key| as the Hash option and MGF1 (defined in Section B.2.1 of
                     [[RFC3447]]) as the MGF option.
                   </p>
                 </li>
@@ -6338,7 +6338,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>plaintext</var> the value <var>M</var> that results from performing the
+                    Let |plaintext| the value |M| that results from performing the
                     operation.
                   </p>
                 </li>
@@ -6347,7 +6347,7 @@ dictionary RsaOaepParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>plaintext</var>.
+                    containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -6357,7 +6357,7 @@ dictionary RsaOaepParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                     "`encrypt`", "`decrypt`",
                     "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
@@ -6368,9 +6368,9 @@ dictionary RsaOaepParams : Algorithm {
                   <p>
                     Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
                     {{RsaKeyGenParams/modulusLength}} member of
-                    <var>normalizedAlgorithm</var> and RSA public exponent equal to the
+                    |normalizedAlgorithm| and RSA public exponent equal to the
                     {{RsaKeyGenParams/publicExponent}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
@@ -6382,7 +6382,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{RsaHashedKeyAlgorithm}}
                     object.
                   </p>
@@ -6390,38 +6390,38 @@ dictionary RsaOaepParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`RSA-OAEP`".
+                    |algorithm| to "`RSA-OAEP`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the
                     {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{RsaKeyGenParams/modulusLength}}
-                    member of <var>normalizedAlgorithm</var>.
+                    member of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the
                     {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{RsaKeyGenParams/publicExponent}}
-                    member of <var>normalizedAlgorithm</var>.
+                    member of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaHashedKeyAlgorithm/hash}} attribute
-                    of <var>algorithm</var> to equal the
+                    of |algorithm| to equal the
                     {{RsaHashedKeyGenParams/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
+                    Let |publicKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the public key of the generated key pair.
@@ -6430,32 +6430,32 @@ dictionary RsaOaepParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to "`public`"
+                    |publicKey| to "`public`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>publicKey</var> to <var>algorithm</var>.
+                    |publicKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal slot of
-                    <var>publicKey</var> to true.
+                    |publicKey| to true.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>publicKey</var> to be the
+                    |publicKey| to be the
                     [= usage intersection =] of
-                    <var>usages</var> and `[ "encrypt", "wrapKey" ]`.
+                    |usages| and `[ "encrypt", "wrapKey" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
+                    Let |privateKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the private key of the generated key pair.
@@ -6464,50 +6464,50 @@ dictionary RsaOaepParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>privateKey</var> to {{KeyType/"private"}}
+                    |privateKey| to {{KeyType/"private"}}
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>privateKey</var> to <var>algorithm</var>.
+                    |privateKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal slot of
-                    <var>privateKey</var> to <var>extractable</var>.
+                    |privateKey| to |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>privateKey</var> to be the
+                    |privateKey| to be the
                     [= usage intersection =] of
-                    <var>usages</var> and `[ "decrypt", "unwrapKey" ]`.
+                    |usages| and `[ "decrypt", "unwrapKey" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a new {{CryptoKeyPair}}
+                    Let |result| be a new {{CryptoKeyPair}}
                     dictionary.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/publicKey}} attribute
-                    of <var>result</var> to be <var>publicKey</var>.
+                    of |result| to be |publicKey|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/privateKey}} attribute
-                    of <var>result</var> to be <var>privateKey</var>.
+                    of |result| to be |privateKey|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return the result of converting <var>result</var> to an ECMAScript Object, as
+                    Return the result of converting |result| to an ECMAScript Object, as
                     defined by [[WebIDL]].
                   </p>
                 </li>
@@ -6518,16 +6518,16 @@ dictionary RsaOaepParams : Algorithm {
             <dd>
               <ol>
                 <li>
-                  <p>Let <var>keyData</var> be the key data to be imported.</p>
+                  <p>Let |keyData| be the key data to be imported.</p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains an entry which is not
+                            If |usages| contains an entry which is not
                             "`encrypt`" or
                             "`wrapKey`",
                             then [= exception/throw =] a
@@ -6536,9 +6536,9 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>spki</var> be the result of running the
+                            Let |spki| be the result of running the
                             [= parse a subjectPublicKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -6550,43 +6550,43 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be a string whose initial value is undefined.
+                            Let |hash| be a string whose initial value is undefined.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the `algorithm` object identifier
+                            Let |alg| be the `algorithm` object identifier
                             field of the `algorithm` AlgorithmIdentifier field of
-                            <var>spki</var>.
+                            |spki|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the `rsaEncryption`
+                              If |alg| is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the `id-RSAES-OAEP`
+                              If |alg| is equivalent to the `id-RSAES-OAEP`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>params</var> be the ASN.1 structure contained within
+                                    Let |params| be the ASN.1 structure contained within
                                     the `parameters` field of the `algorithm`
-                                    AlgorithmIdentifier field of <var>spki</var>.
+                                    AlgorithmIdentifier field of |spki|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>params</var> is not defined, or is not an instance of
+                                    If |params| is not defined, or is not an instance of
                                     the `RSAES-OAEP-params` ASN.1 type defined in
                                     [[RFC3447]],
                                     [= exception/throw =] a
@@ -6595,50 +6595,50 @@ dictionary RsaOaepParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
-                                    within the `hashAlgorithm` field of <var>params</var>.
+                                    Let |hashAlg| be the AlgorithmIdentifier ASN.1 type
+                                    within the `hashAlgorithm` field of |params|.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha1`
+                                      |hashAlg| is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-1`".
+                                        Set |hash| to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha256`
+                                      |hashAlg| is equivalent to the `id-sha256`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-256`".
+                                        Set |hash| to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha384`
+                                      |hashAlg| is equivalent to the `id-sha384`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-384`".
+                                        Set |hash| to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha512`
+                                      |hashAlg| is equivalent to the `id-sha512`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-512`".
+                                        Set |hash| to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -6649,8 +6649,8 @@ dictionary RsaOaepParams : Algorithm {
                                             Perform any [= RSA-OAEP key import steps | key
                                             import steps =] defined by
                                             <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var>, <var>spki</var>
-                                            and obtaining <var>hash</var>.
+                                            specifications</a>, passing |format|, |spki|
+                                            and obtaining |hash|.
                                           </p>
                                         </li>
                                         <li>
@@ -6669,17 +6669,17 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     If the `algorithm` object identifier field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If the `parameters` field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     an instance of the `HashAlgorithm` ASN.1 type that is
                                     identical in content to the `hashAlgorithm` field of
-                                    <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
+                                    |params|, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -6696,23 +6696,23 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -6721,17 +6721,17 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>publicKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with <var>data</var> as the
-                            `subjectPublicKeyInfo` field of <var>spki</var>,
-                            <var>structure</var> as the `RSAPublicKey` structure
+                            Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
+                            algorithm, with |data| as the
+                            `subjectPublicKeyInfo` field of |spki|,
+                            |structure| as the `RSAPublicKey` structure
                             specified in Section A.1.1 of [[RFC3447]], and
-                            <var>exactData</var> set to true.
+                            |exactData| set to true.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If an error occurred while parsing, or it can be determined that <var>publicKey</var>
+                            If an error occurred while parsing, or it can be determined that |publicKey|
                             is not a valid public key according to [[RFC3447]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -6739,27 +6739,27 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>key</var> be a new {{CryptoKey}} associated with the
+                            Let |key| be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and
                             that represents the RSA public key identified by
-                            <var>publicKey</var>.
+                            |publicKey|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot of
-                            <var>key</var> to "`public`"
+                            |key| to "`public`"
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains an entry which is not
+                            If |usages| contains an entry which is not
                             "`decrypt`" or "`unwrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -6767,9 +6767,9 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>privateKeyInfo</var> be the result of running the
+                            Let |privateKeyInfo| be the result of running the
                             [= parse a privateKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -6779,94 +6779,94 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be a string whose initial value is undefined.
+                            Let |hash| be a string whose initial value is undefined.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the `algorithm` object identifier
+                            Let |alg| be the `algorithm` object identifier
                             field of the `privateKeyAlgorithm`
-                            PrivateKeyAlgorithmIdentifier field of <var>privateKeyInfo</var>.
+                            PrivateKeyAlgorithmIdentifier field of |privateKeyInfo|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the `rsaEncryption`
+                              If |alg| is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be undefined.
+                                Let |hash| be undefined.
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the `id-RSAES-OAEP`
+                              If |alg| is equivalent to the `id-RSAES-OAEP`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>params</var> be the ASN.1 structure contained within
+                                    Let |params| be the ASN.1 structure contained within
                                     the `parameters` field of the
                                     `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier
-                                    field of <var>privateKeyInfo</var>.
+                                    field of |privateKeyInfo|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>params</var> is not defined, or is not an instance of
+                                    If |params| is not defined, or is not an instance of
                                     the `RSAES-OAEP-params` ASN.1 type defined in [[RFC3447]], [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
+                                    Let |hashAlg| be the AlgorithmIdentifier ASN.1 type
                                     within the `hashAlgorithm` field of
-                                    <var>params</var>.
+                                    |params|.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the `id-sha1`
+                                      |hashAlg| is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-1`".
+                                        Set |hash| to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the
+                                      |hashAlg| is equivalent to the
                                       `id-sha256` OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-256`".
+                                        Set |hash| to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the
+                                      |hashAlg| is equivalent to the
                                       `id-sha384` OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-384`".
+                                        Set |hash| to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
                                       If the `algorithm` object identifier field of
-                                      <var>hashAlg</var> is equivalent to the
+                                      |hashAlg| is equivalent to the
                                       `id-sha512` OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string "`SHA-512`".
+                                        Set |hash| to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -6876,8 +6876,8 @@ dictionary RsaOaepParams : Algorithm {
                                           <p>
                                             Perform any [= RSA-OAEP key import steps | key import steps =] defined by
                                             <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var>, <var>spki</var>
-                                            and obtaining <var>hash</var>.
+                                            specifications</a>, passing |format|, |spki|
+                                            and obtaining |hash|.
                                           </p>
                                         </li>
                                         <li>
@@ -6896,17 +6896,17 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     If the `algorithm` object identifier field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If the `parameters` field of the
-                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    `maskGenAlgorithm` field of |params| is not
                                     an instance of the `HashAlgorithm` ASN.1 type that is
                                     identical in content to the `hashAlgorithm` field of
-                                    <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
+                                    |params|, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -6923,23 +6923,23 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -6948,17 +6948,17 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>rsaPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with <var>data</var> as the
-                            `privateKey` field of <var>privateKeyInfo</var>,
-                            <var>structure</var> as the `RSAPrivateKey` structure
+                            Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                            algorithm, with |data| as the
+                            `privateKey` field of |privateKeyInfo|,
+                            |structure| as the `RSAPrivateKey` structure
                             specified in Section A.1.2 of [[RFC3447]], and
-                            <var>exactData</var> set to true.
+                            |exactData| set to true.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If an error occurred while parsing, or if <var>rsaPrivateKey</var> is not
+                            If an error occurred while parsing, or if |rsaPrivateKey| is not
                             a valid RSA private key according to [[RFC3447]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -6966,36 +6966,36 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>key</var> be a new {{CryptoKey}} associated with the
+                            Let |key| be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and
                             that represents the RSA private key identified by
-                            <var>rsaPrivateKey</var>.
+                            |rsaPrivateKey|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot of
-                            <var>key</var> to {{KeyType/"private"}}
+                            |key| to {{KeyType/"private"}}
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/d}} field of <var>jwk</var> is present and
-                            <var>usages</var> contains an entry which is not
+                            If the {{JsonWebKey/d}} field of |jwk| is present and
+                            |usages| contains an entry which is not
                             "`decrypt`" or "`unwrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -7003,8 +7003,8 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/d}} field of <var>jwk</var> is not present and
-                            <var>usages</var> contains an entry which is not
+                            If the {{JsonWebKey/d}} field of |jwk| is not present and
+                            |usages| contains an entry which is not
                             "`encrypt`" or "`wrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -7012,7 +7012,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not a
+                            If the {{JsonWebKey/kty}} field of |jwk| is not a
                             case-sensitive string match to "`RSA`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -7020,7 +7020,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not a case-sensitive string match to "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -7028,46 +7028,46 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If the `alg` field of <var>jwk</var> is not present:</dt>
-                            <dd>Let <var>hash</var> be undefined.</dd>
+                            <dt>If the `alg` field of |jwk| is not present:</dt>
+                            <dd>Let |hash| be undefined.</dd>
                             <dt>
-                              If the `alg` field of <var>jwk</var> is equal to
+                              If the `alg` field of |jwk| is equal to
                               "`RSA-OAEP`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string "`SHA-1`".</dd>
+                            <dd>Let |hash| be the string "`SHA-1`".</dd>
                             <dt>
-                              If the `alg` field of <var>jwk</var> is equal to
+                              If the `alg` field of |jwk| is equal to
                               "`RSA-OAEP-256`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string "`SHA-256`".</dd>
+                            <dd>Let |hash| be the string "`SHA-256`".</dd>
                             <dt>
-                              If the `alg` field of <var>jwk</var> is equal to
+                              If the `alg` field of |jwk| is equal to
                               "`RSA-OAEP-384`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string "`SHA-384`".</dd>
+                            <dd>Let |hash| be the string "`SHA-384`".</dd>
                             <dt>
-                              If the `alg` field of <var>jwk</var> is equal to
+                              If the `alg` field of |jwk| is equal to
                               "`RSA-OAEP-512`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string "`SHA-512`".</dd>
+                            <dd>Let |hash| be the string "`SHA-512`".</dd>
                             <dt>Otherwise:</dt>
                             <dd>
                               <ol>
@@ -7075,8 +7075,8 @@ dictionary RsaOaepParams : Algorithm {
                                   <p>
                                     Perform any [= RSA-OAEP key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>jwk</var>
-                                    and obtaining <var>hash</var>.
+                                    specifications</a>, passing |format|, |jwk|
+                                    and obtaining |hash|.
                                   </p>
                                 </li>
                                 <li>
@@ -7095,23 +7095,23 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <dl>
                             <dt>
-                              If <var>hash</var> is not undefined:
+                              If |hash| is not undefined:
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>normalizedHash</var> be the result of
+                                    Let |normalizedHash| be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to <var>hash</var> and `op` set
+                                    with `alg` set to |hash| and `op` set
                                     to `digest`.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>normalizedHash</var> is not equal to the
+                                    If |normalizedHash| is not equal to the
                                     {{RsaHashedImportParams/hash}} member of
-                                    <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                               </ol>
@@ -7120,25 +7120,25 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field of <var>jwk</var> is present:</dt>
+                            <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    If <var>jwk</var> does not meet the requirements of Section
+                                    If |jwk| does not meet the requirements of Section
                                     6.3.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>privateKey</var> represent the
-                                    RSA public key identified by interpreting <var>jwk</var>
+                                    Let |privateKey| represent the
+                                    RSA public key identified by interpreting |jwk|
                                     according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>privateKey</var> can be determined to not be a valid RSA public key
+                                    If |privateKey| can be determined to not be a valid RSA public key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -7146,13 +7146,13 @@ dictionary RsaOaepParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} representing <var>privateKey</var>.
+                                    Let |key| be a new {{CryptoKey}} representing |privateKey|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}} internal slot of
-                                    <var>key</var> to {{KeyType/"private"}}
+                                    |key| to {{KeyType/"private"}}
                                   </p>
                                 </li>
                               </ol>
@@ -7162,20 +7162,20 @@ dictionary RsaOaepParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    If <var>jwk</var> does not meet the requirements of Section
+                                    If |jwk| does not meet the requirements of Section
                                     6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>publicKey</var> represent the
-                                    RSA public key identified by interpreting <var>jwk</var>
+                                    Let |publicKey| represent the
+                                    RSA public key identified by interpreting |jwk|
                                     according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>publicKey</var> can be determined to not be a valid RSA public key
+                                    If |publicKey| can be determined to not be a valid RSA public key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -7183,13 +7183,13 @@ dictionary RsaOaepParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} representing <var>publicKey</var>.
+                                    Let |key| be a new {{CryptoKey}} representing |publicKey|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}} internal slot of
-                                    <var>key</var> to "`public`"
+                                    |key| to "`public`"
                                   </p>
                                 </li>
                               </ol>
@@ -7207,45 +7207,45 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{RsaHashedKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`RSA-OAEP`"
+                    |algorithm| to "`RSA-OAEP`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of <var>algorithm</var> to the length, in bits, of the RSA public
+                    attribute of |algorithm| to the length, in bits, of the RSA public
                     modulus.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of <var>algorithm</var> to the {{BigInteger}}</a>
+                    attribute of |algorithm| to the {{BigInteger}}</a>
                     representation of the RSA public exponent.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
-                    <var>algorithm</var> to the {{RsaHashedImportParams/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |algorithm| to the {{RsaHashedImportParams/hash}} member of
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> to <var>algorithm</var>
+                    |key| to |algorithm|
                   </p>
                 </li>
                 <li>
-                  <p>Return <var>key</var>.</p>
+                  <p>Return |key|.</p>
                 </li>
               </ol>
             </dd>
@@ -7255,122 +7255,122 @@ dictionary RsaOaepParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>key</var> be the key to be exported.
+                    Let |key| be the key to be exported.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot of
-                            <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                            |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>algorithm</var> field to an
+                                Set the |algorithm| field to an
                                 `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>params</var> field to the ASN.1 type NULL.
+                                    Set the |params| field to the ASN.1 type NULL.
                                   </p>
                                 </li>
                               </ul>
                             </li>
                             <li>
                               <p>
-                                Set the <var>subjectPublicKey</var> field to the result of
+                                Set the |subjectPublicKey| field to the result of
                                 DER-encoding an `RSAPublicKey` ASN.1 type, as defined
                                 in [[RFC3447]], Appendix A.1.1, that
                                 represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var>
+                                |key|
                               </p>
                             </li>
                           </ul>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot of
-                            <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                            |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the result of encoding a privateKeyInfo structure
+                            Let |data| be the result of encoding a privateKeyInfo structure
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>version</var> field to 0.
+                                Set the |version| field to 0.
                               </p>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKeyAlgorithm</var> field to an
+                                Set the |privateKeyAlgorithm| field to an
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>params</var> field to the ASN.1 type NULL.
+                                    Set the |params| field to the ASN.1 type NULL.
                                   </p>
                                 </li>
                               </ul>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKey</var> field to the result of DER-encoding
+                                Set the |privateKey| field to the result of DER-encoding
                                 an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
                                 RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var>
+                                |key|
                               </p>
                               <div class=note>
                                 [[RFC5208]] specifies that the encoding of
@@ -7384,72 +7384,72 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>jwk</var> be a new {{JsonWebKey}}
+                            Let |jwk| be a new {{JsonWebKey}}
                             dictionary.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to the string
+                            Set the `kty` attribute of |jwk| to the string
                             "`RSA`".
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be the {{KeyAlgorithm/name}}
+                            Let |hash| be the {{KeyAlgorithm/name}}
                             attribute of the {{RsaHashedKeyAlgorithm/hash}}
                             attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                            <var>key</var>.
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>hash</var> is "`SHA-1`":
+                              If |hash| is "`SHA-1`":
                             </dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RSA-OAEP`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>hash</var> is "`SHA-256`":
+                              If |hash| is "`SHA-256`":
                             </dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RSA-OAEP-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>hash</var> is "`SHA-384`":
+                              If |hash| is "`SHA-384`":
                             </dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RSA-OAEP-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>hash</var> is "`SHA-512`":
+                              If |hash| is "`SHA-512`":
                             </dt>
                             <dd>
                               <p>
-                                Set the `alg` attribute of <var>jwk</var> to the string
+                                Set the `alg` attribute of |jwk| to the string
                                 "`RSA-OAEP-512`".
                               </p>
                             </dd>
@@ -7460,16 +7460,16 @@ dictionary RsaOaepParams : Algorithm {
                                   <p>
                                     Perform any [= RSA-OAEP key export steps | key export steps =]
                                     defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var> and the
+                                    specifications</a>, passing |format| and the
                                     {{RsaHashedKeyAlgorithm/hash}} attribute of
                                     the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of <var>key</var>
-                                    and obtaining <var>alg</var>.
+                                    internal slot of |key|
+                                    and obtaining |alg|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the `alg` attribute of <var>jwk</var> to <var>alg</var>.
+                                    Set the `alg` attribute of |jwk| to |alg|.
                                   </p>
                                 </li>
                               </ol>
@@ -7478,7 +7478,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of <var>jwk</var>
+                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
                             according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
                           </p>
                         </li>
@@ -7486,7 +7486,7 @@ dictionary RsaOaepParams : Algorithm {
                           <dl class="switch">
                             <dt>
                               If the {{CryptoKey/[[type]]}} internal slot
-                              of <var>key</var> is {{KeyType/"private"}}:
+                              of |key| is {{KeyType/"private"}}:
                             </dt>
                             <dd>
                               <ol>
@@ -7494,15 +7494,15 @@ dictionary RsaOaepParams : Algorithm {
                                   <p>
                                     Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
                                     {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
-                                    {{JsonWebKey/qi}} of <var>jwk</var> according to the
+                                    {{JsonWebKey/qi}} of |jwk| according to the
                                     corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                    of <var>key</var> is represented by more than two primes, set
-                                    the attribute named {{JsonWebKey/oth}} of <var>jwk</var>
+                                    of |key| is represented by more than two primes, set
+                                    the attribute named {{JsonWebKey/oth}} of |jwk|
                                     according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
                                   </p>
                                 </li>
@@ -7512,18 +7512,18 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -7540,7 +7540,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -7683,30 +7683,30 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>hashAlgorithm</var> be the {{EcdsaParams/hash}}
-                    member of <var>normalizedAlgorithm</var>.
+                    Let |hashAlgorithm| be the {{EcdsaParams/hash}}
+                    member of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>M</var> be the result of performing the digest operation specified by
-                    <var>hashAlgorithm</var> using <var>message</var>.
+                    Let |M| be the result of performing the digest operation specified by
+                    |hashAlgorithm| using |message|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>d</var> be the ECDSA private key associated with <var>key</var>.
+                    Let |d| be the ECDSA private key associated with |key|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>params</var> be the EC domain parameters associated with
-                    <var>key</var>.
+                    Let |params| be the EC domain parameters associated with
+                    |key|.
                   </p>
                 </li>
                 <li>
@@ -7714,47 +7714,47 @@ dictionary EcKeyImportParams : Algorithm {
                     <dt>
                       If the {{EcKeyAlgorithm/namedCurve}} attribute of the
                       {{CryptoKey/[[algorithm]]}} internal slot of
-                      <var>key</var> is "`P-256`", "`P-384`" or "`P-521`":
+                      |key| is "`P-256`", "`P-384`" or "`P-521`":
                     </dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             Perform the ECDSA signing process, as specified in [[RFC6090]],
-                            Section 5.4, with <var>M</var> as the message, using <var>params</var> as the
-                            EC domain parameters, and with <var>d</var> as the private key.
+                            Section 5.4, with |M| as the message, using |params| as the
+                            EC domain parameters, and with |d| as the private key.
                           </p>
                         </li>
                         <li>
                           <p>
-                          Let <var>r</var> and <var>s</var> be the pair of integers resulting from
+                          Let |r| and |s| be the pair of integers resulting from
                           performing the ECDSA signing process.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new empty {{ArrayBuffer}} associated with the
+                            Let |result| be a new empty {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]].
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>n</var> be the smallest integer such that <var>n</var> * 8 is greater than
+                            Let |n| be the smallest integer such that |n| * 8 is greater than
                             the logarithm to base 2 of the order of the base point of the elliptic curve identified
-                            by <var>params</var>.
+                            by |params|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            <a href="#dfn-convert-integer-to-octet-string">Convert <var>r</var> to an octet string of
-                            length <var>n</var></a> and append this sequence of bytes to <var>result</var>.
+                            <a href="#dfn-convert-integer-to-octet-string">Convert |r| to an octet string of
+                            length |n|</a> and append this sequence of bytes to |result|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            <a href="#dfn-convert-integer-to-octet-string">Convert <var>s</var> to an octet string of
-                            length <var>n</var></a> and append this sequence of bytes to <var>result</var>.
+                            <a href="#dfn-convert-integer-to-octet-string">Convert |s| to an octet string of
+                            length |n|</a> and append this sequence of bytes to |result|.
                           </p>
                         </li>
                       </ol>
@@ -7762,14 +7762,14 @@ dictionary EcKeyImportParams : Algorithm {
                     <dt>
                       Otherwise, the {{EcKeyAlgorithm/namedCurve}} attribute
                       of the {{CryptoKey/[[algorithm]]}} internal slot of
-                      <var>key</var> is a value specified in an
+                      |key| is a value specified in an
                       <a href="#dfn-applicable-specification">applicable specification</a>:
                     </dt>
                     <dd>
                       <p>
                         Perform the [= ECDSA signature steps =]
-                        specified in that specification, passing in <var>M</var>, <var>params</var>
-                        and <var>d</var> and resulting in <var>result</var>.
+                        specified in that specification, passing in |M|, |params|
+                        and |d| and resulting in |result|.
                       </p>
                     </dd>
                   </dl>
@@ -7779,7 +7779,7 @@ dictionary EcKeyImportParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and containing the
-                    bytes of <var>result</var>.
+                    bytes of |result|.
                   </p>
                 </li>
               </ol>
@@ -7791,31 +7791,31 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>hashAlgorithm</var> be the {{EcdsaParams/hash}}
+                    Let |hashAlgorithm| be the {{EcdsaParams/hash}}
                     member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>M</var> be the result of performing the digest operation specified by
-                    <var>hashAlgorithm</var> using <var>message</var>.
+                    Let |M| be the result of performing the digest operation specified by
+                    |hashAlgorithm| using |message|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>Q</var> be the ECDSA public key associated with <var>key</var>.
+                    Let |Q| be the ECDSA public key associated with |key|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>params</var> be the EC domain parameters associated with
-                    <var>key</var>.
+                    Let |params| be the EC domain parameters associated with
+                    |key|.
                   </p>
                 </li>
                 <li>
@@ -7823,27 +7823,27 @@ dictionary EcKeyImportParams : Algorithm {
                     <dt>
                       If the {{EcKeyAlgorithm/namedCurve}} attribute of the
                       {{CryptoKey/[[algorithm]]}} internal slot of
-                      <var>key</var> is "`P-256`", "`P-384`" or "`P-521`":
+                      |key| is "`P-256`", "`P-384`" or "`P-521`":
                     </dt>
                     <dd>
                       <p>
-                        Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.3, with <var>M</var> as the received
-                        message, <var>signature</var> as the received signature and using
-                        <var>params</var> as the EC domain parameters, and
-                        <var>Q</var> as the public key.
+                        Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.3, with |M| as the received
+                        message, |signature| as the received signature and using
+                        |params| as the EC domain parameters, and
+                        |Q| as the public key.
                       </p>
                     </dd>
                     <dt>
                       Otherwise, the {{EcKeyAlgorithm/namedCurve}} attribute
                       of the {{CryptoKey/[[algorithm]]}} internal slot of
-                      <var>key</var> is a value specified in an
+                      |key| is a value specified in an
                       <a href="#dfn-applicable-specification">applicable specification</a>:
                     </dt>
                     <dd>
                       <p>
                         Perform the [= ECDSA verification steps =]
-                        specified in that specification passing in <var>M</var>, <var>signature</var>,
-                        <var>params</var> and <var>Q</var> and resulting in an indication of whether
+                        specified in that specification passing in |M|, |signature|,
+                        |params| and |Q| and resulting in an indication of whether
                         or not the purported signature is valid.
                       </p>
                     </dd>
@@ -7851,13 +7851,13 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a boolean with the value `true` if the signature is valid
+                    Let |result| be a boolean with the value `true` if the signature is valid
                     and the value `false` otherwise.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -7867,7 +7867,7 @@ dictionary EcKeyImportParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains a value which is not
+                    If |usages| contains a value which is not
                     one of "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
@@ -7877,7 +7877,7 @@ dictionary EcKeyImportParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{EcKeyGenParams/namedCurve}} member of
-                      <var>normalizedAlgorithm</var> is "`P-256`", "`P-384`"
+                      |normalizedAlgorithm| is "`P-256`", "`P-384`"
                       or "`P-521`":
                     </dt>
                     <dd>
@@ -7885,19 +7885,19 @@ dictionary EcKeyImportParams : Algorithm {
                         Generate an Elliptic Curve key pair, as defined in [[RFC6090]]
                         with domain parameters for the curve identified by
                         the {{EcKeyGenParams/namedCurve}} member of
-                        <var>normalizedAlgorithm</var>.
+                        |normalizedAlgorithm|.
                       </p>
                     </dd>
                     <dt>
                       If the {{EcKeyGenParams/namedCurve}} member of
-                      <var>normalizedAlgorithm</var> is a value specified in an
+                      |normalizedAlgorithm| is a value specified in an
                       <a href="#dfn-applicable-specification">applicable specification</a>:
                     </dt>
                     <dd>
                       <p>
                         Perform the [=ECDSA
                         generation steps =] specified in that specification, passing in
-                        <var>normalizedAlgorithm</var> and resulting in an elliptic curve key pair.
+                        |normalizedAlgorithm| and resulting in an elliptic curve key pair.
                       </p>
                     </dd>
                     <dt>Otherwise:</dt>
@@ -7918,7 +7918,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{EcKeyAlgorithm}}
                     object.
                   </p>
@@ -7926,20 +7926,20 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`ECDSA`".
+                    |algorithm| to "`ECDSA`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{EcKeyAlgorithm/namedCurve}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{namedCurve}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
+                    Let |publicKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the public key of the generated key pair.
@@ -7948,31 +7948,31 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to "`public`"
+                    |publicKey| to "`public`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>publicKey</var> to <var>algorithm</var>.
+                    slot of |publicKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>publicKey</var> to true.
+                    slot of |publicKey| to true.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>publicKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and `[ "verify" ]`.
+                    |publicKey| to be the [= usage
+                    intersection =] of |usages| and `[ "verify" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
+                    Let |privateKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the private key of the generated key pair.
@@ -7981,49 +7981,49 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>privateKey</var> to {{KeyType/"private"}}
+                    |privateKey| to {{KeyType/"private"}}
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>privateKey</var> to <var>algorithm</var>.
+                    slot of |privateKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>privateKey</var> to <var>extractable</var>.
+                    slot of |privateKey| to |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>privateKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and `[ "sign" ]`.
+                    |privateKey| to be the [= usage
+                    intersection =] of |usages| and `[ "sign" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a new {{CryptoKeyPair}}
+                    Let |result| be a new {{CryptoKeyPair}}
                     dictionary.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/publicKey}} attribute
-                    of <var>result</var> to be <var>publicKey</var>.
+                    of |result| to be |publicKey|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/privateKey}} attribute
-                    of <var>result</var> to be <var>privateKey</var>.
+                    of |result| to be |privateKey|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return the result of converting <var>result</var> to an ECMAScript Object, as
+                    Return the result of converting |result| to an ECMAScript Object, as
                     defined by [[WebIDL]].
                   </p>
                 </li>
@@ -8034,16 +8034,16 @@ dictionary EcKeyImportParams : Algorithm {
             <dd>
               <ol>
                 <li>
-                  <p>Let <var>keyData</var> be the key data to be imported.</p>
+                  <p>Let |keyData| be the key data to be imported.</p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains a value which is not
+                            If |usages| contains a value which is not
                             "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -8051,9 +8051,9 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>spki</var> be the result of running the
+                            Let |spki| be the result of running the
                             [= parse a subjectPublicKeyInfo =]
-                            algorithm over <var>keyData</var>
+                            algorithm over |keyData|
                           </p>
                         </li>
                         <li>
@@ -8066,7 +8066,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of <var>spki</var> is
+                            `algorithm` AlgorithmIdentifier field of |spki| is
                             not equal to the `id-ecPublicKey`
                             object identifier defined in [[RFC5480]],
                             then [= exception/throw =] a
@@ -8076,20 +8076,20 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If the `parameters` field of the `algorithm`
-                            AlgorithmIdentifier field of <var>spki</var> is absent,
+                            AlgorithmIdentifier field of |spki| is absent,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the `parameters` field of the
-                            `algorithm` AlgorithmIdentifier field of <var>spki</var>.
+                            Let |params| be the `parameters` field of the
+                            `algorithm` AlgorithmIdentifier field of |spki|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If <var>params</var> is not an instance of the
+                            If |params| is not an instance of the
                             `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
                             `namedCurve`, then [= exception/throw =] a {{DataError}}.
@@ -8097,51 +8097,51 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>namedCurve</var> be a string whose initial value is
+                            Let |namedCurve| be a string whose initial value is
                             undefined.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the `secp256r1`
+                              If |params| is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-256`".
+                                Set |namedCurve| "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp384r1`
+                              If |params| is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-384`".
+                                Set |namedCurve| "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp521r1`
+                              If |params| is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-521`".
+                                Set |namedCurve| "`P-521`".
                               </p>
                             </dd>
                           </dl>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>namedCurve</var> is not undefined:</dt>
+                            <dt>If |namedCurve| is not undefined:</dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>publicKey</var> be the Elliptic Curve public key identified by
+                                    Let |publicKey| be the Elliptic Curve public key identified by
                                     performing the conversion steps defined in Section 2.3.4 of [[SEC1]] using the `subjectPublicKey`
-                                    field of <var>spki</var>.
+                                    field of |spki|.
                                   </p>
                                   <p>
                                     The uncompressed point format MUST be supported.
@@ -8164,10 +8164,10 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                                    Let |key| be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
                                     of `this` [[HTML]], and
-                                    that represents <var>publicKey</var>.
+                                    that represents |publicKey|.
                                   </p>
                                 </li>
                               </ol>
@@ -8179,8 +8179,8 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Perform any [= ECDSA key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>spki</var>
-                                    and obtaining <var>namedCurve</var> and <var>key</var>.
+                                    specifications</a>, passing |format|, |spki|
+                                    and obtaining |namedCurve| and |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -8198,54 +8198,54 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>namedCurve</var> is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             If the public key value is not a valid point on the Elliptic Curve
                             identified by the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var> [= exception/throw =] a {{DataError}}.
+                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to "`public`"
+                            of |key| to "`public`"
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new {{EcKeyAlgorithm}}.
+                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDSA`".
+                            |algorithm| to "`ECDSA`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to <var>namedCurve</var>.
+                            attribute of |algorithm| to |namedCurve|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains a value which is not
+                            If |usages| contains a value which is not
                             "`sign`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -8253,9 +8253,9 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>privateKeyInfo</var> be the result of running the
+                            Let |privateKeyInfo| be the result of running the
                             [= parse a privateKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -8269,7 +8269,7 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             If the `algorithm` object identifier field of the
                             `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            <var>privateKeyInfo</var> is not equal to the
+                            |privateKeyInfo| is not equal to the
                             `id-ecPublicKey` object identifier defined in [[RFC5480]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8279,21 +8279,21 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             If the `parameters` field of the
                             `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of <var>privateKeyInfo</var> is not present,
+                            of |privateKeyInfo| is not present,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the `parameters` field of the
+                            Let |params| be the `parameters` field of the
                             `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of <var>privateKeyInfo</var>.
+                            of |privateKeyInfo|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If <var>params</var> is not an instance of the
+                            If |params| is not an instance of the
                             `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
                             `namedCurve`, then [= exception/throw =] a {{DataError}}.
@@ -8301,52 +8301,52 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>namedCurve</var> be a string whose initial value is
+                            Let |namedCurve| be a string whose initial value is
                             undefined.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the `secp256r1`
+                              If |params| is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-256`".
+                                Set |namedCurve| "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp384r1`
+                              If |params| is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-384`".
+                                Set |namedCurve| "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp521r1`
+                              If |params| is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-521`".
+                                Set |namedCurve| "`P-521`".
                               </p>
                             </dd>
                           </dl>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>namedCurve</var> is not undefined:</dt>
+                            <dt>If |namedCurve| is not undefined:</dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>ecPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                                    algorithm, with <var>data</var> as the `privateKey` field
-                                    of <var>privateKeyInfo</var>, <var>structure</var> as the ASN.1
-                                    `ECPrivateKey` structure specified in Section 3 of [[RFC5915]], and <var>exactData</var> set to true.
+                                    Let |ecPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                                    algorithm, with |data| as the `privateKey` field
+                                    of |privateKeyInfo|, |structure| as the ASN.1
+                                    `ECPrivateKey` structure specified in Section 3 of [[RFC5915]], and |exactData| set to true.
                                   </p>
                                 </li>
                                 <li>
@@ -8358,23 +8358,23 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If the `parameters` field of <var>ecPrivateKey</var> is
+                                    If the `parameters` field of |ecPrivateKey| is
                                     present, and is not an instance of the `namedCurve` ASN.1
                                     type defined in [[RFC5480]], or does not contain
                                     the same object identifier as the `parameters` field of the
                                     `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                                    of <var>privateKeyInfo</var>,
+                                    of |privateKeyInfo|,
                                     then [= exception/throw =] a
                                     {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                                    Let |key| be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
                                     of `this` [[HTML]], and
                                     that represents the Elliptic Curve private key identified by
-                                    performing the conversion steps defined in Section 3 of [[RFC5915]] using <var>ecPrivateKey</var>.
+                                    performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
                                   </p>
                                 </li>
                               </ol>
@@ -8386,8 +8386,8 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Perform any [= ECDSA key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>privateKeyInfo</var>
-                                    and obtaining <var>namedCurve</var> and <var>key</var>.
+                                    specifications</a>, passing |format|, |privateKeyInfo|
+                                    and obtaining |namedCurve| and |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -8405,65 +8405,65 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>namedCurve</var> is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             If the private key value is not a valid point on the Elliptic Curve
                             identified by the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var> [= exception/throw =] a {{DataError}}.
+                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to {{KeyType/"private"}}
+                            of |key| to {{KeyType/"private"}}
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new {{EcKeyAlgorithm}}.
+                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDSA`".
+                            |algorithm| to "`ECDSA`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to <var>namedCurve</var>.
+                            attribute of |algorithm| to |namedCurve|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/d}} field is present and <var>usages</var> contains
+                            If the {{JsonWebKey/d}} field is present and |usages| contains
                             a value which is not
                             "`sign`", or,
-                            if the {{JsonWebKey/d}} field is not present and <var>usages</var> contains
+                            if the {{JsonWebKey/d}} field is not present and |usages| contains
                             a value which is not
                             "`verify`"
                             then [= exception/throw =] a
@@ -8472,7 +8472,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
                             "`EC`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8480,7 +8480,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not  "`sig`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8488,9 +8488,9 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of JSON Web
-                            Key [[JWK]], or it does not contain all of the specified <var>usages</var>
+                            Key [[JWK]], or it does not contain all of the specified |usages|
                             values,
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8498,35 +8498,35 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>namedCurve</var> be a string whose value is equal to the
-                            {{JsonWebKey/crv}} field of <var>jwk</var>.
+                            Let |namedCurve| be a string whose value is equal to the
+                            {{JsonWebKey/crv}} field of |jwk|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If <var>namedCurve</var> is not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                            If |namedCurve| is not equal to the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is equal to "`P-256`",
+                              If |namedCurve| is equal to "`P-256`",
                               "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>algNamedCurve</var> be a string whose initial value is
+                                    Let |algNamedCurve| be a string whose initial value is
                                     undefined.
                                   </p>
                                 </li>
@@ -8534,25 +8534,25 @@ dictionary EcKeyImportParams : Algorithm {
                                   <dl class="switch">
                                     <dt>If the {{JsonWebKey/alg}} field is not present:</dt>
                                     <dd>
-                                      Let <var>algNamedCurve</var> be undefined.
+                                      Let |algNamedCurve| be undefined.
                                     </dd>
                                     <dt>
                                       If the {{JsonWebKey/alg}} field is equal to the string "ES256":
                                     </dt>
                                     <dd>
-                                      Let <var>algNamedCurve</var> be the string "`P-256`".
+                                      Let |algNamedCurve| be the string "`P-256`".
                                     </dd>
                                     <dt>
                                       If the {{JsonWebKey/alg}} field is equal to the string "ES384":
                                     </dt>
                                     <dd>
-                                      Let <var>algNamedCurve</var> be the string "`P-384`".
+                                      Let |algNamedCurve| be the string "`P-384`".
                                     </dd>
                                     <dt>
                                       If the {{JsonWebKey/alg}} field is equal to the string "ES512":
                                     </dt>
                                     <dd>
-                                      Let <var>algNamedCurve</var> be the string "`P-521`".
+                                      Let |algNamedCurve| be the string "`P-521`".
                                     </dd>
                                     <dt>otherwise:</dt>
                                     <dd>
@@ -8563,8 +8563,8 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If <var>algNamedCurve</var> is defined, and is not equal to
-                                    <var>namedCurve</var>, [= exception/throw =] a {{DataError}}.
+                                    If |algNamedCurve| is defined, and is not equal to
+                                    |namedCurve|, [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
@@ -8574,21 +8574,21 @@ dictionary EcKeyImportParams : Algorithm {
                                       <ol>
                                         <li>
                                           <p>
-                                            If <var>jwk</var> does not meet the requirements of Section
+                                            If |jwk| does not meet the requirements of Section
                                             6.2.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            Let <var>key</var> be a new {{CryptoKey}} object that represents the
+                                            Let |key| be a new {{CryptoKey}} object that represents the
                                             Elliptic Curve private key identified by interpreting
-                                            <var>jwk</var> according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
+                                            |jwk| according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
                                           </p>
                                         </li>
                                         <li>
                                           <p>
                                             Set the {{CryptoKey/[[type]]}}
-                                            internal slot of <var>Key</var> to {{KeyType/"private"}}.
+                                            internal slot of |Key| to {{KeyType/"private"}}.
                                           </p>
                                         </li>
                                       </ol>
@@ -8598,21 +8598,21 @@ dictionary EcKeyImportParams : Algorithm {
                                       <ol>
                                         <li>
                                           <p>
-                                            If <var>jwk</var> does not meet the requirements of Section
+                                            If |jwk| does not meet the requirements of Section
                                             6.2.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            Let <var>key</var> be a new {{CryptoKey}} object that represents the
+                                            Let |key| be a new {{CryptoKey}} object that represents the
                                             Elliptic Curve public key identified by interpreting
-                                            <var>jwk</var> according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
+                                            |jwk| according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
                                           </p>
                                         </li>
                                         <li>
                                           <p>
                                             Set the {{CryptoKey/[[type]]}}
-                                            internal slot of <var>Key</var> to "`public`".
+                                            internal slot of |Key| to "`public`".
                                           </p>
                                         </li>
                                       </ol>
@@ -8630,8 +8630,8 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Perform any [= ECDSA key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>jwk</var>
-                                    and obtaining <var>key</var>.
+                                    specifications</a>, passing |format|, |jwk|
+                                    and obtaining |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -8651,41 +8651,41 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             If the key value is not a valid point on the Elliptic Curve
                             identified by the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var> [= exception/throw =] a {{DataError}}.
+                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new instance of an {{EcKeyAlgorithm}} object.
+                            Let |algorithm| be a new instance of an {{EcKeyAlgorithm}} object.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDSA`".
+                            |algorithm| to "`ECDSA`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to <var>namedCurve</var>.
+                            attribute of |algorithm| to |namedCurve|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{EcKeyImportParams/namedCurve}}
-                            member of <var>normalizedAlgorithm</var> is not a
+                            member of |normalizedAlgorithm| is not a
                             <a href="#dfn-NamedCurve">named curve</a>,
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8693,7 +8693,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> contains a value which is not
+                            If |usages| contains a value which is not
                             "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -8702,17 +8702,17 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is "`P-256`",
+                              If |namedCurve| is "`P-256`",
                               "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>Q</var> be the elliptic curve point on the curve identified
+                                    Let |Q| be the elliptic curve point on the curve identified
                                     by the {{EcKeyImportParams/namedCurve}}
-                                    member of <var>normalizedAlgorithm</var> identified by performing
-                                    the conversion steps defined in Section 2.3.4 of [[SEC1]] on <var>keyData</var>.
+                                    member of |normalizedAlgorithm| identified by performing
+                                    the conversion steps defined in Section 2.3.4 of [[SEC1]] on |keyData|.
                                   </p>
                                   <p>
                                     The uncompressed point format MUST be supported.
@@ -8735,10 +8735,10 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                                    Let |key| be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
                                     of `this` [[HTML]], and
-                                    that represents <var>Q</var>
+                                    that represents |Q|
                                   </p>
                                 </li>
                               </ol>
@@ -8750,8 +8750,8 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Perform any [= ECDH key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>keyData</var>
-                                    and obtaining <var>key</var>.
+                                    specifications</a>, passing |format|, |keyData|
+                                    and obtaining |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -8769,32 +8769,32 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new {{EcKeyAlgorithm}} object.
+                            Let |algorithm| be a new {{EcKeyAlgorithm}} object.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDSA`".
+                            |algorithm| to "`ECDSA`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to equal the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>.
+                            attribute of |algorithm| to equal the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to "`public`"
+                            of |key| to "`public`"
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
@@ -8810,7 +8810,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>
+                    Return |key|
                   </p>
                 </li>
               </ol>
@@ -8821,51 +8821,51 @@ dictionary EcKeyImportParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>key</var> be the {{CryptoKey}} to be
+                    Let |key| be the {{CryptoKey}} to be
                     exported.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>algorithm</var> field to an
+                                Set the |algorithm| field to an
                                 `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>parameters</var> field to an instance of the
+                                    Set the |parameters| field to an instance of the
                                     `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
@@ -8873,27 +8873,27 @@ dictionary EcKeyImportParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is "`P-256`",
+                                      internal slot of |key| is "`P-256`",
                                       "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
-                                        Let <var>keyData</var> be the
+                                        Let |keyData| be the
                                         [= octet string =] that
                                         represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        <var>key</var> according to the encoding rules specified in
+                                        |key| according to the encoding rules specified in
                                         Section 2.2 of [[RFC5480]] and using the
-                                        uncompressed form. and <var>keyData</var>.
+                                        uncompressed form. and |keyData|.
                                       </p>
                                       <dl class="switch">
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-256`":
+                                          internal slot of |key| is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
+                                            Set |parameters| to the `namedCurve` choice
                                             with value equal to the object identifier
                                             `secp256r1` defined in [[RFC5480]]
                                           </p>
@@ -8901,11 +8901,11 @@ dictionary EcKeyImportParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-384`":
+                                          internal slot of |key| is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
+                                            Set |parameters| to the `namedCurve` choice
                                             with value equal to the object identifier
                                             `secp384r1` defined in [[RFC5480]]
                                           </p>
@@ -8913,11 +8913,11 @@ dictionary EcKeyImportParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-521`":
+                                          internal slot of |key| is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
+                                            Set |parameters| to the `namedCurve` choice
                                             with value equal to the object identifier
                                             `secp521r1` defined in [[RFC5480]]
                                           </p>
@@ -8933,17 +8933,17 @@ dictionary EcKeyImportParams : Algorithm {
                                           <p>
                                             Perform any [= ECDSA key export steps | key export steps =]
                                             defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var> and the
+                                            specifications</a>, passing |format| and the
                                             {{EcKeyAlgorithm/namedCurve}} attribute of
                                             the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of <var>key</var>
-                                            and obtaining <var>namedCurveOid</var> and <var>keyData</var>.
+                                            internal slot of |key|
+                                            and obtaining |namedCurveOid| and |keyData|.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
-                                            with value equal to the object identifier <var>namedCurveOid</var>.
+                                            Set |parameters| to the `namedCurve` choice
+                                            with value equal to the object identifier |namedCurveOid|.
                                           </p>
                                         </li>
                                       </ol>
@@ -8954,59 +8954,59 @@ dictionary EcKeyImportParams : Algorithm {
                             </li>
                             <li>
                               <p>
-                                Set the <var>subjectPublicKey</var> field to <var>keyData</var>.
+                                Set the |subjectPublicKey| field to |keyData|.
                               </p>
                             </li>
                           </ul>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the `privateKeyInfo`
+                            Let |data| be an instance of the `privateKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>version</var> field to `0`.
+                                Set the |version| field to `0`.
                               </p>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKeyAlgorithm</var> field to an
+                                Set the |privateKeyAlgorithm| field to an
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>parameters</var> field to an instance of the
+                                    Set the |parameters| field to an instance of the
                                     `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
@@ -9014,32 +9014,32 @@ dictionary EcKeyImportParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is "`P-256`",
+                                      internal slot of |key| is "`P-256`",
                                       "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
-                                        Let <var>keyData</var> be the result of DER-encoding
+                                        Let |keyData| be the result of DER-encoding
                                         an instance of the `ECPrivateKey` structure defined in
                                         Section 3 of [[RFC5915]] for the Elliptic
                                         Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        <var>key</var> and that conforms to the following:
+                                        |key| and that conforms to the following:
                                       </p>
                                       <ul>
                                         <li>
                                           <p>
-                                            The <var>parameters</var> field is present, and is equivalent
-                                            to the <var>parameters</var> field of the
-                                            <var>privateKeyAlgorithm</var> field of this
+                                            The |parameters| field is present, and is equivalent
+                                            to the |parameters| field of the
+                                            |privateKeyAlgorithm| field of this
                                             `PrivateKeyInfo` ASN.1 structure.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            The <var>publicKey</var> field is present and represents the
+                                            The |publicKey| field is present and represents the
                                             Elliptic Curve public key associated with the Elliptic Curve
                                             private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                            of <var>key</var>.
+                                            of |key|.
                                           </p>
                                         </li>
                                       </ul>
@@ -9047,11 +9047,11 @@ dictionary EcKeyImportParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-256`":
+                                          internal slot of |key| is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
+                                            Set |parameters| to the `namedCurve` choice
                                             with value equal to the object identifier
                                             `secp256r1` defined in [[RFC5480]]
                                           </p>
@@ -9059,11 +9059,11 @@ dictionary EcKeyImportParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-384`":
+                                          internal slot of |key| is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
+                                            Set |parameters| to the `namedCurve` choice
                                             with value equal to the object identifier
                                             `secp384r1` defined in [[RFC5480]]
                                           </p>
@@ -9071,11 +9071,11 @@ dictionary EcKeyImportParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-521`":
+                                          internal slot of |key| is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
+                                            Set |parameters| to the `namedCurve` choice
                                             with value equal to the object identifier
                                             `secp521r1` defined in [[RFC5480]]
                                           </p>
@@ -9091,17 +9091,17 @@ dictionary EcKeyImportParams : Algorithm {
                                           <p>
                                             Perform any [= ECDSA key export steps | key export steps =]
                                             defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var> and the
+                                            specifications</a>, passing |format| and the
                                             {{EcKeyAlgorithm/namedCurve}} attribute of
                                             the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of <var>key</var>
-                                            and obtaining <var>namedCurveOid</var> and <var>keyData</var>.
+                                            internal slot of |key|
+                                            and obtaining |namedCurveOid| and |keyData|.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
-                                            with value equal to the object identifier <var>namedCurveOid</var>.
+                                            Set |parameters| to the `namedCurve` choice
+                                            with value equal to the object identifier |namedCurveOid|.
                                           </p>
                                         </li>
                                       </ol>
@@ -9112,33 +9112,33 @@ dictionary EcKeyImportParams : Algorithm {
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKey</var> field to <var>keyData</var>.
+                                Set the |privateKey| field to |keyData|.
                               </p>
                             </li>
                           </ul>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>jwk</var> be a new {{JsonWebKey}}
+                            Let |jwk| be a new {{JsonWebKey}}
                             dictionary.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to
+                            Set the `kty` attribute of |jwk| to
                             "`EC`".
                           </p>
                         </li>
@@ -9147,7 +9147,7 @@ dictionary EcKeyImportParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is "`P-256`", "`P-384`" or
+                              of |key| is "`P-256`", "`P-384`" or
                               "`P-521`":
                             </dt>
                             <dd>
@@ -9157,41 +9157,41 @@ dictionary EcKeyImportParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is "`P-256`":
+                                      of |key| is "`P-256`":
                                     </dt>
                                     <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
+                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
                                       "`P-256`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is "`P-384`":
+                                      of |key| is "`P-384`":
                                     </dt>
                                     <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
+                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
                                       "`P-384`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is "`P-521`":
+                                      of |key| is "`P-521`":
                                     </dt>
                                     <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
+                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
                                       "`P-521`"
                                     </dd>
                                   </dl>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the {{JsonWebKey/x}} attribute of <var>jwk</var> according to the
+                                    Set the {{JsonWebKey/x}} attribute of |jwk| according to the
                                     definition in Section 6.2.1.2 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the {{JsonWebKey/y}} attribute of <var>jwk</var> according to the
+                                    Set the {{JsonWebKey/y}} attribute of |jwk| according to the
                                     definition in Section 6.2.1.3 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
@@ -9199,11 +9199,11 @@ dictionary EcKeyImportParams : Algorithm {
                                   <dl class="switch">
                                     <dt>
                                       If the {{CryptoKey/[[type]]}} internal slot
-                                      of <var>key</var> is {{KeyType/"private"}}
+                                      of |key| is {{KeyType/"private"}}
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set the {{JsonWebKey/d}} attribute of <var>jwk</var> according to
+                                        Set the {{JsonWebKey/d}} attribute of |jwk| according to
                                         the definition in Section 6.2.2.1 of JSON Web Algorithms [[JWA]].
                                       </p>
                                     </dd>
@@ -9220,17 +9220,17 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Perform any [= ECDSA key export steps | key export steps =]
                                     defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var> and the
+                                    specifications</a>, passing |format| and the
                                     {{EcKeyAlgorithm/namedCurve}} attribute of
                                     the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of <var>key</var>
-                                    and obtaining <var>namedCurve</var> and a new value of <var>jwk</var>.
+                                    internal slot of |key|
+                                    and obtaining |namedCurve| and a new value of |jwk|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                    <var>namedCurve</var>.
+                                    Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                    |namedCurve|.
                                   </p>
                                 </li>
                               </ol>
@@ -9239,32 +9239,32 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
                       </ol>
                     </dd>
                     <dt>
-                      If <var>format</var> is {{KeyFormat/"raw"}}:
+                      If |format| is {{KeyFormat/"raw"}}:
                     </dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
@@ -9272,14 +9272,14 @@ dictionary EcKeyImportParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is "`P-256`", "`P-384`"
+                              of |key| is "`P-256`", "`P-384`"
                               or "`P-521`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>data</var> be an [= octet string =] representing the Elliptic Curve
-                                point <var>Q</var> represented by {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var> according to [[SEC1]] 2.3.3 using the uncompressed format.
+                                Let |data| be an [= octet string =] representing the Elliptic Curve
+                                point |Q| represented by {{CryptoKey/[[handle]]}} internal slot of
+                                |key| according to [[SEC1]] 2.3.3 using the uncompressed format.
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -9287,21 +9287,21 @@ dictionary EcKeyImportParams : Algorithm {
                               <p>
                                 Perform any [= ECDH key export steps | key export steps =]
                                 defined by <a href="#dfn-applicable-specification">other applicable
-                                specifications</a>, passing <var>format</var> and the
+                                specifications</a>, passing |format| and the
                                 {{EcKeyAlgorithm/namedCurve}} attribute of
                                 the {{CryptoKey/[[algorithm]]}}
-                                internal slot of <var>key</var>
-                                and obtaining <var>namedCurve</var> and <var>data</var>.
+                                internal slot of |key|
+                                and obtaining |namedCurve| and |data|.
                               </p>
                             </dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
@@ -9317,7 +9317,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -9400,7 +9400,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                     "`deriveKey`" or "`deriveBits`"
                     then [= exception/throw =] a
                     {{SyntaxError}}.
@@ -9410,19 +9410,19 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{EcKeyGenParams/namedCurve}} member of
-                      <var>normalizedAlgorithm</var> is "`P-256`", "`P-384`"
+                      |normalizedAlgorithm| is "`P-256`", "`P-384`"
                       or "`P-521`":
                     </dt>
                     <dd>
                       <p>
                         Generate an Elliptic Curve key pair, as defined in [[RFC6090]] with domain parameters for the curve identified by
                         the {{EcKeyGenParams/namedCurve}} member of
-                        <var>normalizedAlgorithm</var>.
+                        |normalizedAlgorithm|.
                       </p>
                     </dd>
                     <dt>
                       If the {{EcKeyGenParams/namedCurve}} member of
-                      <var>normalizedAlgorithm</var> is a value specified in an
+                      |normalizedAlgorithm| is a value specified in an
                       <a href="#dfn-applicable-specification">applicable specification</a> that
                       specifies the use of that value with ECDH:
                     </dt>
@@ -9430,7 +9430,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <p>
                         Perform the [= ECDH
                         generation steps =] specified in that specification, passing in
-                        <var>normalizedAlgorithm</var> and resulting in an elliptic curve key pair.
+                        |normalizedAlgorithm| and resulting in an elliptic curve key pair.
                       </p>
                     </dd>
                     <dt>Otherwise:</dt>
@@ -9451,7 +9451,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{EcKeyAlgorithm}}
                     object.
                   </p>
@@ -9459,20 +9459,20 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <li>
                   <p>
                     Set the {{Algorithm/name}} member of
-                    <var>algorithm</var> to "`ECDH`".
+                    |algorithm| to "`ECDH`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{EcKeyAlgorithm/namedCurve}}
-                    attribute of <var>algorithm</var> to equal the
+                    attribute of |algorithm| to equal the
                     {{namedCurve}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
+                    Let |publicKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the public key of the generated key pair.
@@ -9481,30 +9481,30 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to "`public`"
+                    |publicKey| to "`public`"
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>publicKey</var> to <var>algorithm</var>.
+                    slot of |publicKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>publicKey</var> to true.
+                    slot of |publicKey| to true.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>publicKey</var> to be the empty list.
+                    |publicKey| to be the empty list.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
+                    Let |privateKey| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
                     representing the private key of the generated key pair.
@@ -9513,50 +9513,50 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>privateKey</var> to {{KeyType/"private"}}
+                    |privateKey| to {{KeyType/"private"}}
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>privateKey</var> to <var>algorithm</var>.
+                    slot of |privateKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>privateKey</var> to <var>extractable</var>.
+                    slot of |privateKey| to |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>privateKey</var> to be the
+                    |privateKey| to be the
                     [= usage intersection =] of
-                    <var>usages</var> and `[ "deriveKey", "deriveBits" ]`.
+                    |usages| and `[ "deriveKey", "deriveBits" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a new {{CryptoKeyPair}}
+                    Let |result| be a new {{CryptoKeyPair}}
                     dictionary.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/publicKey}} attribute
-                    of <var>result</var> to be <var>publicKey</var>.
+                    of |result| to be |publicKey|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKeyPair/privateKey}} attribute
-                    of <var>result</var> to be <var>privateKey</var>.
+                    of |result| to be |privateKey|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return the result of converting <var>result</var> to an ECMAScript Object, as
+                    Return the result of converting |result| to an ECMAScript Object, as
                     defined by [[WebIDL]].
                   </p>
                 </li>
@@ -9568,43 +9568,43 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>publicKey</var> be the
+                    Let |publicKey| be the
                     {{EcdhKeyDeriveParams/public}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                    |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     If the {{KeyAlgorithm/name}} attribute of
                     the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>publicKey</var> is not equal to the {{KeyAlgorithm/name}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var>, then [= exception/throw =] an {{InvalidAccessError}}.
+                    |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key|, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     If the {{EcKeyAlgorithm/namedCurve}} attribute of
                     the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>publicKey</var> is not equal to the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var>, then [= exception/throw =] an {{InvalidAccessError}}.
+                    |publicKey| is not equal to the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key|, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
                     <dt>
                       If the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> is "`P-256`", "`P-384`"
+                    |key| is "`P-256`", "`P-384`"
                       or "`P-521`":
                     </dt>
                     <dd>
@@ -9612,14 +9612,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Perform the ECDH primitive specified in [[RFC6090]] Section
-                            4 with <var>key</var> as the EC private key <var>d</var> and the EC public
+                            4 with |key| as the EC private key |d| and the EC public
                             key represented by the {{CryptoKey/[[handle]]}}
-                            internal slot of <var>publicKey</var> as the EC public key.
+                            internal slot of |publicKey| as the EC public key.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>secret</var> be the result of applying the field element to
+                            Let |secret| be the result of applying the field element to
                             [= octet string =] conversion defined in Section
                             6.2 of [[RFC6090]]
                             to the output of the ECDH primitive.
@@ -9629,7 +9629,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                     </dd>
                     <dt>
                       If the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> is a value specified in an
+                    |key| is a value specified in an
                       <a href="#dfn-applicable-specification">applicable specification</a> that
                       specifies the use of that value with ECDH:
                     </dt>
@@ -9637,7 +9637,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <p>
                         Perform the [= ECDH
                         derivation steps =] specified in that specification, passing in
-                        <var>key</var> and <var>publicKey</var> and resulting in <var>secret</var>.
+                        |key| and |publicKey| and resulting in |secret|.
                       </p>
                     </dd>
                     <dt>Otherwise:</dt>
@@ -9659,14 +9659,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>length</var> is null:</dt>
-                    <dd>Return <var>secret</var></dd>
+                    <dt>If |length| is null:</dt>
+                    <dd>Return |secret|</dd>
                     <dt>Otherwise:</dt>
                     <dd>
                       <dl class="switch">
                         <dt>
-                          If the length of <var>secret</var> in bits is less than
-                          <var>length</var>:
+                          If the length of |secret| in bits is less than
+                          |length|:
                         </dt>
                         <dd>
                           [= exception/throw =] an
@@ -9674,7 +9674,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </dd>
                         <dt>Otherwise:</dt>
                         <dd>
-                          Return an [= octet string containing =] the first <var>length</var> bits of <var>secret</var>.
+                          Return an [= octet string containing =] the first |length| bits of |secret|.
                         </dd>
                       </dl>
                     </dd>
@@ -9687,25 +9687,25 @@ dictionary EcdhKeyDeriveParams : Algorithm {
             <dd>
               <ol>
                 <li>
-                  <p>Let <var>keyData</var> be the key data to be imported.</p>
+                  <p>Let |keyData| be the key data to be imported.</p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> is not empty
+                            If |usages| is not empty
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>spki</var> be the result of running the
+                            Let |spki| be the result of running the
                             [= parse a subjectPublicKeyInfo =]
-                            algorithm over <var>keyData</var>
+                            algorithm over |keyData|
                           </p>
                         </li>
                         <li>
@@ -9718,7 +9718,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of <var>spki</var> is
+                            `algorithm` AlgorithmIdentifier field of |spki| is
                             not equal to the `id-ecPublicKey` or `id-ecDH`
                             object identifiers defined in [[RFC5480]],
                             then [= exception/throw =] a
@@ -9728,20 +9728,20 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             If the `parameters` field of the `algorithm`
-                            AlgorithmIdentifier field of <var>spki</var> is absent,
+                            AlgorithmIdentifier field of |spki| is absent,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the `parameters` field of the
-                            `algorithm` AlgorithmIdentifier field of <var>spki</var>.
+                            Let |params| be the `parameters` field of the
+                            `algorithm` AlgorithmIdentifier field of |spki|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If <var>params</var> is not an instance of the
+                            If |params| is not an instance of the
                             `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
                             `namedCurve`, then [= exception/throw =] a {{DataError}}.
@@ -9749,51 +9749,51 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>namedCurve</var> be a string whose initial value is
+                            Let |namedCurve| be a string whose initial value is
                             undefined.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the `secp256r1`
+                              If |params| is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-256`".
+                                Set |namedCurve| "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp384r1`
+                              If |params| is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-384`".
+                                Set |namedCurve| "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp521r1`
+                              If |params| is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> "`P-521`".
+                                Set |namedCurve| "`P-521`".
                               </p>
                             </dd>
                           </dl>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>namedCurve</var> is not undefined:</dt>
+                            <dt>If |namedCurve| is not undefined:</dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>publicKey</var> be the Elliptic Curve public key identified by
+                                    Let |publicKey| be the Elliptic Curve public key identified by
                                     performing the conversion steps defined in Section 2.3.4 of [[SEC1]] to the `subjectPublicKey` field of
-                                    <var>spki</var>.
+                                    |spki|.
                                   </p>
                                   <p>
                                     The uncompressed point format MUST be supported.
@@ -9816,10 +9816,10 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                                    Let |key| be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
                                     of `this` [[HTML]], and
-                                    that represents <var>publicKey</var>.
+                                    that represents |publicKey|.
                                   </p>
                                 </li>
                               </ol>
@@ -9831,8 +9831,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Perform any [= ECDH key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>spki</var>
-                                    and obtaining <var>namedCurve</var> and <var>key</var>.
+                                    specifications</a>, passing |format|, |spki|
+                                    and obtaining |namedCurve| and |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -9850,54 +9850,54 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>namedCurve</var> is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             If the key value is not a valid point on the Elliptic Curve
                             identified by the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var> [= exception/throw =] a {{DataError}}.
+                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to "`public`"
+                            of |key| to "`public`"
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new {{EcKeyAlgorithm}}.
+                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDH`".
+                            |algorithm| to "`ECDH`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to <var>namedCurve</var>.
+                            attribute of |algorithm| to |namedCurve|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains an entry which is not
+                            If |usages| contains an entry which is not
                             "`deriveKey`" or "`deriveBits`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -9905,9 +9905,9 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>privateKeyInfo</var> be the result of running the
+                            Let |privateKeyInfo| be the result of running the
                             [= parse a privateKeyInfo =]
-                            algorithm over <var>keyData</var>.
+                            algorithm over |keyData|.
                           </p>
                         </li>
                         <li>
@@ -9921,7 +9921,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                           <p>
                             If the `algorithm` object identifier field of the
                             `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            <var>privateKeyInfo</var> is not equal to the
+                            |privateKeyInfo| is not equal to the
                             `id-ecPublicKey` or `id-ecDH` object identifiers
                             defined in [[RFC5480]],
                             [= exception/throw =] a
@@ -9932,21 +9932,21 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                           <p>
                             If the `parameters` field of the
                             `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of <var>privateKeyInfo</var> is not present,
+                            of |privateKeyInfo| is not present,
                             [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the `parameters` field of the
+                            Let |params| be the `parameters` field of the
                             `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of <var>privateKeyInfo</var>.
+                            of |privateKeyInfo|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If <var>params</var> is not an instance of the
+                            If |params| is not an instance of the
                             `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
                             `namedCurve`, then [= exception/throw =] a {{DataError}}.
@@ -9954,54 +9954,54 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>namedCurve</var> be a string whose initial value is
+                            Let |namedCurve| be a string whose initial value is
                             undefined.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the `secp256r1`
+                              If |params| is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> to "`P-256`".
+                                Set |namedCurve| to "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp384r1`
+                              If |params| is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> to "`P-384`".
+                                Set |namedCurve| to "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the `secp521r1`
+                              If |params| is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> to "`P-521`".
+                                Set |namedCurve| to "`P-521`".
                               </p>
                             </dd>
                           </dl>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>namedCurve</var> is not undefined:</dt>
+                            <dt>If |namedCurve| is not undefined:</dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>ecPrivateKey</var> be the result of performing the
+                                    Let |ecPrivateKey| be the result of performing the
                                     [= parse an ASN.1 structure =]
-                                    algorithm, with <var>data</var> as the `privateKey` field
-                                    of <var>privateKeyInfo</var>, <var>structure</var> as the ASN.1
+                                    algorithm, with |data| as the `privateKey` field
+                                    of |privateKeyInfo|, |structure| as the ASN.1
                                     `ECPrivateKey` structure specified in Section 3 of
-                                    [[RFC5915]], and <var>exactData</var> set to true.
+                                    [[RFC5915]], and |exactData| set to true.
                                   </p>
                                 </li>
                                 <li>
@@ -10013,23 +10013,23 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If the `parameters` field of <var>ecPrivateKey</var> is
+                                    If the `parameters` field of |ecPrivateKey| is
                                     present, and is not an instance of the `namedCurve` ASN.1
                                     type defined in [[RFC5480]], or does not contain
                                     the same object identifier as the `parameters` field of the
                                     `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                                    of <var>privateKeyInfo</var>,
+                                    of |privateKeyInfo|,
                                     [= exception/throw =] a
                                     {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                                    Let |key| be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
                                     of `this` [[HTML]], and
                                     that represents the Elliptic Curve private key identified by
-                                    performing the conversion steps defined in Section 3 of [[RFC5915]] using <var>ecPrivateKey</var>.
+                                    performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
                                   </p>
                                 </li>
                               </ol>
@@ -10041,8 +10041,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Perform any [= ECDH key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>privateKeyInfo</var>
-                                    and obtaining <var>namedCurve</var> and <var>key</var>.
+                                    specifications</a>, passing |format|, |privateKeyInfo|
+                                    and obtaining |namedCurve| and |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -10060,62 +10060,62 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>namedCurve</var> is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             If the key value is not a valid point on the Elliptic Curve
                             identified by the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var> [= exception/throw =] a {{DataError}}.
+                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to {{KeyType/"private"}}.
+                            of |key| to {{KeyType/"private"}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new {{EcKeyAlgorithm}}.
+                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDH`".
+                            |algorithm| to "`ECDH`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to <var>namedCurve</var>.
+                            attribute of |algorithm| to |namedCurve|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/d}} field is present and if <var>usages</var>
+                            If the {{JsonWebKey/d}} field is present and if |usages|
                             contains an entry which is not
                             "`deriveKey`" or "`deriveBits`"
                             then [= exception/throw =] a
@@ -10124,7 +10124,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/d}} field is not present and if <var>usages</var> is not
+                            If the {{JsonWebKey/d}} field is not present and if |usages| is not
                             empty
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -10132,7 +10132,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is
+                            If the {{JsonWebKey/kty}} field of |jwk| is
                             not "`EC`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -10140,43 +10140,43 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
                             and is not equal to "`enc`" then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of JSON Web
-                            Key [[JWK]], or it does not contain all of the specified <var>usages</var>
+                            Key [[JWK]], or it does not contain all of the specified |usages|
                             values, then [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>namedCurve</var> be a string whose value is equal to the
-                            {{JsonWebKey/crv}} field of <var>jwk</var>.
+                            Let |namedCurve| be a string whose value is equal to the
+                            {{JsonWebKey/crv}} field of |jwk|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If <var>namedCurve</var> is not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>, [= exception/throw =] a {{DataError}}.
+                            If |namedCurve| is not equal to the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is "`P-256`",
+                              If |namedCurve| is "`P-256`",
                               "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
@@ -10186,21 +10186,21 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <ol>
                                     <li>
                                       <p>
-                                        If <var>jwk</var> does not meet the requirements of Section
+                                        If |jwk| does not meet the requirements of Section
                                         6.2.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                       </p>
                                     </li>
                                     <li>
                                       <p>
-                                        Let <var>key</var> be a new {{CryptoKey}} object that represents the
+                                        Let |key| be a new {{CryptoKey}} object that represents the
                                         Elliptic Curve private key identified by interpreting
-                                        <var>jwk</var> according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
+                                        |jwk| according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
                                       </p>
                                     </li>
                                     <li>
                                       <p>
                                         Set the {{CryptoKey/[[type]]}}
-                                        internal slot of <var>Key</var> to {{KeyType/"private"}}.
+                                        internal slot of |Key| to {{KeyType/"private"}}.
                                       </p>
                                     </li>
                                   </ol>
@@ -10210,21 +10210,21 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <ol>
                                     <li>
                                       <p>
-                                        If <var>jwk</var> does not meet the requirements of Section
+                                        If |jwk| does not meet the requirements of Section
                                         6.2.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
                                       </p>
                                     </li>
                                     <li>
                                       <p>
-                                        Let <var>key</var> be a new {{CryptoKey}} object that represents the
+                                        Let |key| be a new {{CryptoKey}} object that represents the
                                         Elliptic Curve public key identified by interpreting
-                                        <var>jwk</var> according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
+                                        |jwk| according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
                                       </p>
                                     </li>
                                     <li>
                                       <p>
                                         Set the {{CryptoKey/[[type]]}}
-                                        internal slot of <var>Key</var> to "`public`".
+                                        internal slot of |Key| to "`public`".
                                       </p>
                                     </li>
                                   </ol>
@@ -10238,8 +10238,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Perform any [= ECDH key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>jwk</var>
-                                    and obtaining <var>key</var>.
+                                    specifications</a>, passing |format|, |jwk|
+                                    and obtaining |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -10259,41 +10259,41 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                           <p>
                             If the key value is not a valid point on the Elliptic Curve
                             identified by the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var> [= exception/throw =] a {{DataError}}.
+                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new instance of an {{EcKeyAlgorithm}} object.
+                            Let |algorithm| be a new instance of an {{EcKeyAlgorithm}} object.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDH`".
+                            |algorithm| to "`ECDH`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to <var>namedCurve</var>.
+                            attribute of |algorithm| to |namedCurve|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{EcKeyImportParams/namedCurve}}
-                            member of <var>normalizedAlgorithm</var> is not a
+                            member of |normalizedAlgorithm| is not a
                             <a href="#dfn-NamedCurve">named curve</a>,
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -10301,7 +10301,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is not the empty list,
+                            If |usages| is not the empty list,
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -10309,17 +10309,17 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is "`P-256`",
+                              If |namedCurve| is "`P-256`",
                               "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
                               <ol>
                                 <li>
                                   <p>
-                                    Let <var>Q</var> be the Elliptic Curve public key on the curve identified
+                                    Let |Q| be the Elliptic Curve public key on the curve identified
                                     by the {{EcKeyImportParams/namedCurve}}
-                                    member of <var>normalizedAlgorithm</var> identified by performing
-                                    the conversion steps defined in Section 2.3.4 of [[SEC1]] to <var>keyData</var>.
+                                    member of |normalizedAlgorithm| identified by performing
+                                    the conversion steps defined in Section 2.3.4 of [[SEC1]] to |keyData|.
                                   </p>
                                   <p>
                                     The uncompressed point format MUST be supported.
@@ -10342,10 +10342,10 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                                    Let |key| be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
                                     of `this` [[HTML]], and
-                                    that represents <var>Q</var>.
+                                    that represents |Q|.
                                   </p>
                                 </li>
                               </ol>
@@ -10357,8 +10357,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Perform any [= ECDH key import steps | key import steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var>, <var>keyData</var>
-                                    and obtaining <var>key</var>.
+                                    specifications</a>, passing |format|, |keyData|
+                                    and obtaining |key|.
                                   </p>
                                 </li>
                                 <li>
@@ -10376,32 +10376,32 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new {{EcKeyAlgorithm}} object.
+                            Let |algorithm| be a new {{EcKeyAlgorithm}} object.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`ECDH`".
+                            |algorithm| to "`ECDH`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of <var>algorithm</var> to equal the {{EcKeyImportParams/namedCurve}} member of
-                            <var>normalizedAlgorithm</var>.
+                            attribute of |algorithm| to equal the {{EcKeyImportParams/namedCurve}} member of
+                            |normalizedAlgorithm|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to "`public`"
+                            of |key| to "`public`"
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of <var>key</var> to <var>algorithm</var>.
+                            internal slot of |key| to |algorithm|.
                           </p>
                         </li>
                       </ol>
@@ -10410,7 +10410,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>
+                    Return |key|
                   </p>
                 </li>
               </ol>
@@ -10421,51 +10421,51 @@ dictionary EcdhKeyDeriveParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>key</var> be the {{CryptoKey}} to be
+                    Let |key| be the {{CryptoKey}} to be
                     exported.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"spki"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>algorithm</var> field to an
+                                Set the |algorithm| field to an
                                 `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>parameters</var> field to an instance of the
+                                    Set the |parameters| field to an instance of the
                                     `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
@@ -10473,14 +10473,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is "`P-256`",
+                                      internal slot of |key| is "`P-256`",
                                       "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
-                                        Let <var>keyData</var> be the [= octet string =] that
+                                        Let |keyData| be the [= octet string =] that
                                         represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        <var>key</var> according to the encoding rules specified in
+                                        |key| according to the encoding rules specified in
                                         Section 2.3.3 of [[SEC1]] and using the
                                         uncompressed form.
                                       </p>
@@ -10488,11 +10488,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-256`":
+                                          internal slot of |key| is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <var>namedCurve</var> choice
+                                            Set |parameters| to the |namedCurve| choice
                                             with value equal to the object identifier
                                             `secp256r1` defined in [[RFC5480]]
                                           </p>
@@ -10500,11 +10500,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-384`":
+                                          internal slot of |key| is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <var>namedCurve</var> choice
+                                            Set |parameters| to the |namedCurve| choice
                                             with value equal to the object identifier
                                             `secp384r1` defined in [[RFC5480]]
                                           </p>
@@ -10512,11 +10512,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-521`":
+                                          internal slot of |key| is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <var>namedCurve</var> choice
+                                            Set |parameters| to the |namedCurve| choice
                                             with value equal to the object identifier
                                             `secp521r1` defined in [[RFC5480]]
                                           </p>
@@ -10532,17 +10532,17 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                           <p>
                                             Perform any [= ECDH key export steps | key export steps =]
                                             defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var> and the
+                                            specifications</a>, passing |format| and the
                                             {{EcKeyAlgorithm/namedCurve}} attribute of
                                             the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of <var>key</var>
-                                            and obtaining <var>namedCurveOid</var> and <var>keyData</var>.
+                                            internal slot of |key|
+                                            and obtaining |namedCurveOid| and |keyData|.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
-                                            with value equal to the object identifier <var>namedCurveOid</var>.
+                                            Set |parameters| to the `namedCurve` choice
+                                            with value equal to the object identifier |namedCurveOid|.
                                           </p>
                                         </li>
                                       </ol>
@@ -10553,51 +10553,51 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             </li>
                             <li>
                               <p>
-                                Set the <var>subjectPublicKey</var> field to <var>keyData</var>
+                                Set the |subjectPublicKey| field to |keyData|
                               </p>
                             </li>
                           </ul>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the `privateKeyInfo`
+                            Let |data| be an instance of the `privateKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>version</var> field to `0`.
+                                Set the |version| field to `0`.
                               </p>
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKeyAlgorithm</var> field to an
+                                Set the |privateKeyAlgorithm| field to an
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
-                                    Set the <var>algorithm</var> field to the OID
+                                    Set the |algorithm| field to the OID
                                     `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <var>parameters</var> field to an instance of the
+                                    Set the |parameters| field to an instance of the
                                     `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
@@ -10605,32 +10605,32 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is "`P-256`",
+                                      internal slot of |key| is "`P-256`",
                                       "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
-                                        Let <var>keyData</var> be the result of DER-encoding
+                                        Let |keyData| be the result of DER-encoding
                                         an instance of the `ECPrivateKey` structure defined in
                                         Section 3 of [[RFC5915]] for the Elliptic
                                         Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        <var>key</var> and that conforms to the following:
+                                        |key| and that conforms to the following:
                                       </p>
                                       <ul>
                                         <li>
                                           <p>
-                                            The <var>parameters</var> field is present, and is equivalent
-                                            to the <var>parameters</var> field of the
-                                            <var>privateKeyAlgorithm</var> field of this
+                                            The |parameters| field is present, and is equivalent
+                                            to the |parameters| field of the
+                                            |privateKeyAlgorithm| field of this
                                             `PrivateKeyInfo` ASN.1 structure.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            The <var>publicKey</var> field is present and represents the
+                                            The |publicKey| field is present and represents the
                                             Elliptic Curve public key associated with the Elliptic Curve
                                             private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                            of <var>key</var>.
+                                            of |key|.
                                           </p>
                                         </li>
                                       </ul>
@@ -10638,11 +10638,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-256`":
+                                          internal slot of |key| is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <var>namedCurve</var> choice
+                                            Set |parameters| to the |namedCurve| choice
                                             with value equal to the object identifier
                                             `secp256r1` defined in [[RFC5480]]
                                           </p>
@@ -10650,11 +10650,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-384`":
+                                          internal slot of |key| is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <var>namedCurve</var> choice
+                                            Set |parameters| to the |namedCurve| choice
                                             with value equal to the object identifier
                                             `secp384r1` defined in [[RFC5480]]
                                           </p>
@@ -10662,11 +10662,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is "`P-521`":
+                                          internal slot of |key| is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <var>namedCurve</var> choice
+                                            Set |parameters| to the |namedCurve| choice
                                             with value equal to the object identifier
                                             `secp521r1` defined in [[RFC5480]]
                                           </p>
@@ -10682,17 +10682,17 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                           <p>
                                             Perform any [= ECDH key export steps | key export steps =]
                                             defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing <var>format</var> and the
+                                            specifications</a>, passing |format| and the
                                             {{EcKeyAlgorithm/namedCurve}} attribute of
                                             the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of <var>key</var>
-                                            and obtaining <var>namedCurveOid</var> and <var>keyData</var>.
+                                            internal slot of |key|
+                                            and obtaining |namedCurveOid| and |keyData|.
                                           </p>
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the `namedCurve` choice
-                                            with value equal to the object identifier <var>namedCurveOid</var>.
+                                            Set |parameters| to the `namedCurve` choice
+                                            with value equal to the object identifier |namedCurveOid|.
                                           </p>
                                         </li>
                                       </ol>
@@ -10703,25 +10703,25 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             </li>
                             <li>
                               <p>
-                                Set the <var>privateKey</var> field to <var>keyData</var>.
+                                Set the |privateKey| field to |keyData|.
                               </p>
                             </li>
                           </ul>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>jwk</var> be a new {{JsonWebKey}}
+                            Let |jwk| be a new {{JsonWebKey}}
                             dictionary.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to
+                            Set the `kty` attribute of |jwk| to
                             "`EC`".
                           </p>
                         </li>
@@ -10730,7 +10730,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is "`P-256`", "`P-384`"
+                              of |key| is "`P-256`", "`P-384`"
                               or "`P-521`":
                             </dt>
                             <dd>
@@ -10740,41 +10740,41 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is "`P-256`":
+                                      of |key| is "`P-256`":
                                     </dt>
                                     <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
+                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
                                       "`P-256`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is "`P-384`":
+                                      of |key| is "`P-384`":
                                     </dt>
                                     <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
+                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
                                       "`P-384`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is "`P-521`":
+                                      of |key| is "`P-521`":
                                     </dt>
                                     <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
+                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
                                       "`P-521`"
                                     </dd>
                                   </dl>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the {{JsonWebKey/x}} attribute of <var>jwk</var> according to the
+                                    Set the {{JsonWebKey/x}} attribute of |jwk| according to the
                                     definition in Section 6.2.1.2 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the {{JsonWebKey/y}} attribute of <var>jwk</var> according to the
+                                    Set the {{JsonWebKey/y}} attribute of |jwk| according to the
                                     definition in Section 6.2.1.3 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
@@ -10782,11 +10782,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <dl class="switch">
                                     <dt>
                                       If the {{CryptoKey/[[type]]}} internal slot
-                                      of <var>key</var> is {{KeyType/"private"}}
+                                      of |key| is {{KeyType/"private"}}
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set the {{JsonWebKey/d}} attribute of <var>jwk</var> according to the
+                                        Set the {{JsonWebKey/d}} attribute of |jwk| according to the
                                         definition in Section 6.2.2.1 of JSON Web Algorithms [[JWA]].
                                       </p>
                                     </dd>
@@ -10803,17 +10803,17 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Perform any [= ECDH key export steps | key export steps =]
                                     defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var> and the
+                                    specifications</a>, passing |format| and the
                                     {{EcKeyAlgorithm/namedCurve}} attribute of
                                     the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of <var>key</var>
-                                    and obtaining <var>namedCurve</var> and a new value of <var>jwk</var>.
+                                    internal slot of |key|
+                                    and obtaining |namedCurve| and a new value of |jwk|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                    <var>namedCurve</var>.
+                                    Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                    |namedCurve|.
                                   </p>
                                 </li>
                               </ol>
@@ -10822,33 +10822,33 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to the
-                            {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to the
+                            {{CryptoKey/usages}} attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
                       </ol>
                     </dd>
                     <dt>
-                      If <var>format</var> is {{KeyFormat/"raw"}}:
+                      If |format| is {{KeyFormat/"raw"}}:
                     </dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
@@ -10856,14 +10856,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is "`P-256`", "`P-384`"
+                              of |key| is "`P-256`", "`P-384`"
                               or "`P-521`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>data</var> be the [= octet string =] that
+                                Let |data| be the [= octet string =] that
                                 represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                <var>key</var> according to the encoding rules specified in
+                                |key| according to the encoding rules specified in
                                 Section 2.3.3 of [[SEC1]] and using the
                                 uncompressed form.
                               </p>
@@ -10873,21 +10873,21 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               <p>
                                 Perform any [= ECDH key export steps | key export steps =]
                                 defined by <a href="#dfn-applicable-specification">other applicable
-                                specifications</a>, passing <var>format</var> and the
+                                specifications</a>, passing |format| and the
                                 {{EcKeyAlgorithm/namedCurve}} attribute of
                                 the {{CryptoKey/[[algorithm]]}}
-                                internal slot of <var>key</var>
-                                and obtaining <var>namedCurve</var> and <var>data</var>.
+                                internal slot of |key|
+                                and obtaining |namedCurve| and |data|.
                               </p>
                             </dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
@@ -10896,7 +10896,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -11017,7 +11017,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCtrParams/counter}} member of
-                    <var>normalizedAlgorithm</var> does not have length 16
+                    |normalizedAlgorithm| does not have length 16
                     bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11026,7 +11026,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCtrParams/length}} member of
-                    <var>normalizedAlgorithm</var> is zero or is greater
+                    |normalizedAlgorithm| is zero or is greater
                     than 128,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11034,14 +11034,14 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>ciphertext</var> be the result of performing the CTR Encryption
+                    Let |ciphertext| be the result of performing the CTR Encryption
                     operation described in Section 6.5 of [[NIST-SP800-38A]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesCtrParams/counter}} member of
-                    <var>normalizedAlgorithm</var> as the initial value of the counter block, the
+                    |normalizedAlgorithm| as the initial value of the counter block, the
                     {{AesCtrParams/length}} member of
-                    <var>normalizedAlgorithm</var> as the input parameter <var>m</var> to the
+                    |normalizedAlgorithm| as the input parameter |m| to the
                     standard counter block incrementing function defined in Appendix B.1 of
                     [[NIST-SP800-38A]] and <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>plaintext</var></a> as the input plaintext.
+                    |plaintext|</a> as the input plaintext.
                   </p>
                 </li>
                 <li>
@@ -11049,7 +11049,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>ciphertext</var>.
+                    containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -11060,7 +11060,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCtrParams/counter}} member of
-                    <var>normalizedAlgorithm</var> does not have length 16
+                    |normalizedAlgorithm| does not have length 16
                     bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11069,7 +11069,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCtrParams/length}} member of
-                    <var>normalizedAlgorithm</var> is zero or is greater
+                    |normalizedAlgorithm| is zero or is greater
                     than 128,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11077,14 +11077,14 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>plaintext</var> be the result of performing the CTR Decryption
+                    Let |plaintext| be the result of performing the CTR Decryption
                     operation described in Section 6.5 of [[NIST-SP800-38A]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesCtrParams/counter}} member of
-                    <var>normalizedAlgorithm</var> as the initial value of the counter block, the
+                    |normalizedAlgorithm| as the initial value of the counter block, the
                     {{AesCtrParams/length}} member of
-                    <var>normalizedAlgorithm</var> as the input parameter <var>m</var> to the
+                    |normalizedAlgorithm| as the input parameter |m| to the
                     standard counter block incrementing function defined in Appendix B.1 of
                     [[NIST-SP800-38A]] and <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>ciphertext</var></a> as the input ciphertext.
+                    |ciphertext|</a> as the input ciphertext.
                   </p>
                 </li>
                 <li>
@@ -11092,7 +11092,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>plaintext</var>.
+                    containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -11102,7 +11102,7 @@ dictionary AesDerivedKeyParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains any entry which is not
+                    If |usages| contains any entry which is not
                     one of "`encrypt`", "`decrypt`",
                     "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
@@ -11112,7 +11112,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var> is not equal to one of
+                    |normalizedAlgorithm| is not equal to one of
                     128, 192 or 256,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11123,7 +11123,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                   <p>
                     Generate an AES key of length
                     equal to the {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
@@ -11135,52 +11135,52 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new
+                    Let |key| be a new
                     {{CryptoKey}} object representing the
                     generated AES key.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-CTR`".
+                    |algorithm| to "`AES-CTR`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to equal the
+                    |algorithm| to equal the
                     {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>key</var> to be <var>extractable</var>.
+                    slot of |key| to be |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>key</var> to be <var>usages</var>.
+                    |key| to be |usages|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -11190,7 +11190,7 @@ dictionary AesDerivedKeyParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                     one of "`encrypt`", "`decrypt`",
                     "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
@@ -11199,37 +11199,37 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] contained in <var>keyData</var>.
+                            Let |data| be the [= octet string =] contained in |keyData|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the length in bits of <var>data</var> is not 128, 192 or 256
+                            If the length in bits of |data| is not 128, 192 or 256
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
                              "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -11237,7 +11237,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>jwk</var> does not meet the requirements of
+                            If |jwk| does not meet the requirements of
                             Section 6.4 of JSON Web Algorithms [[JWA]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -11245,25 +11245,25 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] obtained by decoding the
-                            {{JsonWebKey/k}} field of <var>jwk</var>.
+                            Let |data| be the [= octet string =] obtained by decoding the
+                            {{JsonWebKey/k}} field of |jwk|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>data</var> has length 128 bits:</dt>
+                            <dt>If |data| has length 128 bits:</dt>
                             <dd>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                              If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                               not "`A128CTR`", then [= exception/throw =] a {{DataError}}.
                             </dd>
-                            <dt>If <var>data</var> has length 192 bits:</dt>
+                            <dt>If |data| has length 192 bits:</dt>
                             <dd>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                              If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                               not "`A192CTR`", then [= exception/throw =] a {{DataError}}.
                             </dd>
-                            <dt>If <var>data</var> has length 256 bits:</dt>
+                            <dt>If |data| has length 256 bits:</dt>
                             <dd>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                              If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                               not "`A256CTR`", then [= exception/throw =] a {{DataError}}.
                             </dd>
                             <dt>Otherwise:</dt>
@@ -11274,7 +11274,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -11282,18 +11282,18 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -11309,37 +11309,37 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new `{{CryptoKey}}` object representing an AES key with
-                    value <var>data</var>.
+                    Let |key| be a new `{{CryptoKey}}` object representing an AES key with
+                    value |data|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-CTR`".
+                    |algorithm| to "`AES-CTR`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to the length, in bits, of <var>data</var>.
+                    |algorithm| to the length, in bits, of |data|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -11349,85 +11349,85 @@ dictionary AesDerivedKeyParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>.
+                            Let |data| be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>jwk</var> be a new {{JsonWebKey}}
+                            Let |jwk| be a new {{JsonWebKey}}
                             dictionary.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to the
+                            Set the `kty` attribute of |jwk| to the
                             string "`oct`".
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the {{JsonWebKey/k}} attribute of <var>jwk</var> to be a string
+                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
                             containing the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 128:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 128:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A128CTR`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 192:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 192:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A192CTR`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 256:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 256:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A256CTR`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to equal the
+                            Set the `key_ops` attribute of |jwk| to equal the
                             {{CryptoKey/[[usages]]}} internal slot of
-                            <var>key</var>.
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -11444,7 +11444,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -11455,7 +11455,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var> is not 128, 192 or 256,
+                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256,
                     then [= exception/throw =] a
                     {{OperationError}}.
                   </p>
@@ -11463,7 +11463,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     Return the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var>.
+                    |normalizedDerivedKeyAlgorithm|.
                   </p>
                 </li>
               </ol>
@@ -11555,7 +11555,7 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCbcParams/iv}} member of
-                    <var>normalizedAlgorithm</var> does not have length 16
+                    |normalizedAlgorithm| does not have length 16
                     bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11563,18 +11563,18 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>paddedPlaintext</var> be the result of adding padding octets to
-                    the <a href="#concept-contents-of-arraybuffer">contents of <var>plaintext</var></a>
+                    Let |paddedPlaintext| be the result of adding padding octets to
+                    the <a href="#concept-contents-of-arraybuffer">contents of |plaintext|</a>
                     according to the procedure defined in Section 10.3
                     of [[RFC2315]], step 2, with a value of
-                    <var>k</var> of 16.
+                    |k| of 16.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>ciphertext</var> be the result of performing the CBC Encryption
-                    operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesCbcParams/iv}} member of <var>normalizedAlgorithm</var> as
-                    the <var>IV</var> input parameter and <var>paddedPlaintext</var>
+                    Let |ciphertext| be the result of performing the CBC Encryption
+                    operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesCbcParams/iv}} member of |normalizedAlgorithm| as
+                    the |IV| input parameter and |paddedPlaintext|
                     as the input plaintext.
                   </p>
                 </li>
@@ -11583,7 +11583,7 @@ dictionary AesCbcParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>ciphertext</var>.
+                    containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -11594,7 +11594,7 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCbcParams/iv}} member of
-                    <var>normalizedAlgorithm</var> does not have length 16
+                    |normalizedAlgorithm| does not have length 16
                     bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11602,29 +11602,29 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>paddedPlaintext</var> be the result of performing the CBC Decryption
-                    operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesCbcParams/iv}} member of <var>normalizedAlgorithm</var> as
-                    the <var>IV</var> input parameter and <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>ciphertext</var></a> as the input ciphertext.
+                    Let |paddedPlaintext| be the result of performing the CBC Decryption
+                    operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesCbcParams/iv}} member of |normalizedAlgorithm| as
+                    the |IV| input parameter and <a href="#concept-contents-of-arraybuffer">the contents of
+                    |ciphertext|</a> as the input ciphertext.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>p</var> be the value of the last octet of <var>paddedPlaintext</var>.
+                    Let |p| be the value of the last octet of |paddedPlaintext|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If <var>p</var> is zero or greater than 16, or if any of the last <var>p</var>
-                    octets of <var>paddedPlaintext</var> have a value which is not <var>p</var>,
+                    If |p| is zero or greater than 16, or if any of the last |p|
+                    octets of |paddedPlaintext| have a value which is not |p|,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>plaintext</var> be the result of removing <var>p</var> octets from
-                    the end of <var>paddedPlaintext</var>.
+                    Let |plaintext| be the result of removing |p| octets from
+                    the end of |paddedPlaintext|.
                   </p>
                 </li>
                 <li>
@@ -11632,7 +11632,7 @@ dictionary AesCbcParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>plaintext</var>.
+                    containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -11642,7 +11642,7 @@ dictionary AesCbcParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains any entry which is not
+                    If |usages| contains any entry which is not
                      one of "`encrypt`", "`decrypt`",
                     "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
@@ -11652,7 +11652,7 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var> is not equal to one of
+                    |normalizedAlgorithm| is not equal to one of
                     128, 192 or 256,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -11663,7 +11663,7 @@ dictionary AesCbcParams : Algorithm {
                   <p>
                     Generate an AES key of length
                     equal to the {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
@@ -11675,52 +11675,52 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new
+                    Let |key| be a new
                     {{CryptoKey}} object representing the
                     generated AES key.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-CBC`".
+                    |algorithm| to "`AES-CBC`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to equal the
+                    |algorithm| to equal the
                     {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>key</var> to be <var>extractable</var>.
+                    slot of |key| to be |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>key</var> to be <var>usages</var>.
+                    |key| to be |usages|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -11730,7 +11730,7 @@ dictionary AesCbcParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                     one of "`encrypt`", "`decrypt`",
                     "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
@@ -11739,37 +11739,37 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] contained in <var>keyData</var>.
+                            Let |data| be the [= octet string =] contained in |keyData|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the length in bits of <var>data</var> is not 128, 192 or 256
+                            If the length in bits of |data| is not 128, 192 or 256
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
                             "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -11777,7 +11777,7 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>jwk</var> does not meet the requirements of
+                            If |jwk| does not meet the requirements of
                             Section 6.4 of JSON Web Algorithms [[JWA]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -11785,24 +11785,24 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] obtained by decoding the
-                            {{JsonWebKey/k}} field of <var>jwk</var>.
+                            Let |data| be the [= octet string =] obtained by decoding the
+                            {{JsonWebKey/k}} field of |jwk|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>data</var> has length 128 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 128 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A128CBC`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
-                            <dt>If <var>data</var> has length 192 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 192 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A192CBC`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
-                            <dt>If <var>data</var> has length 256 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 256 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A256CBC`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
@@ -11815,7 +11815,7 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not  "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -11823,18 +11823,18 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -11850,37 +11850,37 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new `{{CryptoKey}}`
-                    object representing an AES key with value <var>data</var>.
+                    Let |key| be a new `{{CryptoKey}}`
+                    object representing an AES key with value |data|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-CBC`".
+                    |algorithm| to "`AES-CBC`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to the length, in bits, of <var>data</var>.
+                    |algorithm| to the length, in bits, of |data|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -11890,86 +11890,86 @@ dictionary AesCbcParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>.
+                            Let |data| be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to the
+                            Set the `kty` attribute of |jwk| to the
                             string "`oct`".
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the {{JsonWebKey/k}} attribute of <var>jwk</var> to be a string
+                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
                             containing the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 128:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 128:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A128CBC`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 192:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 192:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A192CBC`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 256:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 256:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A256CBC`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to equal the
-                            {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to equal the
+                            {{CryptoKey/usages}} attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -11986,7 +11986,7 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -11997,7 +11997,7 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var> is not 128, 192 or 256,
+                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -12005,7 +12005,7 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     Return the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var>.
+                    |normalizedDerivedKeyAlgorithm|.
                   </p>
                 </li>
               </ol>
@@ -12093,7 +12093,7 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>plaintext</var> has a length greater than 2^39 - 256
+                    If |plaintext| has a length greater than 2^39 - 256
                     bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -12102,7 +12102,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/iv}} member of
-                    <var>normalizedAlgorithm</var> has a length greater than 2^64 - 1
+                    |normalizedAlgorithm| has a length greater than 2^64 - 1
                     bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -12111,7 +12111,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/additionalData}} member
-                    of <var>normalizedAlgorithm</var> is present and has a length
+                    of |normalizedAlgorithm| is present and has a length
                     greater than 2^64 - 1 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -12120,13 +12120,13 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <dl class="switch">
                     <dt>If the {{AesGcmParams/tagLength}} member of
-                    <var>normalizedAlgorithm</var> is not present:</dt>
-                    <dd>Let <var>tagLength</var> be 128.</dd>
+                    |normalizedAlgorithm| is not present:</dt>
+                    <dd>Let |tagLength| be 128.</dd>
                     <dt>If the {{AesGcmParams/tagLength}} member of
-                    <var>normalizedAlgorithm</var> is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
-                    <dd>Let <var>tagLength</var> be equal to the
+                    |normalizedAlgorithm| is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
+                    <dd>Let |tagLength| be equal to the
                     {{AesGcmParams/tagLength}} member of
-                     <var>normalizedAlgorithm</var></dd>
+                     |normalizedAlgorithm|</dd>
                     <dt>Otherwise:</dt>
                     <dd>
                       [= exception/throw =] an
@@ -12136,25 +12136,25 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>additionalData</var> be <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesGcmParams/additionalData}} member of
-                    <var>normalizedAlgorithm</var> if present or the empty octet
+                    Let |additionalData| be <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesGcmParams/additionalData}} member of
+                    |normalizedAlgorithm| if present or the empty octet
                     string otherwise.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>C</var> and <var>T</var> be the outputs that result from performing
+                    Let |C| and |T| be the outputs that result from performing
                     the Authenticated Encryption Function described in Section 7.1 of
-                    [[NIST-SP800-38D]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesGcmParams/iv}} member of <var>normalizedAlgorithm</var> as
-                    the <var>IV</var> input parameter, <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>additionalData</var></a> as the <var>A</var> input parameter,
-                    <var>tagLength</var> as the <var>t</var> pre-requisite and <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>plaintext</var></a> as the input plaintext.
+                    [[NIST-SP800-38D]] using AES as the block cipher, <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesGcmParams/iv}} member of |normalizedAlgorithm| as
+                    the |IV| input parameter, <a href="#concept-contents-of-arraybuffer">the contents of
+                    |additionalData|</a> as the |A| input parameter,
+                    |tagLength| as the |t| pre-requisite and <a href="#concept-contents-of-arraybuffer">the contents of
+                    |plaintext|</a> as the input plaintext.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>ciphertext</var> be equal to <var>C</var> | <var>T</var>,
+                    Let |ciphertext| be equal to |C| | |T|,
                     where '|' denotes concatenation.
                   </p>
                 </li>
@@ -12163,7 +12163,7 @@ dictionary AesGcmParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>ciphertext</var>.
+                    containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -12174,13 +12174,13 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <dl class="switch">
                     <dt>If the {{AesGcmParams/tagLength}} member of
-                    <var>normalizedAlgorithm</var> is not present:</dt>
-                    <dd>Let <var>tagLength</var> be 128.</dd>
+                    |normalizedAlgorithm| is not present:</dt>
+                    <dd>Let |tagLength| be 128.</dd>
                     <dt>If the {{AesGcmParams/tagLength}} member of
-                    <var>normalizedAlgorithm</var> is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
-                    <dd>Let <var>tagLength</var> be equal to the
+                    |normalizedAlgorithm| is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
+                    <dd>Let |tagLength| be equal to the
                     {{AesGcmParams/tagLength}} member of
-                     <var>normalizedAlgorithm</var></dd>
+                     |normalizedAlgorithm|</dd>
                     <dt>Otherwise:</dt>
                     <dd>
                       [= exception/throw =] an
@@ -12190,7 +12190,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    If <var>ciphertext</var> has a length less than <var>tagLength</var> bits,
+                    If |ciphertext| has a length less than |tagLength| bits,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -12198,7 +12198,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/iv}} member of
-                    <var>normalizedAlgorithm</var> has a length greater than 2^64 - 1
+                    |normalizedAlgorithm| has a length greater than 2^64 - 1
                     bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -12207,7 +12207,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/additionalData}} member
-                    of <var>normalizedAlgorithm</var> is present and has a length
+                    of |normalizedAlgorithm| is present and has a length
                     greater than 2^64 - 1
                     bytes,
                     then [= exception/throw =] an
@@ -12216,20 +12216,20 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>tag</var> be the last <var>tagLength</var> bits of
-                    <var>ciphertext</var>.
+                    Let |tag| be the last |tagLength| bits of
+                    |ciphertext|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>actualCiphertext</var> be the result of removing the last <var>tagLength</var> bits
-                    from <var>ciphertext</var>.
+                    Let |actualCiphertext| be the result of removing the last |tagLength| bits
+                    from |ciphertext|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>additionalData</var> be <a href="#concept-contents-of-arraybuffer">the contents</a> of the {{AesGcmParams/additionalData}} member of
-                    <var>normalizedAlgorithm</var> if present or the empty octet
+                    Let |additionalData| be <a href="#concept-contents-of-arraybuffer">the contents</a> of the {{AesGcmParams/additionalData}} member of
+                    |normalizedAlgorithm| if present or the empty octet
                     string otherwise.
                   </p>
                 </li>
@@ -12237,22 +12237,22 @@ dictionary AesGcmParams : Algorithm {
                   <p>
                     Perform the Authenticated Decryption Function described in Section 7.2 of
                     [[NIST-SP800-38D]] using AES as the block cipher,
-                    <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesGcmParams/iv}} member of <var>normalizedAlgorithm</var> as
-                    the <var>IV</var> input parameter, <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>additionalData</var></a> as the <var>A</var> input parameter,
-                    <var>tagLength</var> as the <var>t</var> pre-requisite, <a href="#concept-contents-of-arraybuffer">the contents of
-                    <var>actualCiphertext</var></a> as the input ciphertext, <var>C</var> and <a href="#concept-contents-of-arraybuffer">the contents of <var>tag</var></a> as
-                    the authentication tag, <var>T</var>.
+                    <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{AesGcmParams/iv}} member of |normalizedAlgorithm| as
+                    the |IV| input parameter, <a href="#concept-contents-of-arraybuffer">the contents of
+                    |additionalData|</a> as the |A| input parameter,
+                    |tagLength| as the |t| pre-requisite, <a href="#concept-contents-of-arraybuffer">the contents of
+                    |actualCiphertext|</a> as the input ciphertext, |C| and <a href="#concept-contents-of-arraybuffer">the contents of |tag|</a> as
+                    the authentication tag, |T|.
                   </p>
                   <dl class="switch">
                     <dt>If the result of the algorithm is the indication of inauthenticity,
-                    "<var>FAIL</var>":</dt>
+                    "|FAIL|":</dt>
                     <dd>
                       [= exception/throw =] an
                       {{OperationError}}
                     </dd>
                     <dt>Otherwise:</dt>
-                    <dd>Let <var>plaintext</var> be the output <var>P</var> of the Authenticated
+                    <dd>Let |plaintext| be the output |P| of the Authenticated
                     Decryption Function.</dd>
                   </dl>
                 </li>
@@ -12261,7 +12261,7 @@ dictionary AesGcmParams : Algorithm {
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    containing <var>plaintext</var>.
+                    containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -12271,7 +12271,7 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains any entry which is not
+                    If |usages| contains any entry which is not
                     one of "`encrypt`", "`decrypt`",
                     "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
@@ -12281,7 +12281,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var> is not equal to one of
+                    |normalizedAlgorithm| is not equal to one of
                     128, 192 or 256,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -12292,7 +12292,7 @@ dictionary AesGcmParams : Algorithm {
                   <p>
                     Generate an AES key of length
                     equal to the {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
@@ -12304,52 +12304,52 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new
+                    Let |key| be a new
                     {{CryptoKey}} object representing the
                     generated AES key.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-GCM`".
+                    |algorithm| to "`AES-GCM`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to equal the
+                    |algorithm| to equal the
                     {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>key</var> to be <var>extractable</var>.
+                    slot of |key| to be |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>key</var> to be <var>usages</var>.
+                    |key| to be |usages|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -12359,7 +12359,7 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                     one of "`encrypt`", "`decrypt`",
                     "`wrapKey`" or "`unwrapKey`",
                             then [= exception/throw =] a
@@ -12368,37 +12368,37 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] contained in <var>keyData</var>.
+                            Let |data| be the [= octet string =] contained in |keyData|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the length in bits of <var>data</var> is not 128, 192 or 256
+                            If the length in bits of |data| is not 128, 192 or 256
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
                             "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -12406,7 +12406,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>jwk</var> does not meet the requirements of
+                            If |jwk| does not meet the requirements of
                             Section 6.4 of JSON Web Algorithms [[JWA]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -12414,24 +12414,24 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] obtained by decoding the
-                            {{JsonWebKey/k}} field of <var>jwk</var>.
+                            Let |data| be the [= octet string =] obtained by decoding the
+                            {{JsonWebKey/k}} field of |jwk|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>data</var> has length 128 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 128 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A128GCM`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
-                            <dt>If <var>data</var> has length 192 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 192 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A192GCM`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
-                            <dt>If <var>data</var> has length 256 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 256 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A256GCM`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
@@ -12444,7 +12444,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not  "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -12452,18 +12452,18 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -12479,37 +12479,37 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new `{{CryptoKey}}`
-                    object representing an AES key with value <var>data</var>.
+                    Let |key| be a new `{{CryptoKey}}`
+                    object representing an AES key with value |data|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-GCM`".
+                    |algorithm| to "`AES-GCM`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to the length, in bits, of <var>data</var>.
+                    |algorithm| to the length, in bits, of |data|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -12519,85 +12519,85 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>.
+                            Let |data| be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>jwk</var> be a new {{JsonWebKey}}
+                            Let |jwk| be a new {{JsonWebKey}}
                             dictionary.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to the
+                            Set the `kty` attribute of |jwk| to the
                             string "`oct`".
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the {{JsonWebKey/k}} attribute of <var>jwk</var> to be a string
+                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
                             containing the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 128:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 128:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A128GCM`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 192:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 192:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A192GCM`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 256:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 256:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A256GCM`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to equal the
+                            Set the `key_ops` attribute of |jwk| to equal the
                             {{CryptoKey/usages}} attribute of
-                            <var>key</var>.
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -12614,7 +12614,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -12625,13 +12625,13 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var> is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
+                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Return the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var>.
+                    |normalizedDerivedKeyAlgorithm|.
                   </p>
                 </li>
               </ol>
@@ -12706,22 +12706,22 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>plaintext</var> is not a multiple of 64 bits in length,
+                    If |plaintext| is not a multiple of 64 bits in length,
                             then [= exception/throw =] an
                             {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>ciphertext</var> be the result of performing the Key Wrap
+                    Let |ciphertext| be the result of performing the Key Wrap
                     operation described in Section 2.2.1 of [[RFC3394]]
-                    with <var>plaintext</var> as the plaintext to be wrapped and using the default
+                    with |plaintext| as the plaintext to be wrapped and using the default
                     Initial Value defined in Section 2.2.3.1 of the same document.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>ciphertext</var>.
+                    Return |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -12731,9 +12731,9 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>plaintext</var> be the result of performing the Key Unwrap
+                    Let |plaintext| be the result of performing the Key Unwrap
                     operation described in Section 2.2.2 of [[RFC3394]] with
-                    <var>ciphertext</var> as the input ciphertext and using the default Initial
+                    |ciphertext| as the input ciphertext and using the default Initial
                     Value defined in Section 2.2.3.1 of the same document.
                   </p>
                 </li>
@@ -12746,7 +12746,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>plaintext</var>.
+                    Return |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -12756,21 +12756,21 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains any entry which is not one of
+                    If |usages| contains any entry which is not one of
                     "`wrapKey`" or "`unwrapKey`", then [= exception/throw =] a {{SyntaxError}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     If the {{AesKeyGenParams/length}} property of
-                    <var>normalizedAlgorithm</var> is not equal to one of 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
+                    |normalizedAlgorithm| is not equal to one of 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Generate an AES key of length
                     equal to the {{AesKeyGenParams/length}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
@@ -12782,52 +12782,52 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new
+                    Let |key| be a new
                     {{CryptoKey}} object representing the
                     generated AES key.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-KW`".
+                    |algorithm| to "`AES-KW`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to equal the
+                    |algorithm| to equal the
                     {{AesKeyGenParams/length}} property of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>key</var> to be <var>extractable</var>.
+                    slot of |key| to be |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>key</var> to be <var>usages</var>.
+                    |key| to be |usages|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -12837,7 +12837,7 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                      one of "`wrapKey`" or "`unwrapKey`",
 
                             then [= exception/throw =] a
@@ -12846,17 +12846,17 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] contained in <var>keyData</var>.
+                            Let |data| be the [= octet string =] contained in |keyData|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the length in bits of <var>data</var> is not 128, 192 or 256
+                            If the length in bits of |data| is not 128, 192 or 256
 
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -12864,20 +12864,20 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
                             "`oct`",
                               then [= exception/throw =] a
                               {{DataError}}.
@@ -12885,7 +12885,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>jwk</var> does not meet the requirements of
+                            If |jwk| does not meet the requirements of
                             Section 6.4 of JSON Web Algorithms [[JWA]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -12893,24 +12893,24 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] obtained by decoding the
-                            {{JsonWebKey/k}} field of <var>jwk</var>.
+                            Let |data| be the [= octet string =] obtained by decoding the
+                            {{JsonWebKey/k}} field of |jwk|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>data</var> has length 128 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 128 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A128KW`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
-                            <dt>If <var>data</var> has length 192 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 192 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A192KW`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
-                            <dt>If <var>data</var> has length 256 bits:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
+                            <dt>If |data| has length 256 bits:</dt>
+                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
                             not  "`A256KW`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
@@ -12923,7 +12923,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not  "`enc`",
                               then [= exception/throw =] a
                               {{DataError}}.
@@ -12931,18 +12931,18 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                               then [= exception/throw =] a
                               {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                               then [= exception/throw =] a
                               {{DataError}}.                          </p>
                         </li>
@@ -12957,39 +12957,39 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                    Let |key| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    representing an AES key with value <var>data</var>.
+                    representing an AES key with value |data|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`AES-KW`".
+                    |algorithm| to "`AES-KW`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{AesKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to the length, in bits, of <var>data</var>.
+                    |algorithm| to the length, in bits, of |data|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -12999,84 +12999,84 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>.
+                            Let |data| be the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and containing
-                            <var>data</var>.
+                            |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>jwk</var> be a new {{JsonWebKey}}
+                            Let |jwk| be a new {{JsonWebKey}}
                             dictionary.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to the
+                            Set the `kty` attribute of |jwk| to the
                             string "`oct`".
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the {{JsonWebKey/k}} attribute of <var>jwk</var> to be a string
+                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
                             containing the raw octets of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                            <var>key</var>, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 128:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 128:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A128KW`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 192:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 192:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A192KW`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            <var>key</var> is 256:</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |key| is 256:</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`A256KW`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to equal the
-                            {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to equal the
+                            {{CryptoKey/usages}} attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -13093,7 +13093,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -13104,13 +13104,13 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var> is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
+                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Return the {{AesDerivedKeyParams/length}} member of
-                    <var>normalizedDerivedKeyAlgorithm</var>.
+                    |normalizedDerivedKeyAlgorithm|.
                   </p>
                 </li>
               </ol>
@@ -13226,11 +13226,11 @@ dictionary HmacKeyGenParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>mac</var> be the result of performing the MAC Generation operation
+                    Let |mac| be the result of performing the MAC Generation operation
                     described in Section 4 of [[FIPS-198-1]] using
                     the key represented by {{CryptoKey/[[handle]]}}
-                    internal slot of <var>key</var>, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> and <var>message</var> as the input data <var>text</var>.
+                    internal slot of |key|, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key| and |message| as the input data |text|.
                   </p>
                 </li>
                 <li>
@@ -13238,7 +13238,7 @@ dictionary HmacKeyGenParams : Algorithm {
                     Return a new {{ArrayBuffer}} object, associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and containing the
-                    bytes of <var>mac</var>.
+                    bytes of |mac|.
                   </p>
                 </li>
               </ol>
@@ -13248,16 +13248,16 @@ dictionary HmacKeyGenParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    Let <var>mac</var> be the result of performing the MAC Generation operation
+                    Let |mac| be the result of performing the MAC Generation operation
                     described in Section 4 of [[FIPS-198-1]] using
                     the key represented by {{CryptoKey/[[handle]]}}
-                    internal slot of <var>key</var>, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> and <var>message</var> as the input data <var>text</var>.
+                    internal slot of |key|, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key| and |message| as the input data |text|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return true if <var>mac</var> is equal to <var>signature</var> and false
+                    Return true if |mac| is equal to |signature| and false
                     otherwise.
                   </p>
                 </li>
@@ -13268,7 +13268,7 @@ dictionary HmacKeyGenParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains any entry which is not "`sign`" or
+                    If |usages| contains any entry which is not "`sign`" or
                     "`verify`", then [= exception/throw =] a {{SyntaxError}}.
                   </p>
                 </li>
@@ -13276,21 +13276,21 @@ dictionary HmacKeyGenParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{HmacKeyGenParams/length}} member of
-                      <var>normalizedAlgorithm</var> is not present:
+                      |normalizedAlgorithm| is not present:
                     </dt>
                     <dd>
-                      Let <var>length</var> be the block size in bits of the hash function
+                      Let |length| be the block size in bits of the hash function
                       identified by the {{HmacKeyGenParams/hash}} member
-                      of <var>normalizedAlgorithm</var>.
+                      of |normalizedAlgorithm|.
                     </dd>
                     <dt>
                       Otherwise, if the {{HmacKeyGenParams/length}}
-                      member of <var>normalizedAlgorithm</var> is non-zero:
+                      member of |normalizedAlgorithm| is non-zero:
                     </dt>
                     <dd>
-                      Let <var>length</var> be equal to the
+                      Let |length| be equal to the
                       {{HmacKeyGenParams/length}}
-                      member of <var>normalizedAlgorithm</var>.
+                      member of |normalizedAlgorithm|.
                     </dd>
                     <dt>Otherwise:</dt>
                     <dd>
@@ -13302,7 +13302,7 @@ dictionary HmacKeyGenParams : Algorithm {
 
                 <li>
                   <p>
-                    Generate a key of length <var>length</var> bits.
+                    Generate a key of length |length| bits.
                   </p>
                 </li>
                 <li>
@@ -13314,64 +13314,64 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new
+                    Let |key| be a new
                     {{CryptoKey}} object representing the
                     generated key.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{HmacKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`HMAC`".
+                    |algorithm| to "`HMAC`".
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>hash</var> be a new
+                    Let |hash| be a new
                     {{KeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>hash</var> to equal the {{Algorithm/name}}
+                    |hash| to equal the {{Algorithm/name}}
                     member of the {{HmacKeyGenParams/hash}}
-                    member of <var>normalizedAlgorithm</var>.
+                    member of |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{HmacKeyAlgorithm/hash}} attribute
-                    of <var>algorithm</var> to <var>hash</var>.
+                    of |algorithm| to |hash|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of <var>key</var> to be <var>extractable</var>.
+                    slot of |key| to be |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
-                    <var>key</var> to be <var>usages</var>.
+                    |key| to be |usages|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -13380,11 +13380,11 @@ dictionary HmacKeyGenParams : Algorithm {
             <dd>
               <ol>
                 <li>
-                  <p>Let <var>keyData</var> be the key data to be imported.</p>
+                  <p>Let |keyData| be the key data to be imported.</p>
                 </li>
                 <li>
                   <p>
-                    If <var>usages</var> contains an entry which is not
+                    If |usages| contains an entry which is not
                     "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
@@ -13392,41 +13392,41 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>hash</var> be a new {{KeyAlgorithm}}.
+                    Let |hash| be a new {{KeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] contained in <var>keyData</var>.
+                            Let |data| be the [= octet string =] contained in |keyData|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set <var>hash</var> to equal the {{HmacImportParams/hash}}
-                              member of <var>normalizedAlgorithm</var>.
+                            Set |hash| to equal the {{HmacImportParams/hash}}
+                              member of |normalizedAlgorithm|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>keyData</var> is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let <var>jwk</var> equal <var>keyData</var>.</p></dd>
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
                             <dt>Otherwise:</dt>
                             <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
                             "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -13434,7 +13434,7 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>jwk</var> does not meet the requirements of
+                            If |jwk| does not meet the requirements of
                             Section 6.4 of JSON Web Algorithms [[JWA]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -13442,65 +13442,65 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be the [= octet string =] obtained by decoding the
-                            {{JsonWebKey/k}} field of <var>jwk</var>.
+                            Let |data| be the [= octet string =] obtained by decoding the
+                            {{JsonWebKey/k}} field of |jwk|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <var>hash</var> to equal the {{HmacImportParams/hash}} member of
-                            <var>normalizedAlgorithm</var>.
+                            Set the |hash| to equal the {{HmacImportParams/hash}} member of
+                            |normalizedAlgorithm|.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
-                              of <var>hash</var> is
+                              of |hash| is
                               "`SHA-1`":
                             </dt>
                             <dd>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
+                              If the {{JsonWebKey/alg}} field of |jwk| is present
                               and is not "`HS1`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
-                              of <var>hash</var> is
+                              of |hash| is
                               "`SHA-256`":
                             </dt>
                             <dd>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
+                              If the {{JsonWebKey/alg}} field of |jwk| is present
                               and is not "`HS256`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
-                              of <var>hash</var> is
+                              of |hash| is
                               "`SHA-384`":
                             </dt>
                             <dd>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
+                              If the {{JsonWebKey/alg}} field of |jwk| is present
                               and is not "`HS384`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
-                              of <var>hash</var> is
+                              of |hash| is
                               "`SHA-512`":
                             </dt>
                             <dd>
-                              If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
+                              If the {{JsonWebKey/alg}} field of |jwk| is present
                               and is not "`HS512`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
                             <dt>
                               Otherwise, if the {{KeyAlgorithm/name}} attribute
-                              of <var>hash</var> is defined in
+                              of |hash| is defined in
                               <a href="#dfn-applicable-specification">another applicable
                               specification</a>:
                             </dt>
@@ -13508,15 +13508,15 @@ dictionary HmacKeyGenParams : Algorithm {
                               Perform any [= HMAC key import steps | key
                               import steps =] defined by
                               <a href="#dfn-applicable-specification">other applicable
-                              specifications</a>, passing <var>format</var>, <var>jwk</var>
-                              and <var>hash</var>
-                              and obtaining <var>hash</var>.
+                              specifications</a>, passing |format|, |jwk|
+                              and |hash|
+                              and obtaining |hash|.
                             </dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not  "`sign`",
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -13524,18 +13524,18 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/key_ops}} field of <var>jwk</var> is present, and
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
                             is invalid according to the requirements of
                             JSON Web Key [[JWK]] or
-                            does not contain all of the specified <var>usages</var> values,
+                            does not contain all of the specified |usages| values,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the {{JsonWebKey/ext}} field of <var>jwk</var> is present and
-                            has the value false and <var>extractable</var> is true,
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -13551,13 +13551,13 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>length</var> be equivalent to the length, in octets, of
-                    <var>data</var>, multiplied by 8.
+                    Let |length| be equivalent to the length, in octets, of
+                    |data|, multiplied by 8.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If <var>length</var> is zero
+                    If |length| is zero
                     then [= exception/throw =] a
                     {{DataError}}.
                   </p>
@@ -13566,13 +13566,13 @@ dictionary HmacKeyGenParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{HmacImportParams/length}} member of
-                      <var>normalizedAlgorithm</var> is present:
+                      |normalizedAlgorithm| is present:
                     </dt>
                     <dd>
                       <dl class="switch">
                         <dt>
                           If the {{HmacImportParams/length}} member of
-                          <var>normalizedAlgorithm</var> is greater than <var>length</var>:
+                          |normalizedAlgorithm| is greater than |length|:
                         </dt>
                         <dd>
                           [= exception/throw =] a
@@ -13580,8 +13580,8 @@ dictionary HmacKeyGenParams : Algorithm {
                         </dd>
                         <dt>
                           If the {{HmacImportParams/length}} member of
-                          <var>normalizedAlgorithm</var>, is less than or equal to
-                          <var>length</var> minus eight:
+                          |normalizedAlgorithm|, is less than or equal to
+                          |length| minus eight:
                         </dt>
                         <dd>
                           [= exception/throw =] a
@@ -13591,8 +13591,8 @@ dictionary HmacKeyGenParams : Algorithm {
                           Otherwise:
                         </dt>
                         <dd>
-                          Set <var>length</var> equal to the {{HmacImportParams/length}}
-                          member of <var>normalizedAlgorithm</var>.
+                          Set |length| equal to the {{HmacImportParams/length}}
+                          member of |normalizedAlgorithm|.
                         </dd>
                       </dl>
                     </dd>
@@ -13600,44 +13600,44 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new `{{CryptoKey}}`
-                    object representing an HMAC key with the first <var>length</var>
-                    bits of <var>data</var>.
+                    Let |key| be a new `{{CryptoKey}}`
+                    object representing an HMAC key with the first |length|
+                    bits of |data|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new
+                    Let |algorithm| be a new
                     {{HmacKeyAlgorithm}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`HMAC`".
+                    |algorithm| to "`HMAC`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{HmacKeyAlgorithm/length}} attribute of
-                    <var>algorithm</var> to <var>length</var>.
+                    |algorithm| to |length|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{HmacKeyAlgorithm/hash}} attribute of
-                    <var>algorithm</var> to <var>hash</var>.
+                    |algorithm| to |hash|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>
@@ -13647,91 +13647,91 @@ dictionary HmacKeyGenParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>bits</var> be the raw bits of the key represented by {{CryptoKey/[[handle]]}} internal slot of
-                    <var>key</var>.
+                    Let |bits| be the raw bits of the key represented by {{CryptoKey/[[handle]]}} internal slot of
+                    |key|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>data</var> be an [= octet string containing =] <var>bits</var>.
+                    Let |data| be an [= octet string containing =] |bits|.
                   </p>
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If <var>format</var> is {{KeyFormat/"raw"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>result</var> be a new {{ArrayBuffer}} associated with the
+                            Let |result| be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of `this` [[HTML]], and containing <var>data</var>.
+                            of `this` [[HTML]], and containing |data|.
                           </p>
                         </li>
                       </ol>
                     </dd>
-                    <dt>If <var>format</var> is {{KeyFormat/"jwk"}}:</dt>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            Let <var>jwk</var> be a new {{JsonWebKey}}
+                            Let |jwk| be a new {{JsonWebKey}}
                             dictionary.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `kty` attribute of <var>jwk</var> to the
+                            Set the `kty` attribute of |jwk| to the
                             string "`oct`".
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the {{JsonWebKey/k}} attribute of <var>jwk</var> to be a string
-                            containing <var>data</var>, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
+                            containing |data|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be the {{CryptoKey/[[algorithm]]}} internal slot of
-                            <var>key</var>.
+                            Let |algorithm| be the {{CryptoKey/[[algorithm]]}} internal slot of
+                            |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>hash</var> be the
+                            Let |hash| be the
                             {{HmacKeyAlgorithm/hash}} attribute of
-                            <var>algorithm</var>.
+                            |algorithm|.
                           </p>
                         </li>
 
                         <li>
                           <dl class="switch">
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is "`SHA-1`":</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |hash| is "`SHA-1`":</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`HS1`".</dd>
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is "`SHA-256`":</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |hash| is "`SHA-256`":</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`HS256`".</dd>
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is "`SHA-384`":</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |hash| is "`SHA-384`":</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`HS384`".</dd>
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is "`SHA-512`":</dt>
-                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            |hash| is "`SHA-512`":</dt>
+                            <dd>Set the `alg` attribute of |jwk| to
                             the string "`HS512`".</dd>
                             <dt>
                               Otherwise, the {{KeyAlgorithm/name}} attribute
-                              of <var>hash</var> is defined in
+                              of |hash| is defined in
                               <a href="#dfn-applicable-specification">another applicable
                               specification</a>:
                             </dt>
@@ -13741,14 +13741,14 @@ dictionary HmacKeyGenParams : Algorithm {
                                   <p>
                                     Perform any [= HMAC key export steps | key export steps =] defined by
                                     <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing <var>format</var> and <var>key</var>
-                                    and obtaining <var>alg</var>.
+                                    specifications</a>, passing |format| and |key|
+                                    and obtaining |alg|.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    Set the `alg` attribute of <var>jwk</var> to
-                                    <var>alg</var>.
+                                    Set the `alg` attribute of |jwk| to
+                                    |alg|.
                                   </p>
                                 </li>
                               </ol>
@@ -13757,19 +13757,19 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `key_ops` attribute of <var>jwk</var> to equal the
-                            {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of |jwk| to equal the
+                            {{CryptoKey/usages}} attribute of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of <var>key</var>.
+                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            of |key|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>result</var> be the result of converting <var>jwk</var>
+                            Let |result| be the result of converting |jwk|
                             to an ECMAScript Object, as defined by [[WebIDL]].
                           </p>
                         </li>
@@ -13786,7 +13786,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -13798,23 +13798,23 @@ dictionary HmacKeyGenParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{HmacImportParams/length}} member of
-                      <var>normalizedDerivedKeyAlgorithm</var> is not present:
+                      |normalizedDerivedKeyAlgorithm| is not present:
                     </dt>
                     <dd>
                       <p>
-                        Let <var>length</var> be the block size in bits of the hash function
+                        Let |length| be the block size in bits of the hash function
                         identified by the {{HmacImportParams/hash}} member
-                        of <var>normalizedDerivedKeyAlgorithm</var>.
+                        of |normalizedDerivedKeyAlgorithm|.
                       </p>
                     </dd>
                     <dt>
                       Otherwise, if the {{HmacImportParams/length}}
-                      member of <var>normalizedDerivedKeyAlgorithm</var> is non-zero:
+                      member of |normalizedDerivedKeyAlgorithm| is non-zero:
                     </dt>
                     <dd>
-                      Let <var>length</var> be equal to the
+                      Let |length| be equal to the
                       {{HmacImportParams/length}}
-                      member of <var>normalizedDerivedKeyAlgorithm</var>.
+                      member of |normalizedDerivedKeyAlgorithm|.
                     </dd>
                     <dt>Otherwise:</dt>
                     <dd>
@@ -13825,7 +13825,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>length</var>.
+                    Return |length|.
                   </p>
                 </li>
               </ol>
@@ -13878,43 +13878,43 @@ dictionary HmacKeyGenParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{Algorithm/name}} member of
-                      <var>normalizedAlgorithm</var> is a cases-sensitive string match for
+                      |normalizedAlgorithm| is a cases-sensitive string match for
                       "`SHA-1`":
                     </dt>
                     <dd>
-                      Let <var>result</var> be the result of performing the SHA-1 hash function
+                      Let |result| be the result of performing the SHA-1 hash function
                       defined in Section 6.1 of [[FIPS-180-4]] using
-                      <var>message</var> as the input message, <var>M</var>.
+                      |message| as the input message, |M|.
                     </dd>
                     <dt>
                       If the {{Algorithm/name}} member of
-                      <var>normalizedAlgorithm</var> is a cases-sensitive string match for
+                      |normalizedAlgorithm| is a cases-sensitive string match for
                       "`SHA-256`":
                     </dt>
                     <dd>
-                      Let <var>result</var> be the result of performing the SHA-256 hash function
+                      Let |result| be the result of performing the SHA-256 hash function
                       defined in Section 6.2 of [[FIPS-180-4]] using
-                      <var>message</var> as the input message, <var>M</var>.
+                      |message| as the input message, |M|.
                     </dd>
                     <dt>
                       If the {{Algorithm/name}} member of
-                      <var>normalizedAlgorithm</var> is a cases-sensitive string match for
+                      |normalizedAlgorithm| is a cases-sensitive string match for
                       "`SHA-384`":
                     </dt>
                     <dd>
-                      Let <var>result</var> be the result of performing the SHA-384 hash function
+                      Let |result| be the result of performing the SHA-384 hash function
                       defined in Section 6.5 of [[FIPS-180-4]] using
-                      <var>message</var> as the input message, <var>M</var>.
+                      |message| as the input message, |M|.
                     </dd>
                     <dt>
                       If the {{Algorithm/name}} member of
-                      <var>normalizedAlgorithm</var> is a cases-sensitive string match for
+                      |normalizedAlgorithm| is a cases-sensitive string match for
                       "`SHA-512`":
                     </dt>
                     <dd>
-                      Let <var>result</var> be the result of performing the SHA-1 hash function
+                      Let |result| be the result of performing the SHA-1 hash function
                       defined in Section 6.4 of [[FIPS-180-4]] using
-                      <var>message</var> as the input message, <var>M</var>.
+                      |message| as the input message, |M|.
                     </dd>
                   </dl>
                 </li>
@@ -13925,7 +13925,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new ArrayBuffer containing <var>result</var>.
+                    Return a new ArrayBuffer containing |result|.
                   </p>
                 </li>
               </ol>
@@ -14004,26 +14004,26 @@ dictionary HkdfParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>length</var> is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                    If |length| is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>extractKey</var> be a key equal to <var>n</var> zero bits where
-                    <var>n</var> is the size of the output of the hash function described by the
+                    Let |extractKey| be a key equal to |n| zero bits where
+                    |n| is the size of the output of the hash function described by the
                     {{HkdfParams/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>keyDerivationKey</var> be the secret represented by {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
+                    Let |keyDerivationKey| be the secret represented by {{CryptoKey/[[handle]]}} internal slot of |key|
                     as the message.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be the result of performing the HKDF extract and then
+                    Let |result| be the result of performing the HKDF extract and then
                     the HKDF expand step described in Section 2 of
                     [[RFC5869]] using:
                   </p>
@@ -14031,30 +14031,30 @@ dictionary HkdfParams : Algorithm {
                     <li>
                       <p>
                         the {{HkdfParams/hash}} member of
-                        <var>normalizedAlgorithm</var> as <var>Hash</var>,
+                        |normalizedAlgorithm| as |Hash|,
                       </p>
                     </li>
                     <li>
                       <p>
-                        <var>keyDerivationKey</var> as the input keying material,
-                        <var>IKM</var>,
+                        |keyDerivationKey| as the input keying material,
+                        |IKM|,
                       </p>
                     </li>
                     <li>
                       <p>
                         <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{HkdfParams/salt}} member of
-                        <var>normalizedAlgorithm</var> as <var>salt</var>,
+                        |normalizedAlgorithm| as |salt|,
                       </p>
                     </li>
                     <li>
                       <p>
                         <a href="#concept-contents-of-arraybuffer">the contents of</a> the {{HkdfParams/info}} member of
-                        <var>normalizedAlgorithm</var> as <var>info</var>,
+                        |normalizedAlgorithm| as |info|,
                       </p>
                     </li>
                     <li>
                       <p>
-                        <var>length</var> divided by 8 as the value of <var>L</var>,
+                        |length| divided by 8 as the value of |L|,
                       </p>
                     </li>
                   </ul>
@@ -14068,7 +14068,7 @@ dictionary HkdfParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -14077,18 +14077,18 @@ dictionary HkdfParams : Algorithm {
             <dd>
               <ol>
                 <li>
-                  <p>Let <var>keyData</var> be the key data to be imported.</p>
+                  <p>Let |keyData| be the key data to be imported.</p>
                 </li>
                 <li>
                   <dl class="switch">
                     <dt>
-                      If <var>format</var> is {{KeyFormat/"raw"}}:
+                      If |format| is {{KeyFormat/"raw"}}:
                     </dt>
                     <dd>
                       <ol>
                         <li>
                           <p>
-                            If <var>usages</var> contains a value that is not
+                            If |usages| contains a value that is not
                              "`deriveKey`" or "`deriveBits`",
 
                                 then [= exception/throw =] a
@@ -14097,52 +14097,52 @@ dictionary HkdfParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>extractable</var> is not `false`,
+                            If |extractable| is not `false`,
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>key</var> be a new {{CryptoKey}} associated with the
+                            Let |key| be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
                             of `this` [[HTML]], and
-                            representing the key data provided in <var>keyData</var>.
+                            representing the key data provided in |keyData|.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot of
-                            <var>key</var> to {{KeyType/"secret"}}.
+                            |key| to {{KeyType/"secret"}}.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[extractable]]}} internal slot of
-                            <var>key</var> to `false`.
+                            |key| to `false`.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>algorithm</var> be a new
+                            Let |algorithm| be a new
                             {{KeyAlgorithm}} object.
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to "`HKDF`".
+                            |algorithm| to "`HKDF`".
                           </p>
                         </li>
                         <li>
                           <p>
                             Set the {{CryptoKey/[[algorithm]]}} internal
-                            slot of <var>key</var> to <var>algorithm</var>.
+                            slot of |key| to |algorithm|.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Return <var>key</var>.
+                            Return |key|.
                           </p>
                         </li>
                       </ol>
@@ -14240,33 +14240,33 @@ dictionary Pbkdf2Params : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>length</var> is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                    If |length| is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If the {{Pbkdf2Params/iterations}} member of <var>normalizedAlgorithm</var> is zero,
+                    If the {{Pbkdf2Params/iterations}} member of |normalizedAlgorithm| is zero,
                     then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>prf</var> be the MAC Generation function described in Section 4 of
+                    Let |prf| be the MAC Generation function described in Section 4 of
                     [[FIPS-198-1]] using the hash function
                     described by the {{Pbkdf2Params/hash}} member of
-                    <var>normalizedAlgorithm</var>.
+                    |normalizedAlgorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be the result of performing the PBKDF2 operation defined
-                    in Section 5.2 of [[RFC8018]] using <var>prf</var> as the
-                    pseudo-random function, <var>PRF</var>, the password represented by {{CryptoKey/[[handle]]}} internal slot of <var>key</var>
-                    as the password, <var>P</var>, <a href="#concept-contents-of-arraybuffer">the
+                    Let |result| be the result of performing the PBKDF2 operation defined
+                    in Section 5.2 of [[RFC8018]] using |prf| as the
+                    pseudo-random function, |PRF|, the password represented by {{CryptoKey/[[handle]]}} internal slot of |key|
+                    as the password, |P|, <a href="#concept-contents-of-arraybuffer">the
                     contents of</a> the {{Pbkdf2Params/salt}} attribute of
-                    <var>normalizedAlgorithm</var> as the salt, <var>S</var>, the value of the {{Pbkdf2Params/iterations}} attribute of
-                    <var>normalizedAlgorithm</var> as the iteration count, <var>c</var>, and
-                    <var>length</var> divided by 8 as the intended key length, <var>dkLen</var>.
+                    |normalizedAlgorithm| as the salt, |S|, the value of the {{Pbkdf2Params/iterations}} attribute of
+                    |normalizedAlgorithm| as the iteration count, |c|, and
+                    |length| divided by 8 as the intended key length, |dkLen|.
                   </p>
                 </li>
                 <li>
@@ -14278,7 +14278,7 @@ dictionary Pbkdf2Params : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return <var>result</var>
+                    Return |result|
                   </p>
                 </li>
               </ol>
@@ -14288,64 +14288,64 @@ dictionary Pbkdf2Params : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>format</var> is not {{KeyFormat/"raw"}}, [= exception/throw =] a {{NotSupportedError}}
+                    If |format| is not {{KeyFormat/"raw"}}, [= exception/throw =] a {{NotSupportedError}}
                   </p>
                 </li>
                 <li>
                   <p>
-                    If <var>usages</var> contains a value that is not
+                    If |usages| contains a value that is not
                     "`deriveKey`"  or "`deriveBits`", then
                     [= exception/throw =] a {{SyntaxError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If <var>extractable</var> is not `false`,
+                    If |extractable| is not `false`,
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new {{CryptoKey}} associated with the
+                    Let |key| be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
                     of `this` [[HTML]], and
-                    representing <var>keyData</var>.
+                    representing |keyData|.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> to {{KeyType/"secret"}}.
+                    |key| to {{KeyType/"secret"}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal slot of
-                    <var>key</var> to `false`.
+                    |key| to `false`.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Let <var>algorithm</var> be a new {{KeyAlgorithm}}
+                    Let |algorithm| be a new {{KeyAlgorithm}}
                     object.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to "`PBKDF2`".
+                    |algorithm| to "`PBKDF2`".
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of <var>key</var> to <var>algorithm</var>.
+                    slot of |key| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Return <var>key</var>.
+                    Return |key|.
                   </p>
                 </li>
               </ol>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -266,7 +266,7 @@
         <p>
           Unless otherwise stated, string comparisons are done in a
           [= case-sensitive =] manner. String literals in this specification
-           written in monospace font like <code>"this"</code> do not include the enclosing quotes.
+           written in monospace font like "`this`" do not include the enclosing quotes.
         </p>
         <section id="extensibility">
           <h3>Extensibility</h3>
@@ -478,7 +478,7 @@
             same-origin security model; that is, any application that shares the same scheme, host,
             and port have access to the same storage partition, even if other information, such as
             the path, may differ. Authors may explicitly choose to relax this security through the
-            use of inter-origin sharing, such as <code>postMessage</code>.
+            use of inter-origin sharing, such as `postMessage`.
           </p>
           <p>
             Authors should be aware that this specification places no normative requirements on
@@ -501,7 +501,7 @@
           <p>
             Applications may share a {{CryptoKey}} object across security
             boundaries, such as origins, through the use of the structured clone algorithm and APIs
-            such as <code>postMessage</code>. While access to the underlying cryptographic key
+            such as `postMessage`. While access to the underlying cryptographic key
             material may be restricted, based upon the {{CryptoKey/extractable}}
             attribute, once a key is shared with a destination origin, the source origin can not
             later restrict or revoke access to the key. As such, authors must be careful to ensure
@@ -666,7 +666,7 @@
           <li>
             <p>
               Let <var>exactData</var> be an optional boolean value. If it is not supplied,
-              let it be initialized to <code>true</code>.
+              let it be initialized to `true`.
             </p>
           </li>
           <li>
@@ -696,14 +696,14 @@
           [= parse an ASN.1 structure =], with
           <var>data</var> set to the sequence of bytes to be parsed, <var>structure</var> as the
           ASN.1 structure of subjectPublicKeyInfo, as specified in [[RFC5280]],
-          and <var>exactData</var> set to <code>true</code>.
+          and <var>exactData</var> set to `true`.
         </p>
         <p>
           When this specification says to <dfn id="concept-parse-a-privateKeyInfo">parse a
           PrivateKeyInfo</dfn>, the user agent must [= parse
           an ASN.1 structure =] with <var>data</var> set to the sequence of bytes to be parsed,
           <var>structure</var> as the ASN.1 structure of PrivateKeyInfo, as specified in
-          [[RFC5208]], and <var>exactData</var> set to <code>true</code>.
+          [[RFC5208]], and <var>exactData</var> set to `true`.
         </p>
         <p>
           When this specification says to <dfn id="concept-parse-a-jwk">parse a JWK</dfn>, the user
@@ -729,8 +729,8 @@
           <li>
             <p>
               Let <var>result</var> be the object literal that results from executing the
-              <code>JSON.parse</code> internal function in the context of a new global object,
-              with <code>text</code> argument set to a JavaScript String containing <var>json</var>.
+              `JSON.parse` internal function in the context of a new global object,
+              with `text` argument set to a JavaScript String containing <var>json</var>.
             </p>
           </li>
           <li>
@@ -856,7 +856,7 @@ interface Crypto {
               </li>
               <li>
                 <p>
-                  If the <code>byteLength</code> of <var>array</var> is greater than 65536, [= exception/throw =] a
+                  If the `byteLength` of <var>array</var> is greater than 65536, [= exception/throw =] a
                   {{QuotaExceededError}} and
                   [= terminate the algorithm =].
                 </p>
@@ -875,7 +875,7 @@ interface Crypto {
             </ol>
             <div class=note>
               <p>
-                Do not generate keys using the <code>getRandomValues</code> method. Use the
+                Do not generate keys using the `getRandomValues` method. Use the
                 {{SubtleCrypto/generateKey}} method
                 instead.
               </p>
@@ -956,7 +956,7 @@ interface Crypto {
               For the steps described in the algorithm to [= generate a random UUID =],
               the <dfn>hexadecimal representation</dfn> of a byte |value| is the
               two-character string created by expressing |value| in hexadecimal using
-              [= ASCII lower hex digits =], left-padded with `"0"` to reach two
+              [= ASCII lower hex digits =], left-padded with "`0`" to reach two
               [= ASCII lower hex digits =].
             </p>
           </section>
@@ -1079,7 +1079,7 @@ interface CryptoKey {
             <dt id="dfn-KeyType"><dfn data-idl>KeyType</dfn></dt>
             <dd data-dfn-for=KeyType>
               The type of a key. The <dfn id="dfn-RecognizedKeyType">recognized key type values</dfn>
-              are <code>"public"</code>, <code>"private"</code> and <code>"secret"</code>.
+              are "`public`", "`private`" and "`secret`".
               Opaque keying material, including that used for symmetric algorithms, is represented by
               <dfn data-idl>secret</dfn>, while keys used as part of asymmetric algorithms composed of
               public/private keypairs will be either <dfn data-idl>public</dfn> or <dfn data-idl>private</dfn>.
@@ -1329,7 +1329,7 @@ interface SubtleCrypto {
           <p>
             Unless otherwise stated, objects created by the methods defined in this section shall be associated with the
             [= relevant global object =]
-            of <code>this</code> [[HTML]].
+            of `this` [[HTML]].
           </p>
           <div class=note>
             <p>
@@ -1351,7 +1351,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>algorithm</var> and <var>key</var> be the
-                  <code>algorithm</code> and <code>key</code> parameters
+                  `algorithm` and `key` parameters
                   passed to the {{SubtleCrypto/encrypt()}} method,
                   respectively.
                 </p>
@@ -1360,7 +1360,7 @@ interface SubtleCrypto {
                 <p>
                   Let <var>data</var> be the result of
                   [= get a copy of the buffer source |
-                  getting a copy of the bytes =] held by the <code>data</code> parameter passed to the
+                  getting a copy of the bytes =] held by the `data` parameter passed to the
                   {{SubtleCrypto/encrypt()}} method.
                 </p>
               </li>
@@ -1368,8 +1368,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"encrypt"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`encrypt`".
                 </p>
               </li>
               <li>
@@ -1409,7 +1409,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is <code>"encrypt"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                  <var>key</var> does not contain an entry that is "`encrypt`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
@@ -1440,7 +1440,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>algorithm</var> and <var>key</var> be the
-                  <code>algorithm</code> and <code>key</code>parameters
+                  `algorithm` and `key`parameters
                   passed to the {{SubtleCrypto/decrypt()}} method,
                   respectively.
                 </p>
@@ -1449,7 +1449,7 @@ interface SubtleCrypto {
                 <p>
                   Let <var>data</var> be the result of
                   [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the <code>data</code> parameter passed to the
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/decrypt()}} method.
                 </p>
               </li>
@@ -1457,8 +1457,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"decrypt"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`decrypt`".
                 </p>
               </li>
               <li>
@@ -1498,7 +1498,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is <code>"decrypt"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                  <var>key</var> does not contain an entry that is "`decrypt`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
@@ -1529,7 +1529,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>algorithm</var> and <var>key</var> be the
-                  <code>algorithm</code> and <code>key</code> parameters
+                  `algorithm` and `key` parameters
                   passed to the {{SubtleCrypto/sign()}} method,
                   respectively.
                 </p>
@@ -1538,7 +1538,7 @@ interface SubtleCrypto {
                 <p>
                   Let <var>data</var> be the result of
                   [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the <code>data</code> parameter passed to the
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/sign()}} method.
                 </p>
               </li>
@@ -1546,8 +1546,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"sign"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`sign`".
                 </p>
               </li>
               <li>
@@ -1587,7 +1587,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is <code>"sign"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                  <var>key</var> does not contain an entry that is "`sign`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
@@ -1617,7 +1617,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>algorithm</var> and <var>key</var>
-                  be the <code>algorithm</code> and <code>key</code> parameters passed to the
+                  be the `algorithm` and `key` parameters passed to the
                   {{SubtleCrypto/verify()}} method, respectively.
                 </p>
               </li>
@@ -1625,7 +1625,7 @@ interface SubtleCrypto {
                 <p>
                   Let <var>signature</var> be the result of
                   [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the <code>signature</code> parameter passed to the
+                  getting a copy of the bytes held by =] the `signature` parameter passed to the
                   {{SubtleCrypto/verify()}} method.
                 </p>
               </li>
@@ -1633,7 +1633,7 @@ interface SubtleCrypto {
                 <p>
                   Let <var>data</var> be the result of
                   [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the <code>data</code> parameter passed to the
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/verify()}} method.
                 </p>
               </li>
@@ -1641,8 +1641,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"verify"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`verify`".
                 </p>
               </li>
               <li>
@@ -1683,7 +1683,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>key</var> does not contain an entry that is <code>"verify"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                  <var>key</var> does not contain an entry that is "`verify`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
@@ -1714,7 +1714,7 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>algorithm</var> be the <code>algorithm</code> parameter passed to the
+                  Let <var>algorithm</var> be the `algorithm` parameter passed to the
                   {{SubtleCrypto/digest()}} method.
                 </p>
               </li>
@@ -1722,7 +1722,7 @@ interface SubtleCrypto {
                 <p>
                   Let <var>data</var> be the result of
                   [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the <code>data</code> parameter passed to the
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
                   {{SubtleCrypto/digest()}} method.
                 </p>
               </li>
@@ -1730,8 +1730,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"digest"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`digest`".
                 </p>
               </li>
               <li>
@@ -1786,7 +1786,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>algorithm</var>, <var>extractable</var> and <var>usages</var>
-                  be the <code>algorithm</code>, <code>extractable</code> and <code>keyUsages</code>
+                  be the `algorithm`, `extractable` and `keyUsages`
                   parameters passed to the
                   {{SubtleCrypto/generateKey()}} method,
                   respectively.
@@ -1796,8 +1796,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"generateKey"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`generateKey`".
                 </p>
               </li>
               <li>
@@ -1872,17 +1872,17 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>algorithm</var>, <var>baseKey</var>, <var>derivedKeyType</var>,
-                  <var>extractable</var> and <var>usages</var> be the <code>algorithm</code>,
-                  <code>baseKey</code>, <code>derivedKeyType</code>, <code>extractable</code> and
-                  <code>keyUsages</code> parameters passed to the {{SubtleCrypto/deriveKey()}} method, respectively.
+                  <var>extractable</var> and <var>usages</var> be the `algorithm`,
+                  `baseKey`, `derivedKeyType`, `extractable` and
+                  `keyUsages` parameters passed to the {{SubtleCrypto/deriveKey()}} method, respectively.
                 </p>
               </li>
               <li>
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"deriveBits"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`deriveBits`".
                 </p>
               </li>
               <li>
@@ -1895,8 +1895,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedDerivedKeyAlgorithmImport</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>derivedKeyType</var> and <code>op</code> set to
-                  <code>"importKey"</code>.
+                  `alg` set to <var>derivedKeyType</var> and `op` set to
+                  "`importKey`".
                 </p>
               </li>
               <li>
@@ -1909,8 +1909,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedDerivedKeyAlgorithmLength</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>derivedKeyType</var> and <code>op</code> set to
-                  <code>"get key length"</code>.
+                  `alg` set to <var>derivedKeyType</var> and `op` set to
+                  "`get key length`".
                 </p>
               </li>
               <li>
@@ -1950,7 +1950,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>baseKey</var> does not contain an entry that is <code>"deriveKey"</code>,
+                  <var>baseKey</var> does not contain an entry that is "`deriveKey`",
                   then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
@@ -1971,7 +1971,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>result</var> be the result of performing the import key operation
-                  specified by <var>normalizedDerivedKeyAlgorithmImport</var> using <code>"raw"</code> as
+                  specified by <var>normalizedDerivedKeyAlgorithmImport</var> using "`raw`" as
                   <var>format</var>, <var>secret</var> as <var>keyData</var>,
                   <var>derivedKeyType</var> as <var>algorithm</var> and using
                   <var>extractable</var> and <var>usages</var>.
@@ -2003,8 +2003,8 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>algorithm</var>, <var>baseKey</var> and <var>length</var>,
-                  be the <code>algorithm</code>,
-                  <code>baseKey</code> and <code>length</code>
+                  be the `algorithm`,
+                  `baseKey` and `length`
                   parameters passed to the
                   {{SubtleCrypto/deriveBits()}} method,
                   respectively.
@@ -2014,8 +2014,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"deriveBits"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`deriveBits`".
                 </p>
               </li>
               <li>
@@ -2055,7 +2055,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>baseKey</var> does not contain an entry that is <code>"deriveBits"</code>,
+                  <var>baseKey</var> does not contain an entry that is "`deriveBits`",
                   then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
@@ -2064,7 +2064,7 @@ interface SubtleCrypto {
                   Let <var>result</var> be a new {{ArrayBuffer}}
                   associated with the
                   [= relevant global object =]
-                  of <code>this</code> [[HTML]], and
+                  of `this` [[HTML]], and
                   containing the result of performing the derive bits operation
                   specified by <var>normalizedAlgorithm</var> using <var>baseKey</var>,
                   <var>algorithm</var> and <var>length</var>.
@@ -2088,8 +2088,8 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>format</var>, <var>algorithm</var>, <var>extractable</var> and
-                  <var>usages</var>, be the <code>format</code>, <code>algorithm</code>,
-                  <code>extractable</code> and <code>keyUsages</code> parameters passed to the {{SubtleCrypto/importKey()}} method, respectively.
+                  <var>usages</var>, be the `format`, `algorithm`,
+                  `extractable` and `keyUsages` parameters passed to the {{SubtleCrypto/importKey()}} method, respectively.
                 </p>
               </li>
               <li>
@@ -2102,7 +2102,7 @@ interface SubtleCrypto {
                     <ol>
                       <li>
                         <p>
-                          If the <code>keyData</code> parameter passed to the
+                          If the `keyData` parameter passed to the
                           {{SubtleCrypto/importKey()}} method is a
                           {{JsonWebKey}} dictionary, [= exception/throw =] a
                           {{TypeError}}.
@@ -2113,7 +2113,7 @@ interface SubtleCrypto {
                           Let <var>keyData</var> be the result of
                           [= get a copy of the buffer source |
                           getting a copy of the bytes held by =] the
-                          <code>keyData</code> parameter passed to the
+                          `keyData` parameter passed to the
                           {{SubtleCrypto/importKey()}} method.
                         </p>
                       </li>
@@ -2126,7 +2126,7 @@ interface SubtleCrypto {
                     <ol>
                       <li>
                         <p>
-                          If the <code>keyData</code> parameter passed to the
+                          If the `keyData` parameter passed to the
                           {{SubtleCrypto/importKey()}} method is not a
                           {{JsonWebKey}} dictionary, [= exception/throw =] a
                           {{TypeError}}.
@@ -2134,7 +2134,7 @@ interface SubtleCrypto {
                       </li>
                       <li>
                         <p>
-                          Let <var>keyData</var> be the <code>keyData</code> parameter passed to the
+                          Let <var>keyData</var> be the `keyData` parameter passed to the
                           {{SubtleCrypto/importKey()}} method.
                         </p>
                       </li>
@@ -2146,8 +2146,8 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"importKey"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`importKey`".
                 </p>
               </li>
               <li>
@@ -2234,8 +2234,8 @@ interface SubtleCrypto {
             <ol>
               <li>
                 <p>
-                  Let <var>format</var> and <var>key</var> be the <code>format</code> and
-                  <code>key</code> parameters passed to the {{SubtleCrypto/exportKey()}} method, respectively.
+                  Let <var>format</var> and <var>key</var> be the `format` and
+                  `key` parameters passed to the {{SubtleCrypto/exportKey()}} method, respectively.
                 </p>
               </li>
               <li>
@@ -2301,8 +2301,8 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>format</var>, <var>key</var>, <var>wrappingKey</var> and
-                  <var>algorithm</var> be the <code>format</code>, <code>key</code>,
-                  <code>wrappingKey</code> and <code>wrapAlgorithm</code> parameters passed to the
+                  <var>algorithm</var> be the `format`, `key`,
+                  `wrappingKey` and `wrapAlgorithm` parameters passed to the
                   {{SubtleCrypto/wrapKey()}} method,
                   respectively.
                 </p>
@@ -2311,16 +2311,16 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"wrapKey"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`wrapKey`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"encrypt"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`encrypt`".
                 </p>
               </li>
               <li>
@@ -2360,7 +2360,7 @@ interface SubtleCrypto {
               <li>
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
-                  <var>wrappingKey</var> does not contain an entry that is <code>"wrapKey"</code>,
+                  <var>wrappingKey</var> does not contain an entry that is "`wrapKey`",
                   then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
@@ -2420,7 +2420,7 @@ interface SubtleCrypto {
                         <p>
                           Let <var>json</var> be the result of representing <var>key</var> as a
                           UTF-16 string conforming to the JSON grammar; for example, by executing
-                          the <code>JSON.stringify</code> algorithm specified in
+                          the `JSON.stringify` algorithm specified in
                           [[ECMA-262]] in the context of a new global object.
                         </p>
                       </li>
@@ -2501,9 +2501,9 @@ interface SubtleCrypto {
                   Let <var>format</var>, <var>unwrappingKey</var>,
                   <var>algorithm</var>, <var>unwrappedKeyAlgorithm</var>,
                   <var>extractable</var> and <var>usages</var>,
-                  be the <code>format</code>, <code>unwrappingKey</code>,
-                  <code>unwrapAlgorithm</code>, <code>unwrappedKeyAlgorithm</code>,
-                  <code>extractable</code> and <code>keyUsages</code>
+                  be the `format`, `unwrappingKey`,
+                  `unwrapAlgorithm`, `unwrappedKeyAlgorithm`,
+                  `extractable` and `keyUsages`
                   parameters passed to the
                   {{SubtleCrypto/unwrapKey()}} method,
                   respectively.
@@ -2514,7 +2514,7 @@ interface SubtleCrypto {
                   Let <var>wrappedKey</var> be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the
-                  <code>wrappedKey</code> parameter passed to the
+                  `wrappedKey` parameter passed to the
                   {{SubtleCrypto/unwrapKey()}} method.
                 </p>
               </li>
@@ -2522,16 +2522,16 @@ interface SubtleCrypto {
                 <p>
                   Let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"unwrapKey"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`unwrapKey`".
                 </p>
               </li>
               <li>
                 <p>
                   If an error occurred, let <var>normalizedAlgorithm</var> be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>algorithm</var> and <code>op</code> set to
-                  <code>"decrypt"</code>.
+                  `alg` set to <var>algorithm</var> and `op` set to
+                  "`decrypt`".
                 </p>
               </li>
               <li>
@@ -2543,8 +2543,8 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let <var>normalizedKeyAlgorithm</var> be the result of <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  <code>alg</code> set to <var>unwrappedKeyAlgorithm</var> and <code>op</code> set
-                  to <code>"importKey"</code>.
+                  `alg` set to <var>unwrappedKeyAlgorithm</var> and `op` set
+                  to "`importKey`".
                 </p>
               </li>
               <li>
@@ -2585,7 +2585,7 @@ interface SubtleCrypto {
                 <p>
                   If the {{CryptoKey/[[usages]]}} internal slot of
                   <var>unwrappingKey</var> does not contain an entry that is
-                  <code>"unwrapKey"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                  "`unwrapKey`", then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>
@@ -2629,7 +2629,7 @@ interface SubtleCrypto {
                   <dd>
                     Let <var>bytes</var> be the result of executing the
                     [= parse a JWK =] algorithm, with <var>key</var>
-                    as the <code>data</code> to be parsed.
+                    as the `data` to be parsed.
                   </dd>
                 </dl>
               </li>
@@ -2725,7 +2725,7 @@ interface SubtleCrypto {
             until one is reached that explicitly describes procedures for catching exceptions.
             The error object thrown shall be associated with the
             [= relevant global object =]</a>
-            of <code>this</code> [[HTML]].
+            of `this` [[HTML]].
           </p>
         </section>
       </section>
@@ -2986,9 +2986,9 @@ dictionary CryptoKeyPair {
               <dd>
                 <p>
                   Return the result of running the <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a> algorithm, with
-                  the <code>alg</code> set to a new {{Algorithm}}
+                  the `alg` set to a new {{Algorithm}}
                   dictionary whose {{KeyAlgorithm/name}} attribute is
-                  <var>alg</var>, and with the <code>op</code> set to <var>op</var>.
+                  <var>alg</var>, and with the `op` set to <var>op</var>.
                 </p>
               </dd>
               <dt>If <var>alg</var> is an object:</dt>
@@ -2996,7 +2996,7 @@ dictionary CryptoKeyPair {
                 <ol>
                   <li>
                     Let <var>registeredAlgorithms</var> be the associative container stored at the
-                    <code>op</code> key of {{supportedAlgorithms}}.
+                    `op` key of {{supportedAlgorithms}}.
                   </li>
                   <li>
                     Let <var>initialAlg</var> be the result of converting the ECMAScript object
@@ -3033,7 +3033,7 @@ dictionary CryptoKeyPair {
                       </dd>
                       <dt>Otherwise:</dt>
                       <dd>
-                        Return a new <code>NotSupportedError</code> and terminate this algorithm.
+                        Return a new `NotSupportedError` and terminate this algorithm.
                       </dd>
                     </dl>
                   </li>
@@ -3094,8 +3094,8 @@ dictionary CryptoKeyPair {
                                 Set the dictionary member on <var>normalizedAlgorithm</var> with key
                                 name <var>key</var> to the result of
                                 <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>,
-                                with the <code>alg</code> set to <var>idlValue</var> and the
-                                <code>op</code> set to <code>"digest"</code>.
+                                with the `alg` set to <var>idlValue</var> and the
+                                `op` set to "`digest`".
                               </dd>
                               <dt>
                                 If <var>member</var> is of the type
@@ -3105,8 +3105,8 @@ dictionary CryptoKeyPair {
                                 Set the dictionary member on <var>normalizedAlgorithm</var> with key
                                 name <var>key</var> to the result of
                                 <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>,
-                                with the <code>alg</code> set to <var>idlValue</var> and the
-                                <code>op</code> set to the operation defined by the specification
+                                with the `alg` set to <var>idlValue</var> and the
+                                `op` set to the operation defined by the specification
                                 that defines the algorithm identified by <var>algName</var>.
                               </dd>
                             </dl>
@@ -3525,7 +3525,7 @@ dictionary CryptoKeyPair {
         <section id="rsassa-pkcs1-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"RSASSA-PKCS1-v1_5"</code> algorithm identifier is used to perform
+            The "`RSASSA-PKCS1-v1_5`" algorithm identifier is used to perform
             signing and verification using the RSASSA-PKCS1-v1_5 algorithm specified in
             [[RFC3447]] and using the SHA hash functions defined
             in this specification.
@@ -3542,7 +3542,7 @@ dictionary CryptoKeyPair {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"RSASSA-PKCS1-v1_5"</code>.
+            this algorithm is "`RSASSA-PKCS1-v1_5`".
           </p>
           <table>
             <thead>
@@ -3667,7 +3667,7 @@ dictionary RsaHashedImportParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and containing the
+                    of `this` [[HTML]], and containing the
                     bytes of <var>signature</var>.
                   </p>
                 </li>
@@ -3680,7 +3680,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                    <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
@@ -3714,7 +3714,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                     <code>"sign"</code> or <code>"verify"</code>,
+                     "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -3745,7 +3745,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"RSASSA-PKCS1-v1_5"</code>.
+                    <var>algorithm</var> to "`RSASSA-PKCS1-v1_5`".
                   </p>
                 </li>
                 <li>
@@ -3779,13 +3779,13 @@ dictionary RsaHashedImportParams : Algorithm {
                     Let <var>publicKey</var> be a new {{CryptoKey}}
                     object, associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and representing the public key of the generated key pair.
+                    of `this` [[HTML]], and representing the public key of the generated key pair.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to <code>"public"</code>
+                    <var>publicKey</var> to "`public`"
                   </p>
                 </li>
                 <li>
@@ -3804,14 +3804,14 @@ dictionary RsaHashedImportParams : Algorithm {
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>publicKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and <code>[ "verify" ]</code>.
+                    intersection =] of <var>usages</var> and `[ "verify" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
                     Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -3837,7 +3837,7 @@ dictionary RsaHashedImportParams : Algorithm {
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>privateKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and <code>[ "sign" ]</code>.
+                    intersection =] of <var>usages</var> and `[ "sign" ]`.
                   </p>
                 </li>
                 <li>
@@ -3880,7 +3880,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains an entry which is not
-                            <code>"verify"</code>,
+                            "`verify`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -3906,15 +3906,15 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the <code>algorithm</code> object identifier
-                            field of the <code>algorithm</code> AlgorithmIdentifier field of
+                            Let <var>alg</var> be the `algorithm` object identifier
+                            field of the `algorithm` AlgorithmIdentifier field of
                             <var>spki</var>.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>rsaEncryption</code>
+                              If <var>alg</var> is equivalent to the `rsaEncryption`
                               OID defined in Section 2.3.1 of [[RFC3279]]:
                             </dt>
                             <dd>
@@ -3924,42 +3924,42 @@ dictionary RsaHashedImportParams : Algorithm {
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha1WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha1WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3279]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-1"</code>.
+                                Let <var>hash</var> be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha256WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha256WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-256"</code>.
+                                Let <var>hash</var> be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha384WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha384WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-384"</code>.
+                                Let <var>hash</var> be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha512WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha512WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-512"</code>.
+                                Let <var>hash</var> be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -3998,8 +3998,8 @@ dictionary RsaHashedImportParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -4017,8 +4017,8 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             Let <var>publicKey</var> be the result of performing the [= parse an ASN.1 structure =]
                             algorithm, with <var>data</var> as the
-                            <code>subjectPublicKeyInfo</code> field of <var>spki</var>,
-                            <var>structure</var> as the <code>RSAPublicKey</code> structure
+                            `subjectPublicKeyInfo` field of <var>spki</var>,
+                            <var>structure</var> as the `RSAPublicKey` structure
                             specified in Section A.1.1 of [[RFC3447]], and
                             <var>exactData</var> set to true.
                           </p>
@@ -4035,7 +4035,7 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             Let <var>key</var> be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and
+                            of `this` [[HTML]], and
                             that represents the RSA public key identified by
                             <var>publicKey</var>.
                           </p>
@@ -4043,7 +4043,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to <code>"public"</code>
+                            of <var>key</var> to "`public`"
                           </p>
                         </li>
                       </ol>
@@ -4054,7 +4054,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains an entry which is not
-                             <code>"sign"</code>
+                             "`sign`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -4080,15 +4080,15 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the <code>algorithm</code> object identifier
-                            field of the <code>privateKeyAlgorithm</code>
+                            Let <var>alg</var> be the `algorithm` object identifier
+                            field of the `privateKeyAlgorithm`
                             PrivateKeyAlgorithmIdentifier field of <var>privateKeyInfo</var>.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>rsaEncryption</code>
+                              If <var>alg</var> is equivalent to the `rsaEncryption`
                               OID defined in Section 2.3.1 of [[RFC3279]]:
                             </dt>
                             <dd>
@@ -4098,42 +4098,42 @@ dictionary RsaHashedImportParams : Algorithm {
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha1WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha1WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3279]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-1"</code>.
+                                Let <var>hash</var> be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha256WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha256WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-256"</code>.
+                                Let <var>hash</var> be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha384WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha384WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-384"</code>.
+                                Let <var>hash</var> be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>sha512WithRSAEncryption</code> OID defined in Section A.2.4 of
+                              `sha512WithRSAEncryption` OID defined in Section A.2.4 of
                               [[RFC3447]]:
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-512"</code>.
+                                Let <var>hash</var> be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -4172,8 +4172,8 @@ dictionary RsaHashedImportParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -4191,8 +4191,8 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             Let <var>rsaPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
                             algorithm, with <var>data</var> as the
-                            <code>privateKey</code> field of <var>privateKeyInfo</var>,
-                            <var>structure</var> as the <code>RSAPrivateKey</code> structure
+                            `privateKey` field of <var>privateKeyInfo</var>,
+                            <var>structure</var> as the `RSAPrivateKey` structure
                             specified in Section A.1.2 of [[RFC3447]], and
                             <var>exactData</var> set to true.
                           </p>
@@ -4209,7 +4209,7 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             Let <var>key</var> be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and
+                            of `this` [[HTML]], and
                             that represents the RSA private key identified by
                             <var>rsaPrivateKey</var>.
                           </p>
@@ -4237,10 +4237,10 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             If the {{JsonWebKey/d}} field of <var>jwk</var> is present and
                             <var>usages</var> contains an entry which is not
-                            <code>"sign"</code>, or, if the {{JsonWebKey/d}} field of <var>jwk</var>
+                            "`sign`", or, if the {{JsonWebKey/d}} field of <var>jwk</var>
                             is not present and
                             <var>usages</var> contains an entry which is not
-                            <code>"verify"</code>
+                            "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -4248,7 +4248,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not a
-                            case-sensitive string match to <code>"RSA"</code>,
+                            case-sensitive string match to "`RSA`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -4256,7 +4256,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not a case-sensitive string match to <code>"sig"</code>,
+                            not a case-sensitive string match to "`sig`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -4298,38 +4298,38 @@ dictionary RsaHashedImportParams : Algorithm {
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"RS1"</code>:
+                              "`RS1`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-1"</code>.
+                                Let <var>hash</var> be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"RS256"</code>:
+                              "`RS256`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-256"</code>.
+                                Let <var>hash</var> be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"RS384"</code>:
+                              "`RS384`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-384"</code>.
+                                Let <var>hash</var> be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"RS512"</code>:
+                              "`RS512`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-512"</code>.
+                                Let <var>hash</var> be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -4368,8 +4368,8 @@ dictionary RsaHashedImportParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -4458,7 +4458,7 @@ dictionary RsaHashedImportParams : Algorithm {
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}}
-                                    internal slot of <var>key</var> to <code>"public"</code>
+                                    internal slot of <var>key</var> to "`public`"
                                   </p>
                                 </li>
                               </ol>
@@ -4483,7 +4483,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"RSASSA-PKCS1-v1_5"</code>
+                    <var>algorithm</var> to "`RSASSA-PKCS1-v1_5`"
                   </p>
                 </li>
                 <li>
@@ -4541,12 +4541,12 @@ dictionary RsaHashedImportParams : Algorithm {
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the <code>subjectPublicKeyInfo</code>
+                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -4554,14 +4554,14 @@ dictionary RsaHashedImportParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>algorithm</var> field to an
-                                <code>AlgorithmIdentifier</code> ASN.1 type with the following
+                                `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>rsaEncryption</code> defined in
+                                    `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
@@ -4575,7 +4575,7 @@ dictionary RsaHashedImportParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>subjectPublicKey</var> field to the result of
-                                DER-encoding an <code>RSAPublicKey</code> ASN.1 type, as defined
+                                DER-encoding an `RSAPublicKey` ASN.1 type, as defined
                                 in [[RFC3447]], Appendix A.1.1, that
                                 represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 <var>key</var>
@@ -4587,7 +4587,7 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -4616,14 +4616,14 @@ dictionary RsaHashedImportParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>privateKeyAlgorithm</var> field to a
-                                <code>PrivateKeyAlgorithmIdentifier</code> ASN.1 type with the
+                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>rsaEncryption</code> defined in
+                                    `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
@@ -4637,7 +4637,7 @@ dictionary RsaHashedImportParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>privateKey</var> field to the result of DER-encoding
-                                an <code>RSAPrivateKey</code> ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
+                                an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
                                 RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 <var>key</var>
                               </p>
@@ -4655,7 +4655,7 @@ dictionary RsaHashedImportParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -4669,8 +4669,8 @@ dictionary RsaHashedImportParams : Algorithm {
                           dictionary.</p>
                         </li>
                         <li>
-                          <p>Set the <code>kty</code> attribute of <var>jwk</var> to the string
-                          <code>"RSA"</code>.</p>
+                          <p>Set the `kty` attribute of <var>jwk</var> to the string
+                          "`RSA`".</p>
                         </li>
                         <li>
                           <p>
@@ -4682,32 +4682,32 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>hash</var> is <code>"SHA-1"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-1`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RS1"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RS1`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is <code>"SHA-256"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-256`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RS256"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RS256`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is <code>"SHA-384"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-384`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RS384"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RS384`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is <code>"SHA-512"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-512`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RS512"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RS512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -4733,7 +4733,7 @@ dictionary RsaHashedImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <code>alg</code> attribute of <var>jwk</var> to <var>alg</var>.
+                                    Set the `alg` attribute of <var>jwk</var> to <var>alg</var>.
                                   </p>
                                 </li>
                               </ol>
@@ -4776,12 +4776,12 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to the <a href="#dfn-CryptoKey-usages">usages</a> attribute of <var>key</var>.
+                            Set the `key_ops` attribute of <var>jwk</var> to the <a href="#dfn-CryptoKey-usages">usages</a> attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -4818,7 +4818,7 @@ dictionary RsaHashedImportParams : Algorithm {
         <section id="rsa-pss-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"RSA-PSS"</code> algorithm identifier is used to perform signing
+            The "`RSA-PSS`" algorithm identifier is used to perform signing
             and verification using the RSASSA-PSS algorithm specified in
             [[RFC3447]], using the SHA hash functions defined
             in this specification and the mask generation
@@ -4836,7 +4836,7 @@ dictionary RsaHashedImportParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"RSA-PSS"</code>.
+            this algorithm is "`RSA-PSS`".
           </p>
           <table>
             <thead>
@@ -4925,7 +4925,7 @@ dictionary RsaPssParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and containing the
+                    of `this` [[HTML]], and containing the
                     bytes of <var>signature</var>.
                   </p>
                 </li>
@@ -4938,7 +4938,7 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                    <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
@@ -4972,7 +4972,7 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                    <code>"sign"</code> or <code>"verify"</code>,
+                    "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -5003,7 +5003,7 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"RSA-PSS"</code>.
+                    <var>algorithm</var> to "`RSA-PSS`".
                   </p>
                 </li>
                 <li>
@@ -5036,14 +5036,14 @@ dictionary RsaPssParams : Algorithm {
                   <p>
                     Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the public key of the generated key pair.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to <code>"public"</code>
+                    <var>publicKey</var> to "`public`"
                   </p>
                 </li>
                 <li>
@@ -5062,14 +5062,14 @@ dictionary RsaPssParams : Algorithm {
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>publicKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and <code>[ "verify" ]</code>.
+                    intersection =] of <var>usages</var> and `[ "verify" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
                     Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -5095,7 +5095,7 @@ dictionary RsaPssParams : Algorithm {
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>privateKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and <code>[ "sign" ]</code>.
+                    intersection =] of <var>usages</var> and `[ "sign" ]`.
                   </p>
                 </li>
                 <li>
@@ -5139,7 +5139,7 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains an entry which is not
-                            <code>"verify"</code>
+                            "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -5165,15 +5165,15 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the <code>algorithm</code> object identifier
-                            field of the <code>algorithm</code> AlgorithmIdentifier field of
+                            Let <var>alg</var> be the `algorithm` object identifier
+                            field of the `algorithm` AlgorithmIdentifier field of
                             <var>spki</var>.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>rsaEncryption</code>
+                              If <var>alg</var> is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
@@ -5183,7 +5183,7 @@ dictionary RsaPssParams : Algorithm {
                             </dd>
                             <dt>
                               If <var>alg</var> is equivalent to the
-                              <code>id-RSASSA-PSS</code> OID defined in
+                              `id-RSASSA-PSS` OID defined in
                               [[RFC3447]]:
                             </dt>
                             <dd>
@@ -5191,14 +5191,14 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>params</var> be the ASN.1 structure contained within
-                                    the <code>parameters</code> field of the <code>algorithm</code>
+                                    the `parameters` field of the `algorithm`
                                     AlgorithmIdentifier field of <var>spki</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If <var>params</var> is not defined, or is not an instance of
-                                    the <code>RSASSA-PSS-params</code> ASN.1 type defined in
+                                    the `RSASSA-PSS-params` ASN.1 type defined in
                                     [[RFC3447]],
                                     [= exception/throw =] a
                                     {{DataError}}.
@@ -5207,49 +5207,49 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
-                                    within the <code>hashAlgorithm</code> field of <var>params</var>.
+                                    within the `hashAlgorithm` field of <var>params</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha1</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-1"</code>.
+                                        Set <var>hash</var> to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha256</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha256`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-256"</code>.
+                                        Set <var>hash</var> to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha384</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha384`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-384"</code>.
+                                        Set <var>hash</var> to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha512</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha512`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-512"</code>.
+                                        Set <var>hash</var> to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -5279,17 +5279,17 @@ dictionary RsaPssParams : Algorithm {
 
                                 <li>
                                   <p>
-                                    If the <code>algorithm</code> object identifier field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    equivalent to the OID <code>id-mgf1</code> defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
+                                    If the `algorithm` object identifier field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>parameters</code> field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    an instance of the <code>HashAlgorithm</code> ASN.1 type that is
-                                    identical in content to the <code>hashAlgorithm</code> field of
+                                    If the `parameters` field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    an instance of the `HashAlgorithm` ASN.1 type that is
+                                    identical in content to the `hashAlgorithm` field of
                                     <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
@@ -5315,8 +5315,8 @@ dictionary RsaPssParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -5334,8 +5334,8 @@ dictionary RsaPssParams : Algorithm {
                           <p>
                             Let <var>publicKey</var> be the result of performing the [= parse an ASN.1 structure =]
                             algorithm, with <var>data</var> as the
-                            <code>subjectPublicKeyInfo</code> field of <var>spki</var>,
-                            <var>structure</var> as the <code>RSAPublicKey</code> structure
+                            `subjectPublicKeyInfo` field of <var>spki</var>,
+                            <var>structure</var> as the `RSAPublicKey` structure
                             specified in Section A.1.1 of [[RFC3447]], and
                             <var>exactData</var> set to true.
                           </p>
@@ -5352,7 +5352,7 @@ dictionary RsaPssParams : Algorithm {
                           <p>
                             Let <var>key</var> be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and
+                            of `this` [[HTML]], and
                             that represents the RSA public key identified by
                             <var>publicKey</var>.
                           </p>
@@ -5360,7 +5360,7 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to <code>"public"</code>
+                            of <var>key</var> to "`public`"
                           </p>
                         </li>
                       </ol>
@@ -5371,7 +5371,7 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains an entry which is not
-                            <code>"sign"</code>
+                            "`sign`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -5395,15 +5395,15 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the <code>algorithm</code> object identifier
-                            field of the <code>privateKeyAlgorithm</code>
+                            Let <var>alg</var> be the `algorithm` object identifier
+                            field of the `privateKeyAlgorithm`
                             PrivateKeyAlgorithmIdentifier field of <var>privateKeyInfo</var>.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>rsaEncryption</code>
+                              If <var>alg</var> is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
@@ -5412,7 +5412,7 @@ dictionary RsaPssParams : Algorithm {
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>id-RSASSA-PSS</code> OID
+                              If <var>alg</var> is equivalent to the `id-RSASSA-PSS` OID
                               defined in [[RFC3447]]:
                             </dt>
                             <dd>
@@ -5420,15 +5420,15 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>params</var> be the ASN.1 structure contained within
-                                    the <code>parameters</code> field of the
-                                    <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier
+                                    the `parameters` field of the
+                                    `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier
                                     field of <var>privateKeyInfo</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If <var>params</var> is not defined, or is not an instance of
-                                    the <code>RSASSA-PSS-params</code> ASN.1 type defined in
+                                    the `RSASSA-PSS-params` ASN.1 type defined in
                                     [[RFC3447]],
                                     [= exception/throw =] a
                                     {{DataError}}.
@@ -5437,49 +5437,49 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
-                                    within the <code>hashAlgorithm</code> field of <var>params</var>.
+                                    within the `hashAlgorithm` field of <var>params</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha1</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-1"</code>.
+                                        Set <var>hash</var> to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha256</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha256`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-256"</code>.
+                                        Set <var>hash</var> to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha384</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha384`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-384"</code>.
+                                        Set <var>hash</var> to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha512</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha512`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-512"</code>.
+                                        Set <var>hash</var> to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -5508,17 +5508,17 @@ dictionary RsaPssParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>algorithm</code> object identifier field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    equivalent to the OID <code>id-mgf1</code> defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
+                                    If the `algorithm` object identifier field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>parameters</code> field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    an instance of the <code>HashAlgorithm</code> ASN.1 type that is
-                                    identical in content to the <code>hashAlgorithm</code> field of
+                                    If the `parameters` field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    an instance of the `HashAlgorithm` ASN.1 type that is
+                                    identical in content to the `hashAlgorithm` field of
                                     <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
@@ -5544,8 +5544,8 @@ dictionary RsaPssParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -5563,8 +5563,8 @@ dictionary RsaPssParams : Algorithm {
                           <p>
                             Let <var>rsaPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
                             algorithm, with <var>data</var> as the
-                            <code>privateKey</code> field of <var>privateKeyInfo</var>,
-                            <var>structure</var> as the <code>RSAPrivateKey</code> structure
+                            `privateKey` field of <var>privateKeyInfo</var>,
+                            <var>structure</var> as the `RSAPrivateKey` structure
                             specified in Section A.1.2 of [[RFC3447]], and
                             <var>exactData</var> set to true.
                           </p>
@@ -5581,7 +5581,7 @@ dictionary RsaPssParams : Algorithm {
                           <p>
                             Let <var>key</var> be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and
+                            of `this` [[HTML]], and
                             that represents the RSA private key identified by
                             <var>rsaPrivateKey</var>.
                           </p>
@@ -5609,10 +5609,10 @@ dictionary RsaPssParams : Algorithm {
                           <p>
                             If the {{JsonWebKey/d}} field of <var>jwk</var> is present and
                             <var>usages</var> contains an entry which is not
-                            <code>"sign"</code>, or, if the {{JsonWebKey/d}} field of <var>jwk</var>
+                            "`sign`", or, if the {{JsonWebKey/d}} field of <var>jwk</var>
                             is not present and
                             <var>usages</var> contains an entry which is not
-                            <code>"verify"</code>
+                            "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -5620,7 +5620,7 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not a
-                            case-sensitive string match to <code>"RSA"</code>,
+                            case-sensitive string match to "`RSA`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -5628,7 +5628,7 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not a case-sensitive string match to <code>"sig"</code>,
+                            not a case-sensitive string match to "`sig`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -5664,38 +5664,38 @@ dictionary RsaPssParams : Algorithm {
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"PS1"</code>:
+                              "`PS1`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-1"</code>.
+                                Let <var>hash</var> be the string "`SHA-1`".
                               </p>
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"PS256"</code>:
+                              "`PS256`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-256"</code>.
+                                Let <var>hash</var> be the string "`SHA-256`".
                               </p>
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"PS384"</code>:
+                              "`PS384`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-384"</code>.
+                                Let <var>hash</var> be the string "`SHA-384`".
                               </p>
                             </dd>
                             <dt>
                               If the {{JsonWebKey/alg}} field is equal to the string
-                              <code>"PS512"</code>:
+                              "`PS512`":
                             </dt>
                             <dd>
                               <p>
-                                Let <var>hash</var> be the string <code>"SHA-512"</code>.
+                                Let <var>hash</var> be the string "`SHA-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -5733,8 +5733,8 @@ dictionary RsaPssParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -5822,7 +5822,7 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}}
-                                    internal slot of <var>key</var> to <code>"public"</code>
+                                    internal slot of <var>key</var> to "`public`"
                                   </p>
                                 </li>
                               </ol>
@@ -5847,7 +5847,7 @@ dictionary RsaPssParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"RSA-PSS"</code>
+                    <var>algorithm</var> to "`RSA-PSS`"
                   </p>
                 </li>
                 <li>
@@ -5905,12 +5905,12 @@ dictionary RsaPssParams : Algorithm {
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the <code>subjectPublicKeyInfo</code>
+                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -5918,14 +5918,14 @@ dictionary RsaPssParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>algorithm</var> field to an
-                                <code>AlgorithmIdentifier</code> ASN.1 type with the following
+                                `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>rsaEncryption</code> defined in
+                                    `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
@@ -5939,7 +5939,7 @@ dictionary RsaPssParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>subjectPublicKey</var> field to the result of
-                                DER-encoding an <code>RSAPublicKey</code> ASN.1 type, as defined
+                                DER-encoding an `RSAPublicKey` ASN.1 type, as defined
                                 in [[RFC3447]], Appendix A.1.1, that
                                 represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 <var>key</var>
@@ -5951,7 +5951,7 @@ dictionary RsaPssParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -5980,14 +5980,14 @@ dictionary RsaPssParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>privateKeyAlgorithm</var> field to an
-                                <code>PrivateKeyAlgorithmIdentifier</code> ASN.1 type with the
+                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>rsaEncryption</code> defined in
+                                    `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
@@ -6001,7 +6001,7 @@ dictionary RsaPssParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>privateKey</var> field to the result of DER-encoding
-                                an <code>RSAPrivateKey</code> ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
+                                an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
                                 RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 <var>key</var>
                               </p>
@@ -6019,7 +6019,7 @@ dictionary RsaPssParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -6032,8 +6032,8 @@ dictionary RsaPssParams : Algorithm {
                           <p>Let <var>jwk</var> be a new {{JsonWebKey}} dictionary.</p>
                         </li>
                         <li>
-                          <p>Set the <code>kty</code> attribute of <var>jwk</var> to the string
-                          <code>"RSA"</code>.</p>
+                          <p>Set the `kty` attribute of <var>jwk</var> to the string
+                          "`RSA`".</p>
                         </li>
                         <li>
                           <p>
@@ -6045,32 +6045,32 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If <var>hash</var> is <code>"SHA-1"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-1`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"PS1"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`PS1`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is <code>"SHA-256"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-256`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"PS256"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`PS256`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is <code>"SHA-384"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-384`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"PS384"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`PS384`".
                               </p>
                             </dd>
-                            <dt>If <var>hash</var> is <code>"SHA-512"</code>:</dt>
+                            <dt>If <var>hash</var> is "`SHA-512`":</dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"PS512"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`PS512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -6089,7 +6089,7 @@ dictionary RsaPssParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <code>alg</code> attribute of <var>jwk</var> to <var>alg</var>.
+                                    Set the `alg` attribute of <var>jwk</var> to <var>alg</var>.
                                   </p>
                                 </li>
                               </ol>
@@ -6132,12 +6132,12 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -6174,7 +6174,7 @@ dictionary RsaPssParams : Algorithm {
         <section id="rsa-oaep-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"RSA-OAEP"</code> algorithm identifier is used to perform encryption
+            The "`RSA-OAEP`" algorithm identifier is used to perform encryption
             and decryption ordering to the RSAES-OAEP algorithm specified in
             [[RFC3447]], using the SHA hash functions defined
             in this specification and using the mask
@@ -6192,7 +6192,7 @@ dictionary RsaPssParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"RSA-OAEP"</code>.
+            this algorithm is "`RSA-OAEP`".
           </p>
           <table>
             <thead>
@@ -6250,7 +6250,7 @@ dictionary RsaOaepParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of <var>key</var>
-                    is not <code>"public"</code>,
+                    is not "`public`",
                     then [= exception/throw =] an
                     {{InvalidAccessError}}.
                   </p>
@@ -6292,7 +6292,7 @@ dictionary RsaOaepParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>ciphertext</var>.
                   </p>
                 </li>
@@ -6346,7 +6346,7 @@ dictionary RsaOaepParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>plaintext</var>.
                   </p>
                 </li>
@@ -6358,8 +6358,8 @@ dictionary RsaOaepParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                    <code>"encrypt"</code>, <code>"decrypt"</code>,
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                    "`encrypt`", "`decrypt`",
+                    "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -6390,7 +6390,7 @@ dictionary RsaOaepParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"RSA-OAEP"</code>.
+                    <var>algorithm</var> to "`RSA-OAEP`".
                   </p>
                 </li>
                 <li>
@@ -6423,14 +6423,14 @@ dictionary RsaOaepParams : Algorithm {
                   <p>
                     Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the public key of the generated key pair.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to <code>"public"</code>
+                    <var>publicKey</var> to "`public`"
                   </p>
                 </li>
                 <li>
@@ -6450,14 +6450,14 @@ dictionary RsaOaepParams : Algorithm {
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>publicKey</var> to be the
                     [= usage intersection =] of
-                    <var>usages</var> and <code>[ "encrypt", "wrapKey" ]</code>.
+                    <var>usages</var> and `[ "encrypt", "wrapKey" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
                     Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -6484,7 +6484,7 @@ dictionary RsaOaepParams : Algorithm {
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>privateKey</var> to be the
                     [= usage intersection =] of
-                    <var>usages</var> and <code>[ "decrypt", "unwrapKey" ]</code>.
+                    <var>usages</var> and `[ "decrypt", "unwrapKey" ]`.
                   </p>
                 </li>
                 <li>
@@ -6528,8 +6528,8 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains an entry which is not
-                            <code>"encrypt"</code> or
-                            <code>"wrapKey"</code>,
+                            "`encrypt`" or
+                            "`wrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -6555,15 +6555,15 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the <code>algorithm</code> object identifier
-                            field of the <code>algorithm</code> AlgorithmIdentifier field of
+                            Let <var>alg</var> be the `algorithm` object identifier
+                            field of the `algorithm` AlgorithmIdentifier field of
                             <var>spki</var>.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>rsaEncryption</code>
+                              If <var>alg</var> is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
@@ -6572,7 +6572,7 @@ dictionary RsaOaepParams : Algorithm {
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>id-RSAES-OAEP</code>
+                              If <var>alg</var> is equivalent to the `id-RSAES-OAEP`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
@@ -6580,14 +6580,14 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>params</var> be the ASN.1 structure contained within
-                                    the <code>parameters</code> field of the <code>algorithm</code>
+                                    the `parameters` field of the `algorithm`
                                     AlgorithmIdentifier field of <var>spki</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If <var>params</var> is not defined, or is not an instance of
-                                    the <code>RSAES-OAEP-params</code> ASN.1 type defined in
+                                    the `RSAES-OAEP-params` ASN.1 type defined in
                                     [[RFC3447]],
                                     [= exception/throw =] a
                                     {{DataError}}.
@@ -6596,49 +6596,49 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
-                                    within the <code>hashAlgorithm</code> field of <var>params</var>.
+                                    within the `hashAlgorithm` field of <var>params</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha1</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-1"</code>.
+                                        Set <var>hash</var> to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha256</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha256`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-256"</code>.
+                                        Set <var>hash</var> to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha384</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha384`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-384"</code>.
+                                        Set <var>hash</var> to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha512</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha512`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-512"</code>.
+                                        Set <var>hash</var> to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -6668,17 +6668,17 @@ dictionary RsaOaepParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>algorithm</code> object identifier field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    equivalent to the OID <code>id-mgf1</code> defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
+                                    If the `algorithm` object identifier field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>parameters</code> field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    an instance of the <code>HashAlgorithm</code> ASN.1 type that is
-                                    identical in content to the <code>hashAlgorithm</code> field of
+                                    If the `parameters` field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    an instance of the `HashAlgorithm` ASN.1 type that is
+                                    identical in content to the `hashAlgorithm` field of
                                     <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
@@ -6704,8 +6704,8 @@ dictionary RsaOaepParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -6723,8 +6723,8 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             Let <var>publicKey</var> be the result of performing the [= parse an ASN.1 structure =]
                             algorithm, with <var>data</var> as the
-                            <code>subjectPublicKeyInfo</code> field of <var>spki</var>,
-                            <var>structure</var> as the <code>RSAPublicKey</code> structure
+                            `subjectPublicKeyInfo` field of <var>spki</var>,
+                            <var>structure</var> as the `RSAPublicKey` structure
                             specified in Section A.1.1 of [[RFC3447]], and
                             <var>exactData</var> set to true.
                           </p>
@@ -6741,7 +6741,7 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             Let <var>key</var> be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and
+                            of `this` [[HTML]], and
                             that represents the RSA public key identified by
                             <var>publicKey</var>.
                           </p>
@@ -6749,7 +6749,7 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot of
-                            <var>key</var> to <code>"public"</code>
+                            <var>key</var> to "`public`"
                           </p>
                         </li>
                       </ol>
@@ -6760,7 +6760,7 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains an entry which is not
-                            <code>"decrypt"</code> or <code>"unwrapKey"</code>,
+                            "`decrypt`" or "`unwrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -6784,15 +6784,15 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>alg</var> be the <code>algorithm</code> object identifier
-                            field of the <code>privateKeyAlgorithm</code>
+                            Let <var>alg</var> be the `algorithm` object identifier
+                            field of the `privateKeyAlgorithm`
                             PrivateKeyAlgorithmIdentifier field of <var>privateKeyInfo</var>.
                           </p>
                         </li>
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>rsaEncryption</code>
+                              If <var>alg</var> is equivalent to the `rsaEncryption`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
@@ -6801,7 +6801,7 @@ dictionary RsaOaepParams : Algorithm {
                               </p>
                             </dd>
                             <dt>
-                              If <var>alg</var> is equivalent to the <code>id-RSAES-OAEP</code>
+                              If <var>alg</var> is equivalent to the `id-RSAES-OAEP`
                               OID defined in [[RFC3447]]:
                             </dt>
                             <dd>
@@ -6809,64 +6809,64 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>params</var> be the ASN.1 structure contained within
-                                    the <code>parameters</code> field of the
-                                    <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier
+                                    the `parameters` field of the
+                                    `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier
                                     field of <var>privateKeyInfo</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     If <var>params</var> is not defined, or is not an instance of
-                                    the <code>RSAES-OAEP-params</code> ASN.1 type defined in [[RFC3447]], [= exception/throw =] a {{DataError}}.
+                                    the `RSAES-OAEP-params` ASN.1 type defined in [[RFC3447]], [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Let <var>hashAlg</var> be the AlgorithmIdentifier ASN.1 type
-                                    within the <code>hashAlgorithm</code> field of
+                                    within the `hashAlgorithm` field of
                                     <var>params</var>.
                                   </p>
                                 </li>
                                 <li>
                                   <dl class="switch">
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
-                                      <var>hashAlg</var> is equivalent to the <code>id-sha1</code>
+                                      If the `algorithm` object identifier field of
+                                      <var>hashAlg</var> is equivalent to the `id-sha1`
                                       OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-1"</code>.
+                                        Set <var>hash</var> to the string "`SHA-1`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
+                                      If the `algorithm` object identifier field of
                                       <var>hashAlg</var> is equivalent to the
-                                      <code>id-sha256</code> OID defined in [[RFC3447]]:
+                                      `id-sha256` OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-256"</code>.
+                                        Set <var>hash</var> to the string "`SHA-256`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
+                                      If the `algorithm` object identifier field of
                                       <var>hashAlg</var> is equivalent to the
-                                      <code>id-sha384</code> OID defined in [[RFC3447]]:
+                                      `id-sha384` OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-384"</code>.
+                                        Set <var>hash</var> to the string "`SHA-384`".
                                       </p>
                                     </dd>
                                     <dt>
-                                      If the <code>algorithm</code> object identifier field of
+                                      If the `algorithm` object identifier field of
                                       <var>hashAlg</var> is equivalent to the
-                                      <code>id-sha512</code> OID defined in [[RFC3447]]:
+                                      `id-sha512` OID defined in [[RFC3447]]:
                                     </dt>
                                     <dd>
                                       <p>
-                                        Set <var>hash</var> to the string <code>"SHA-512"</code>.
+                                        Set <var>hash</var> to the string "`SHA-512`".
                                       </p>
                                     </dd>
                                     <dt>Otherwise:</dt>
@@ -6895,17 +6895,17 @@ dictionary RsaOaepParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>algorithm</code> object identifier field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    equivalent to the OID <code>id-mgf1</code> defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
+                                    If the `algorithm` object identifier field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    equivalent to the OID `id-mgf1` defined in [[RFC3447]], [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>parameters</code> field of the
-                                    <code>maskGenAlgorithm</code> field of <var>params</var> is not
-                                    an instance of the <code>HashAlgorithm</code> ASN.1 type that is
-                                    identical in content to the <code>hashAlgorithm</code> field of
+                                    If the `parameters` field of the
+                                    `maskGenAlgorithm` field of <var>params</var> is not
+                                    an instance of the `HashAlgorithm` ASN.1 type that is
+                                    identical in content to the `hashAlgorithm` field of
                                     <var>params</var>, [= exception/throw =] a {{NotSupportedError}}.
                                   </p>
                                 </li>
@@ -6931,8 +6931,8 @@ dictionary RsaOaepParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -6950,8 +6950,8 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             Let <var>rsaPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
                             algorithm, with <var>data</var> as the
-                            <code>privateKey</code> field of <var>privateKeyInfo</var>,
-                            <var>structure</var> as the <code>RSAPrivateKey</code> structure
+                            `privateKey` field of <var>privateKeyInfo</var>,
+                            <var>structure</var> as the `RSAPrivateKey` structure
                             specified in Section A.1.2 of [[RFC3447]], and
                             <var>exactData</var> set to true.
                           </p>
@@ -6968,7 +6968,7 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             Let <var>key</var> be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and
+                            of `this` [[HTML]], and
                             that represents the RSA private key identified by
                             <var>rsaPrivateKey</var>.
                           </p>
@@ -6996,7 +6996,7 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             If the {{JsonWebKey/d}} field of <var>jwk</var> is present and
                             <var>usages</var> contains an entry which is not
-                            <code>"decrypt"</code> or <code>"unwrapKey"</code>,
+                            "`decrypt`" or "`unwrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -7005,7 +7005,7 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             If the {{JsonWebKey/d}} field of <var>jwk</var> is not present and
                             <var>usages</var> contains an entry which is not
-                            <code>"encrypt"</code> or <code>"wrapKey"</code>,
+                            "`encrypt`" or "`wrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -7013,7 +7013,7 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not a
-                            case-sensitive string match to <code>"RSA"</code>,
+                            case-sensitive string match to "`RSA`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -7021,7 +7021,7 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not a case-sensitive string match to <code>"enc"</code>,
+                            not a case-sensitive string match to "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -7046,28 +7046,28 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <dl class="switch">
-                            <dt>If the <code>alg</code> field of <var>jwk</var> is not present:</dt>
+                            <dt>If the `alg` field of <var>jwk</var> is not present:</dt>
                             <dd>Let <var>hash</var> be undefined.</dd>
                             <dt>
-                              If the <code>alg</code> field of <var>jwk</var> is equal to
-                              <code>"RSA-OAEP"</code>:
+                              If the `alg` field of <var>jwk</var> is equal to
+                              "`RSA-OAEP`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string <code>"SHA-1"</code>.</dd>
+                            <dd>Let <var>hash</var> be the string "`SHA-1`".</dd>
                             <dt>
-                              If the <code>alg</code> field of <var>jwk</var> is equal to
-                              <code>"RSA-OAEP-256"</code>:
+                              If the `alg` field of <var>jwk</var> is equal to
+                              "`RSA-OAEP-256`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string <code>"SHA-256"</code>.</dd>
+                            <dd>Let <var>hash</var> be the string "`SHA-256`".</dd>
                             <dt>
-                              If the <code>alg</code> field of <var>jwk</var> is equal to
-                              <code>"RSA-OAEP-384"</code>:
+                              If the `alg` field of <var>jwk</var> is equal to
+                              "`RSA-OAEP-384`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string <code>"SHA-384"</code>.</dd>
+                            <dd>Let <var>hash</var> be the string "`SHA-384`".</dd>
                             <dt>
-                              If the <code>alg</code> field of <var>jwk</var> is equal to
-                              <code>"RSA-OAEP-512"</code>:
+                              If the `alg` field of <var>jwk</var> is equal to
+                              "`RSA-OAEP-512`":
                             </dt>
-                            <dd>Let <var>hash</var> be the string <code>"SHA-512"</code>.</dd>
+                            <dd>Let <var>hash</var> be the string "`SHA-512`".</dd>
                             <dt>Otherwise:</dt>
                             <dd>
                               <ol>
@@ -7103,8 +7103,8 @@ dictionary RsaOaepParams : Algorithm {
                                   <p>
                                     Let <var>normalizedHash</var> be the result of
                                     <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with <code>alg</code> set to <var>hash</var> and <code>op</code> set
-                                    to <code>digest</code>.
+                                    with `alg` set to <var>hash</var> and `op` set
+                                    to `digest`.
                                   </p>
                                 </li>
                                 <li>
@@ -7189,7 +7189,7 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     Set the {{CryptoKey/[[type]]}} internal slot of
-                                    <var>key</var> to <code>"public"</code>
+                                    <var>key</var> to "`public`"
                                   </p>
                                 </li>
                               </ol>
@@ -7214,7 +7214,7 @@ dictionary RsaOaepParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"RSA-OAEP"</code>
+                    <var>algorithm</var> to "`RSA-OAEP`"
                   </p>
                 </li>
                 <li>
@@ -7272,12 +7272,12 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot of
-                            <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                            <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the <code>subjectPublicKeyInfo</code>
+                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -7285,14 +7285,14 @@ dictionary RsaOaepParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>algorithm</var> field to an
-                                <code>AlgorithmIdentifier</code> ASN.1 type with the following
+                                `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>rsaEncryption</code> defined in
+                                    `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
@@ -7306,7 +7306,7 @@ dictionary RsaOaepParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>subjectPublicKey</var> field to the result of
-                                DER-encoding an <code>RSAPublicKey</code> ASN.1 type, as defined
+                                DER-encoding an `RSAPublicKey` ASN.1 type, as defined
                                 in [[RFC3447]], Appendix A.1.1, that
                                 represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 <var>key</var>
@@ -7318,7 +7318,7 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -7347,14 +7347,14 @@ dictionary RsaOaepParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>privateKeyAlgorithm</var> field to an
-                                <code>PrivateKeyAlgorithmIdentifier</code> ASN.1 type with the
+                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>rsaEncryption</code> defined in
+                                    `rsaEncryption` defined in
                                     [[RFC3447]].
                                   </p>
                                 </li>
@@ -7368,7 +7368,7 @@ dictionary RsaOaepParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>privateKey</var> field to the result of DER-encoding
-                                an <code>RSAPrivateKey</code> ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
+                                an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
                                 RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 <var>key</var>
                               </p>
@@ -7386,7 +7386,7 @@ dictionary RsaOaepParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -7403,8 +7403,8 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to the string
-                            <code>"RSA"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to the string
+                            "`RSA`".
                           </p>
                         </li>
                         <li>
@@ -7418,39 +7418,39 @@ dictionary RsaOaepParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>hash</var> is <code>"SHA-1"</code>:
+                              If <var>hash</var> is "`SHA-1`":
                             </dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RSA-OAEP"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RSA-OAEP`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>hash</var> is <code>"SHA-256"</code>:
+                              If <var>hash</var> is "`SHA-256`":
                             </dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RSA-OAEP-256"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RSA-OAEP-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>hash</var> is <code>"SHA-384"</code>:
+                              If <var>hash</var> is "`SHA-384`":
                             </dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RSA-OAEP-384"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RSA-OAEP-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>hash</var> is <code>"SHA-512"</code>:
+                              If <var>hash</var> is "`SHA-512`":
                             </dt>
                             <dd>
                               <p>
-                                Set the <code>alg</code> attribute of <var>jwk</var> to the string
-                                <code>"RSA-OAEP-512"</code>.
+                                Set the `alg` attribute of <var>jwk</var> to the string
+                                "`RSA-OAEP-512`".
                               </p>
                             </dd>
                             <dt>Otherwise:</dt>
@@ -7469,7 +7469,7 @@ dictionary RsaOaepParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <code>alg</code> attribute of <var>jwk</var> to <var>alg</var>.
+                                    Set the `alg` attribute of <var>jwk</var> to <var>alg</var>.
                                   </p>
                                 </li>
                               </ol>
@@ -7512,12 +7512,12 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -7554,7 +7554,7 @@ dictionary RsaOaepParams : Algorithm {
         <section id="ecdsa-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"ECDSA"</code> algorithm identifier is used to perform signing
+            The "`ECDSA`" algorithm identifier is used to perform signing
             and verification using the ECDSA algorithm specified in
             [[RFC6090]] and using the SHA hash functions and elliptic
             curves defined in this specification.
@@ -7577,7 +7577,7 @@ dictionary RsaOaepParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"ECDSA"</code>.
+            this algorithm is "`ECDSA`".
           </p>
           <table>
             <thead>
@@ -7641,12 +7641,12 @@ dictionary EcKeyGenParams : Algorithm {
             curves. The following values defined by this specification:
           </p>
           <dl>
-            <dt id="dfn-NamedCurve-p256"><code>"P-256"</code></dt>
-            <dd>NIST recommended curve P-256, also known as <code>secp256r1</code>.</dd>
-            <dt id="dfn-NamedCurve-p2384"><code>"P-384"</code></dt>
-            <dd>NIST recommended curve P-384, also known as <code>secp384r1</code>.</dd>
-            <dt id="dfn-NamedCurve-p521"><code>"P-521"</code></dt>
-            <dd>NIST recommended curve P-521, also known as <code>secp521r1</code>.</dd>
+            <dt id="dfn-NamedCurve-p256">"`P-256`"</dt>
+            <dd>NIST recommended curve P-256, also known as `secp256r1`.</dd>
+            <dt id="dfn-NamedCurve-p2384">"`P-384`"</dt>
+            <dd>NIST recommended curve P-384, also known as `secp384r1`.</dd>
+            <dt id="dfn-NamedCurve-p521">"`P-521`"</dt>
+            <dd>NIST recommended curve P-521, also known as `secp521r1`.</dd>
           </dl>
           <p>
             <a href="#dfn-applicable-specification">Other specifications</a> may define
@@ -7714,7 +7714,7 @@ dictionary EcKeyImportParams : Algorithm {
                     <dt>
                       If the {{EcKeyAlgorithm/namedCurve}} attribute of the
                       {{CryptoKey/[[algorithm]]}} internal slot of
-                      <var>key</var> is <code>"P-256"</code>, <code>"P-384"</code> or <code>"P-521"</code>:
+                      <var>key</var> is "`P-256`", "`P-384`" or "`P-521`":
                     </dt>
                     <dd>
                       <ol>
@@ -7735,7 +7735,7 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new empty {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]].
+                            of `this` [[HTML]].
                           </p>
                         </li>
                         <li>
@@ -7778,7 +7778,7 @@ dictionary EcKeyImportParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and containing the
+                    of `this` [[HTML]], and containing the
                     bytes of <var>result</var>.
                   </p>
                 </li>
@@ -7791,7 +7791,7 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                    <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
@@ -7823,7 +7823,7 @@ dictionary EcKeyImportParams : Algorithm {
                     <dt>
                       If the {{EcKeyAlgorithm/namedCurve}} attribute of the
                       {{CryptoKey/[[algorithm]]}} internal slot of
-                      <var>key</var> is <code>"P-256"</code>, <code>"P-384"</code> or <code>"P-521"</code>:
+                      <var>key</var> is "`P-256`", "`P-384`" or "`P-521`":
                     </dt>
                     <dd>
                       <p>
@@ -7851,8 +7851,8 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>result</var> be a boolean with the value <code>true</code> if the signature is valid
-                    and the value <code>false</code> otherwise.
+                    Let <var>result</var> be a boolean with the value `true` if the signature is valid
+                    and the value `false` otherwise.
                   </p>
                 </li>
                 <li>
@@ -7868,7 +7868,7 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains a value which is not
-                    one of <code>"sign"</code> or <code>"verify"</code>,
+                    one of "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -7877,8 +7877,8 @@ dictionary EcKeyImportParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{EcKeyGenParams/namedCurve}} member of
-                      <var>normalizedAlgorithm</var> is <code>"P-256"</code>, <code>"P-384"</code>
-                      or <code>"P-521"</code>:
+                      <var>normalizedAlgorithm</var> is "`P-256`", "`P-384`"
+                      or "`P-521`":
                     </dt>
                     <dd>
                       <p>
@@ -7926,7 +7926,7 @@ dictionary EcKeyImportParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"ECDSA"</code>.
+                    <var>algorithm</var> to "`ECDSA`".
                   </p>
                 </li>
                 <li>
@@ -7941,14 +7941,14 @@ dictionary EcKeyImportParams : Algorithm {
                   <p>
                     Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the public key of the generated key pair.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to <code>"public"</code>
+                    <var>publicKey</var> to "`public`"
                   </p>
                 </li>
                 <li>
@@ -7967,14 +7967,14 @@ dictionary EcKeyImportParams : Algorithm {
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>publicKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and <code>[ "verify" ]</code>.
+                    intersection =] of <var>usages</var> and `[ "verify" ]`.
                   </p>
                 </li>
                 <li>
                   <p>
                     Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -8000,7 +8000,7 @@ dictionary EcKeyImportParams : Algorithm {
                   <p>
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>privateKey</var> to be the [= usage
-                    intersection =] of <var>usages</var> and <code>[ "sign" ]</code>.
+                    intersection =] of <var>usages</var> and `[ "sign" ]`.
                   </p>
                 </li>
                 <li>
@@ -8044,7 +8044,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains a value which is not
-                            <code>"verify"</code>
+                            "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -8065,9 +8065,9 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the <code>algorithm</code> object identifier field of the
-                            <code>algorithm</code> AlgorithmIdentifier field of <var>spki</var> is
-                            not equal to the <code>id-ecPublicKey</code>
+                            If the `algorithm` object identifier field of the
+                            `algorithm` AlgorithmIdentifier field of <var>spki</var> is
+                            not equal to the `id-ecPublicKey`
                             object identifier defined in [[RFC5480]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8075,7 +8075,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the <code>parameters</code> field of the <code>algorithm</code>
+                            If the `parameters` field of the `algorithm`
                             AlgorithmIdentifier field of <var>spki</var> is absent,
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8083,16 +8083,16 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the <code>parameters</code> field of the
-                            <code>algorithm</code> AlgorithmIdentifier field of <var>spki</var>.
+                            Let <var>params</var> be the `parameters` field of the
+                            `algorithm` AlgorithmIdentifier field of <var>spki</var>.
                           </p>
                         </li>
                         <li>
                           <p>
                             If <var>params</var> is not an instance of the
-                            <code>ECParameters</code> ASN.1 type defined in
+                            `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
-                            <code>namedCurve</code>, then [= exception/throw =] a {{DataError}}.
+                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
@@ -8104,30 +8104,30 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp256r1</code>
+                              If <var>params</var> is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-256"</code>.
+                                Set <var>namedCurve</var> "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp384r1</code>
+                              If <var>params</var> is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-384"</code>.
+                                Set <var>namedCurve</var> "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp521r1</code>
+                              If <var>params</var> is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-521"</code>.
+                                Set <var>namedCurve</var> "`P-521`".
                               </p>
                             </dd>
                           </dl>
@@ -8140,7 +8140,7 @@ dictionary EcKeyImportParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>publicKey</var> be the Elliptic Curve public key identified by
-                                    performing the conversion steps defined in Section 2.3.4 of [[SEC1]] using the <code>subjectPublicKey</code>
+                                    performing the conversion steps defined in Section 2.3.4 of [[SEC1]] using the `subjectPublicKey`
                                     field of <var>spki</var>.
                                   </p>
                                   <p>
@@ -8166,7 +8166,7 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
-                                    of <code>this</code> [[HTML]], and
+                                    of `this` [[HTML]], and
                                     that represents <var>publicKey</var>.
                                   </p>
                                 </li>
@@ -8212,7 +8212,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to <code>"public"</code>
+                            of <var>key</var> to "`public`"
                           </p>
                         </li>
                         <li>
@@ -8223,7 +8223,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDSA"</code>.
+                            <var>algorithm</var> to "`ECDSA`".
                           </p>
                         </li>
                         <li>
@@ -8246,7 +8246,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains a value which is not
-                            <code>"sign"</code>
+                            "`sign`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -8267,18 +8267,18 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the <code>algorithm</code> object identifier field of the
-                            <code>privateKeyAlgorithm</code> PrivateKeyAlgorithm field of
+                            If the `algorithm` object identifier field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
                             <var>privateKeyInfo</var> is not equal to the
-                            <code>id-ecPublicKey</code> object identifier defined in [[RFC5480]],
+                            `id-ecPublicKey` object identifier defined in [[RFC5480]],
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            If the <code>parameters</code> field of the
-                            <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier field
+                            If the `parameters` field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
                             of <var>privateKeyInfo</var> is not present,
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -8286,17 +8286,17 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the <code>parameters</code> field of the
-                            <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier field
+                            Let <var>params</var> be the `parameters` field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
                             of <var>privateKeyInfo</var>.
                           </p>
                         </li>
                         <li>
                           <p>
                             If <var>params</var> is not an instance of the
-                            <code>ECParameters</code> ASN.1 type defined in
+                            `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
-                            <code>namedCurve</code>, then [= exception/throw =] a {{DataError}}.
+                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
@@ -8308,30 +8308,30 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp256r1</code>
+                              If <var>params</var> is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-256"</code>.
+                                Set <var>namedCurve</var> "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp384r1</code>
+                              If <var>params</var> is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-384"</code>.
+                                Set <var>namedCurve</var> "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp521r1</code>
+                              If <var>params</var> is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-521"</code>.
+                                Set <var>namedCurve</var> "`P-521`".
                               </p>
                             </dd>
                           </dl>
@@ -8344,9 +8344,9 @@ dictionary EcKeyImportParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>ecPrivateKey</var> be the result of performing the [= parse an ASN.1 structure =]
-                                    algorithm, with <var>data</var> as the <code>privateKey</code> field
+                                    algorithm, with <var>data</var> as the `privateKey` field
                                     of <var>privateKeyInfo</var>, <var>structure</var> as the ASN.1
-                                    <code>ECPrivateKey</code> structure specified in Section 3 of [[RFC5915]], and <var>exactData</var> set to true.
+                                    `ECPrivateKey` structure specified in Section 3 of [[RFC5915]], and <var>exactData</var> set to true.
                                   </p>
                                 </li>
                                 <li>
@@ -8358,11 +8358,11 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>parameters</code> field of <var>ecPrivateKey</var> is
-                                    present, and is not an instance of the <code>namedCurve</code> ASN.1
+                                    If the `parameters` field of <var>ecPrivateKey</var> is
+                                    present, and is not an instance of the `namedCurve` ASN.1
                                     type defined in [[RFC5480]], or does not contain
-                                    the same object identifier as the <code>parameters</code> field of the
-                                    <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier field
+                                    the same object identifier as the `parameters` field of the
+                                    `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
                                     of <var>privateKeyInfo</var>,
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -8372,7 +8372,7 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
-                                    of <code>this</code> [[HTML]], and
+                                    of `this` [[HTML]], and
                                     that represents the Elliptic Curve private key identified by
                                     performing the conversion steps defined in Section 3 of [[RFC5915]] using <var>ecPrivateKey</var>.
                                   </p>
@@ -8430,7 +8430,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDSA"</code>.
+                            <var>algorithm</var> to "`ECDSA`".
                           </p>
                         </li>
                         <li>
@@ -8462,10 +8462,10 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             If the {{JsonWebKey/d}} field is present and <var>usages</var> contains
                             a value which is not
-                            <code>"sign"</code>, or,
+                            "`sign`", or,
                             if the {{JsonWebKey/d}} field is not present and <var>usages</var> contains
                             a value which is not
-                            <code>"verify"</code>
+                            "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -8473,7 +8473,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
-                            <code>"EC"</code>,
+                            "`EC`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -8481,7 +8481,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not  <code>"sig"</code>,
+                            not  "`sig`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -8519,8 +8519,8 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is equal to <code>"P-256"</code>,
-                              <code>"P-384"</code> or <code>"P-521"</code>:
+                              If <var>namedCurve</var> is equal to "`P-256`",
+                              "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
                               <ol>
@@ -8540,19 +8540,19 @@ dictionary EcKeyImportParams : Algorithm {
                                       If the {{JsonWebKey/alg}} field is equal to the string "ES256":
                                     </dt>
                                     <dd>
-                                      Let <var>algNamedCurve</var> be the string <code>"P-256"</code>.
+                                      Let <var>algNamedCurve</var> be the string "`P-256`".
                                     </dd>
                                     <dt>
                                       If the {{JsonWebKey/alg}} field is equal to the string "ES384":
                                     </dt>
                                     <dd>
-                                      Let <var>algNamedCurve</var> be the string <code>"P-384"</code>.
+                                      Let <var>algNamedCurve</var> be the string "`P-384`".
                                     </dd>
                                     <dt>
                                       If the {{JsonWebKey/alg}} field is equal to the string "ES512":
                                     </dt>
                                     <dd>
-                                      Let <var>algNamedCurve</var> be the string <code>"P-521"</code>.
+                                      Let <var>algNamedCurve</var> be the string "`P-521`".
                                     </dd>
                                     <dt>otherwise:</dt>
                                     <dd>
@@ -8612,7 +8612,7 @@ dictionary EcKeyImportParams : Algorithm {
                                         <li>
                                           <p>
                                             Set the {{CryptoKey/[[type]]}}
-                                            internal slot of <var>Key</var> to <code>"public"</code>.
+                                            internal slot of <var>Key</var> to "`public`".
                                           </p>
                                         </li>
                                       </ol>
@@ -8662,7 +8662,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDSA"</code>.
+                            <var>algorithm</var> to "`ECDSA`".
                           </p>
                         </li>
                         <li>
@@ -8694,7 +8694,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains a value which is not
-                            <code>"verify"</code>
+                            "`verify`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -8702,8 +8702,8 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is <code>"P-256"</code>,
-                              <code>"P-384"</code> or <code>"P-521"</code>:
+                              If <var>namedCurve</var> is "`P-256`",
+                              "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
                               <ol>
@@ -8737,7 +8737,7 @@ dictionary EcKeyImportParams : Algorithm {
                                   <p>
                                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
-                                    of <code>this</code> [[HTML]], and
+                                    of `this` [[HTML]], and
                                     that represents <var>Q</var>
                                   </p>
                                 </li>
@@ -8775,7 +8775,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDSA"</code>.
+                            <var>algorithm</var> to "`ECDSA`".
                           </p>
                         </li>
                         <li>
@@ -8788,7 +8788,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to <code>"public"</code>
+                            of <var>key</var> to "`public`"
                           </p>
                         </li>
                         <li>
@@ -8839,12 +8839,12 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the <code>subjectPublicKeyInfo</code>
+                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -8852,29 +8852,29 @@ dictionary EcKeyImportParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>algorithm</var> field to an
-                                <code>AlgorithmIdentifier</code> ASN.1 type with the following
+                                `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>id-ecPublicKey</code> defined in
+                                    `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the <var>parameters</var> field to an instance of the
-                                    <code>ECParameters</code> ASN.1 type defined in
+                                    `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
                                   <dl class="switch">
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is <code>"P-256"</code>,
-                                      <code>"P-384"</code> or <code>"P-521"</code>:
+                                      internal slot of <var>key</var> is "`P-256`",
+                                      "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
@@ -8889,37 +8889,37 @@ dictionary EcKeyImportParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-256"</code>:
+                                          internal slot of <var>key</var> is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier
-                                            <code>secp256r1</code> defined in [[RFC5480]]
+                                            `secp256r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-384"</code>:
+                                          internal slot of <var>key</var> is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier
-                                            <code>secp384r1</code> defined in [[RFC5480]]
+                                            `secp384r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-521"</code>:
+                                          internal slot of <var>key</var> is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier
-                                            <code>secp521r1</code> defined in [[RFC5480]]
+                                            `secp521r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                       </dl>
@@ -8942,7 +8942,7 @@ dictionary EcKeyImportParams : Algorithm {
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier <var>namedCurveOid</var>.
                                           </p>
                                         </li>
@@ -8963,7 +8963,7 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -8980,47 +8980,47 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the <code>privateKeyInfo</code>
+                            Let <var>data</var> be an instance of the `privateKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>version</var> field to <code>0</code>.
+                                Set the <var>version</var> field to `0`.
                               </p>
                             </li>
                             <li>
                               <p>
                                 Set the <var>privateKeyAlgorithm</var> field to an
-                                <code>PrivateKeyAlgorithmIdentifier</code> ASN.1 type with the
+                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>id-ecPublicKey</code> defined in
+                                    `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the <var>parameters</var> field to an instance of the
-                                    <code>ECParameters</code> ASN.1 type defined in
+                                    `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
                                   <dl class="switch">
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is <code>"P-256"</code>,
-                                      <code>"P-384"</code> or <code>"P-521"</code>:
+                                      internal slot of <var>key</var> is "`P-256`",
+                                      "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
                                         Let <var>keyData</var> be the result of DER-encoding
-                                        an instance of the <code>ECPrivateKey</code> structure defined in
+                                        an instance of the `ECPrivateKey` structure defined in
                                         Section 3 of [[RFC5915]] for the Elliptic
                                         Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                         <var>key</var> and that conforms to the following:
@@ -9031,7 +9031,7 @@ dictionary EcKeyImportParams : Algorithm {
                                             The <var>parameters</var> field is present, and is equivalent
                                             to the <var>parameters</var> field of the
                                             <var>privateKeyAlgorithm</var> field of this
-                                            <code>PrivateKeyInfo</code> ASN.1 structure.
+                                            `PrivateKeyInfo` ASN.1 structure.
                                           </p>
                                         </li>
                                         <li>
@@ -9047,37 +9047,37 @@ dictionary EcKeyImportParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-256"</code>:
+                                          internal slot of <var>key</var> is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier
-                                            <code>secp256r1</code> defined in [[RFC5480]]
+                                            `secp256r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-384"</code>:
+                                          internal slot of <var>key</var> is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier
-                                            <code>secp384r1</code> defined in [[RFC5480]]
+                                            `secp384r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-521"</code>:
+                                          internal slot of <var>key</var> is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier
-                                            <code>secp521r1</code> defined in [[RFC5480]]
+                                            `secp521r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                       </dl>
@@ -9100,7 +9100,7 @@ dictionary EcKeyImportParams : Algorithm {
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier <var>namedCurveOid</var>.
                                           </p>
                                         </li>
@@ -9121,7 +9121,7 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -9138,8 +9138,8 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to
-                            <code>"EC"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to
+                            "`EC`".
                           </p>
                         </li>
                         <li>
@@ -9147,8 +9147,8 @@ dictionary EcKeyImportParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is <code>"P-256"</code>, <code>"P-384"</code> or
-                              <code>"P-521"</code>:
+                              of <var>key</var> is "`P-256`", "`P-384`" or
+                              "`P-521`":
                             </dt>
                             <dd>
                               <ol>
@@ -9157,29 +9157,29 @@ dictionary EcKeyImportParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is <code>"P-256"</code>:
+                                      of <var>key</var> is "`P-256`":
                                     </dt>
                                     <dd>
                                       Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                      <code>"P-256"</code>
+                                      "`P-256`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is <code>"P-384"</code>:
+                                      of <var>key</var> is "`P-384`":
                                     </dt>
                                     <dd>
                                       Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                      <code>"P-384"</code>
+                                      "`P-384`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is <code>"P-521"</code>:
+                                      of <var>key</var> is "`P-521`":
                                     </dt>
                                     <dd>
                                       Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                      <code>"P-521"</code>
+                                      "`P-521`"
                                     </dd>
                                   </dl>
                                 </li>
@@ -9239,12 +9239,12 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
+                            Set the `key_ops` attribute of <var>jwk</var> to the {{CryptoKey/usages}} attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -9264,7 +9264,7 @@ dictionary EcKeyImportParams : Algorithm {
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
@@ -9272,8 +9272,8 @@ dictionary EcKeyImportParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is <code>"P-256"</code>, <code>"P-384"</code>
-                              or <code>"P-521"</code>:
+                              of <var>key</var> is "`P-256`", "`P-384`"
+                              or "`P-521`":
                             </dt>
                             <dd>
                               <p>
@@ -9300,7 +9300,7 @@ dictionary EcKeyImportParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -9349,7 +9349,7 @@ dictionary EcKeyImportParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"ECDH"</code>.
+            this algorithm is "`ECDH`".
           </p>
           <table>
             <thead>
@@ -9401,7 +9401,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                    <code>"deriveKey"</code> or <code>"deriveBits"</code>
+                    "`deriveKey`" or "`deriveBits`"
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -9410,8 +9410,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{EcKeyGenParams/namedCurve}} member of
-                      <var>normalizedAlgorithm</var> is <code>"P-256"</code>, <code>"P-384"</code>
-                      or <code>"P-521"</code>:
+                      <var>normalizedAlgorithm</var> is "`P-256`", "`P-384`"
+                      or "`P-521`":
                     </dt>
                     <dd>
                       <p>
@@ -9459,7 +9459,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <li>
                   <p>
                     Set the {{Algorithm/name}} member of
-                    <var>algorithm</var> to <code>"ECDH"</code>.
+                    <var>algorithm</var> to "`ECDH`".
                   </p>
                 </li>
                 <li>
@@ -9474,14 +9474,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                   <p>
                     Let <var>publicKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the public key of the generated key pair.
                   </p>
                 </li>
                 <li>
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> to <code>"public"</code>
+                    <var>publicKey</var> to "`public`"
                   </p>
                 </li>
                 <li>
@@ -9506,7 +9506,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                   <p>
                     Let <var>privateKey</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -9533,7 +9533,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                     Set the {{CryptoKey/[[usages]]}} internal slot of
                     <var>privateKey</var> to be the
                     [= usage intersection =] of
-                    <var>usages</var> and <code>[ "deriveKey", "deriveBits" ]</code>.
+                    <var>usages</var> and `[ "deriveKey", "deriveBits" ]`.
                   </p>
                 </li>
                 <li>
@@ -9581,7 +9581,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <li>
                   <p>
                     If the {{CryptoKey/[[type]]}} internal slot of
-                    <var>publicKey</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                    <var>publicKey</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
@@ -9604,8 +9604,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                   <dl class="switch">
                     <dt>
                       If the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    <var>key</var> is <code>"P-256"</code>, <code>"P-384"</code>
-                      or <code>"P-521"</code>:
+                    <var>key</var> is "`P-256`", "`P-384`"
+                      or "`P-521`":
                     </dt>
                     <dd>
                       <ol>
@@ -9717,9 +9717,9 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the <code>algorithm</code> object identifier field of the
-                            <code>algorithm</code> AlgorithmIdentifier field of <var>spki</var> is
-                            not equal to the <code>id-ecPublicKey</code> or <code>id-ecDH</code>
+                            If the `algorithm` object identifier field of the
+                            `algorithm` AlgorithmIdentifier field of <var>spki</var> is
+                            not equal to the `id-ecPublicKey` or `id-ecDH`
                             object identifiers defined in [[RFC5480]],
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -9727,7 +9727,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the <code>parameters</code> field of the <code>algorithm</code>
+                            If the `parameters` field of the `algorithm`
                             AlgorithmIdentifier field of <var>spki</var> is absent,
                             then [= exception/throw =] a
                             {{DataError}}.
@@ -9735,16 +9735,16 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the <code>parameters</code> field of the
-                            <code>algorithm</code> AlgorithmIdentifier field of <var>spki</var>.
+                            Let <var>params</var> be the `parameters` field of the
+                            `algorithm` AlgorithmIdentifier field of <var>spki</var>.
                           </p>
                         </li>
                         <li>
                           <p>
                             If <var>params</var> is not an instance of the
-                            <code>ECParameters</code> ASN.1 type defined in
+                            `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
-                            <code>namedCurve</code>, then [= exception/throw =] a {{DataError}}.
+                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
@@ -9756,30 +9756,30 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp256r1</code>
+                              If <var>params</var> is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-256"</code>.
+                                Set <var>namedCurve</var> "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp384r1</code>
+                              If <var>params</var> is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-384"</code>.
+                                Set <var>namedCurve</var> "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp521r1</code>
+                              If <var>params</var> is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> <code>"P-521"</code>.
+                                Set <var>namedCurve</var> "`P-521`".
                               </p>
                             </dd>
                           </dl>
@@ -9792,7 +9792,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 <li>
                                   <p>
                                     Let <var>publicKey</var> be the Elliptic Curve public key identified by
-                                    performing the conversion steps defined in Section 2.3.4 of [[SEC1]] to the <code>subjectPublicKey</code> field of
+                                    performing the conversion steps defined in Section 2.3.4 of [[SEC1]] to the `subjectPublicKey` field of
                                     <var>spki</var>.
                                   </p>
                                   <p>
@@ -9818,7 +9818,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
-                                    of <code>this</code> [[HTML]], and
+                                    of `this` [[HTML]], and
                                     that represents <var>publicKey</var>.
                                   </p>
                                 </li>
@@ -9864,7 +9864,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to <code>"public"</code>
+                            of <var>key</var> to "`public`"
                           </p>
                         </li>
                         <li>
@@ -9875,7 +9875,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDH"</code>.
+                            <var>algorithm</var> to "`ECDH`".
                           </p>
                         </li>
                         <li>
@@ -9898,7 +9898,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains an entry which is not
-                            <code>"deriveKey"</code> or <code>"deriveBits"</code>
+                            "`deriveKey`" or "`deriveBits`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -9919,10 +9919,10 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the <code>algorithm</code> object identifier field of the
-                            <code>privateKeyAlgorithm</code> PrivateKeyAlgorithm field of
+                            If the `algorithm` object identifier field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
                             <var>privateKeyInfo</var> is not equal to the
-                            <code>id-ecPublicKey</code> or <code>id-ecDH</code> object identifiers
+                            `id-ecPublicKey` or `id-ecDH` object identifiers
                             defined in [[RFC5480]],
                             [= exception/throw =] a
                             {{DataError}}.
@@ -9930,8 +9930,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If the <code>parameters</code> field of the
-                            <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier field
+                            If the `parameters` field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
                             of <var>privateKeyInfo</var> is not present,
                             [= exception/throw =] a
                             {{DataError}}.
@@ -9939,17 +9939,17 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>params</var> be the <code>parameters</code> field of the
-                            <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier field
+                            Let <var>params</var> be the `parameters` field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
                             of <var>privateKeyInfo</var>.
                           </p>
                         </li>
                         <li>
                           <p>
                             If <var>params</var> is not an instance of the
-                            <code>ECParameters</code> ASN.1 type defined in
+                            `ECParameters` ASN.1 type defined in
                             [[RFC5480]] that specifies a
-                            <code>namedCurve</code>, then [= exception/throw =] a {{DataError}}.
+                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
                           </p>
                         </li>
                         <li>
@@ -9961,30 +9961,30 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp256r1</code>
+                              If <var>params</var> is equivalent to the `secp256r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> to <code>"P-256"</code>.
+                                Set <var>namedCurve</var> to "`P-256`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp384r1</code>
+                              If <var>params</var> is equivalent to the `secp384r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> to <code>"P-384"</code>.
+                                Set <var>namedCurve</var> to "`P-384`".
                               </p>
                             </dd>
                             <dt>
-                              If <var>params</var> is equivalent to the <code>secp521r1</code>
+                              If <var>params</var> is equivalent to the `secp521r1`
                               object identifier defined in [[RFC5480]]:
                             </dt>
                             <dd>
                               <p>
-                                Set <var>namedCurve</var> to <code>"P-521"</code>.
+                                Set <var>namedCurve</var> to "`P-521`".
                               </p>
                             </dd>
                           </dl>
@@ -9998,9 +9998,9 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Let <var>ecPrivateKey</var> be the result of performing the
                                     [= parse an ASN.1 structure =]
-                                    algorithm, with <var>data</var> as the <code>privateKey</code> field
+                                    algorithm, with <var>data</var> as the `privateKey` field
                                     of <var>privateKeyInfo</var>, <var>structure</var> as the ASN.1
-                                    <code>ECPrivateKey</code> structure specified in Section 3 of
+                                    `ECPrivateKey` structure specified in Section 3 of
                                     [[RFC5915]], and <var>exactData</var> set to true.
                                   </p>
                                 </li>
@@ -10013,11 +10013,11 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    If the <code>parameters</code> field of <var>ecPrivateKey</var> is
-                                    present, and is not an instance of the <code>namedCurve</code> ASN.1
+                                    If the `parameters` field of <var>ecPrivateKey</var> is
+                                    present, and is not an instance of the `namedCurve` ASN.1
                                     type defined in [[RFC5480]], or does not contain
-                                    the same object identifier as the <code>parameters</code> field of the
-                                    <code>privateKeyAlgorithm</code> PrivateKeyAlgorithmIdentifier field
+                                    the same object identifier as the `parameters` field of the
+                                    `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
                                     of <var>privateKeyInfo</var>,
                                     [= exception/throw =] a
                                     {{DataError}}.
@@ -10027,7 +10027,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
-                                    of <code>this</code> [[HTML]], and
+                                    of `this` [[HTML]], and
                                     that represents the Elliptic Curve private key identified by
                                     performing the conversion steps defined in Section 3 of [[RFC5915]] using <var>ecPrivateKey</var>.
                                   </p>
@@ -10085,7 +10085,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDH"</code>.
+                            <var>algorithm</var> to "`ECDH`".
                           </p>
                         </li>
                         <li>
@@ -10117,7 +10117,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                           <p>
                             If the {{JsonWebKey/d}} field is present and if <var>usages</var>
                             contains an entry which is not
-                            <code>"deriveKey"</code> or <code>"deriveBits"</code>
+                            "`deriveKey`" or "`deriveBits`"
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -10133,7 +10133,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is
-                            not <code>"EC"</code>,
+                            not "`EC`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -10141,7 +10141,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present
-                            and is not equal to <code>"enc"</code> then [= exception/throw =] a
+                            and is not equal to "`enc`" then [= exception/throw =] a
                             {{DataError}}.
                           </p>
                         </li>
@@ -10176,8 +10176,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is <code>"P-256"</code>,
-                              <code>"P-384"</code> or <code>"P-521"</code>:
+                              If <var>namedCurve</var> is "`P-256`",
+                              "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
                               <dl class="switch">
@@ -10224,7 +10224,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                     <li>
                                       <p>
                                         Set the {{CryptoKey/[[type]]}}
-                                        internal slot of <var>Key</var> to <code>"public"</code>.
+                                        internal slot of <var>Key</var> to "`public`".
                                       </p>
                                     </li>
                                   </ol>
@@ -10270,7 +10270,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDH"</code>.
+                            <var>algorithm</var> to "`ECDH`".
                           </p>
                         </li>
                         <li>
@@ -10309,8 +10309,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If <var>namedCurve</var> is <code>"P-256"</code>,
-                              <code>"P-384"</code> or <code>"P-521"</code>:
+                              If <var>namedCurve</var> is "`P-256`",
+                              "`P-384`" or "`P-521`":
                             </dt>
                             <dd>
                               <ol>
@@ -10344,7 +10344,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   <p>
                                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                                     [= relevant global object =]
-                                    of <code>this</code> [[HTML]], and
+                                    of `this` [[HTML]], and
                                     that represents <var>Q</var>.
                                   </p>
                                 </li>
@@ -10382,7 +10382,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"ECDH"</code>.
+                            <var>algorithm</var> to "`ECDH`".
                           </p>
                         </li>
                         <li>
@@ -10395,7 +10395,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> to <code>"public"</code>
+                            of <var>key</var> to "`public`"
                           </p>
                         </li>
                         <li>
@@ -10439,12 +10439,12 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the <code>subjectPublicKeyInfo</code>
+                            Let <var>data</var> be an instance of the `subjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -10452,29 +10452,29 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             <li>
                               <p>
                                 Set the <var>algorithm</var> field to an
-                                <code>AlgorithmIdentifier</code> ASN.1 type with the following
+                                `AlgorithmIdentifier` ASN.1 type with the following
                                 properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>id-ecPublicKey</code> defined in
+                                    `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the <var>parameters</var> field to an instance of the
-                                    <code>ECParameters</code> ASN.1 type defined in
+                                    `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
                                   <dl class="switch">
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is <code>"P-256"</code>,
-                                      <code>"P-384"</code> or <code>"P-521"</code>:
+                                      internal slot of <var>key</var> is "`P-256`",
+                                      "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
@@ -10488,37 +10488,37 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-256"</code>:
+                                          internal slot of <var>key</var> is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
                                             Set <var>parameters</var> to the <var>namedCurve</var> choice
                                             with value equal to the object identifier
-                                            <code>secp256r1</code> defined in [[RFC5480]]
+                                            `secp256r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-384"</code>:
+                                          internal slot of <var>key</var> is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
                                             Set <var>parameters</var> to the <var>namedCurve</var> choice
                                             with value equal to the object identifier
-                                            <code>secp384r1</code> defined in [[RFC5480]]
+                                            `secp384r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-521"</code>:
+                                          internal slot of <var>key</var> is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
                                             Set <var>parameters</var> to the <var>namedCurve</var> choice
                                             with value equal to the object identifier
-                                            <code>secp521r1</code> defined in [[RFC5480]]
+                                            `secp521r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                       </dl>
@@ -10541,7 +10541,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier <var>namedCurveOid</var>.
                                           </p>
                                         </li>
@@ -10571,47 +10571,47 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let <var>data</var> be an instance of the <code>privateKeyInfo</code>
+                            Let <var>data</var> be an instance of the `privateKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the <var>version</var> field to <code>0</code>.
+                                Set the <var>version</var> field to `0`.
                               </p>
                             </li>
                             <li>
                               <p>
                                 Set the <var>privateKeyAlgorithm</var> field to an
-                                <code>PrivateKeyAlgorithmIdentifier</code> ASN.1 type with the
+                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
                               <ul>
                                 <li>
                                   <p>
                                     Set the <var>algorithm</var> field to the OID
-                                    <code>id-ecPublicKey</code> defined in
+                                    `id-ecPublicKey` defined in
                                     [[RFC5480]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
                                     Set the <var>parameters</var> field to an instance of the
-                                    <code>ECParameters</code> ASN.1 type defined in
+                                    `ECParameters` ASN.1 type defined in
                                     [[RFC5480]] as follows:
                                   </p>
                                   <dl class="switch">
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of <var>key</var> is <code>"P-256"</code>,
-                                      <code>"P-384"</code> or <code>"P-521"</code>:
+                                      internal slot of <var>key</var> is "`P-256`",
+                                      "`P-384`" or "`P-521`":
                                     </dt>
                                     <dd>
                                       <p>
                                         Let <var>keyData</var> be the result of DER-encoding
-                                        an instance of the <code>ECPrivateKey</code> structure defined in
+                                        an instance of the `ECPrivateKey` structure defined in
                                         Section 3 of [[RFC5915]] for the Elliptic
                                         Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                         <var>key</var> and that conforms to the following:
@@ -10622,7 +10622,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                             The <var>parameters</var> field is present, and is equivalent
                                             to the <var>parameters</var> field of the
                                             <var>privateKeyAlgorithm</var> field of this
-                                            <code>PrivateKeyInfo</code> ASN.1 structure.
+                                            `PrivateKeyInfo` ASN.1 structure.
                                           </p>
                                         </li>
                                         <li>
@@ -10638,37 +10638,37 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-256"</code>:
+                                          internal slot of <var>key</var> is "`P-256`":
                                         </dt>
                                         <dd>
                                           <p>
                                             Set <var>parameters</var> to the <var>namedCurve</var> choice
                                             with value equal to the object identifier
-                                            <code>secp256r1</code> defined in [[RFC5480]]
+                                            `secp256r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-384"</code>:
+                                          internal slot of <var>key</var> is "`P-384`":
                                         </dt>
                                         <dd>
                                           <p>
                                             Set <var>parameters</var> to the <var>namedCurve</var> choice
                                             with value equal to the object identifier
-                                            <code>secp384r1</code> defined in [[RFC5480]]
+                                            `secp384r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                         <dt>
                                           If the {{EcKeyAlgorithm/namedCurve}}
                                           attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of <var>key</var> is <code>"P-521"</code>:
+                                          internal slot of <var>key</var> is "`P-521`":
                                         </dt>
                                         <dd>
                                           <p>
                                             Set <var>parameters</var> to the <var>namedCurve</var> choice
                                             with value equal to the object identifier
-                                            <code>secp521r1</code> defined in [[RFC5480]]
+                                            `secp521r1` defined in [[RFC5480]]
                                           </p>
                                         </dd>
                                       </dl>
@@ -10691,7 +10691,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                         </li>
                                         <li>
                                           <p>
-                                            Set <var>parameters</var> to the <code>namedCurve</code> choice
+                                            Set <var>parameters</var> to the `namedCurve` choice
                                             with value equal to the object identifier <var>namedCurveOid</var>.
                                           </p>
                                         </li>
@@ -10721,8 +10721,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to
-                            <code>"EC"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to
+                            "`EC`".
                           </p>
                         </li>
                         <li>
@@ -10730,8 +10730,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is <code>"P-256"</code>, <code>"P-384"</code>
-                              or <code>"P-521"</code>:
+                              of <var>key</var> is "`P-256`", "`P-384`"
+                              or "`P-521`":
                             </dt>
                             <dd>
                               <ol>
@@ -10740,29 +10740,29 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is <code>"P-256"</code>:
+                                      of <var>key</var> is "`P-256`":
                                     </dt>
                                     <dd>
                                       Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                      <code>"P-256"</code>
+                                      "`P-256`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is <code>"P-384"</code>:
+                                      of <var>key</var> is "`P-384`":
                                     </dt>
                                     <dd>
                                       Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                      <code>"P-384"</code>
+                                      "`P-384`"
                                     </dd>
                                     <dt>
                                       If the {{EcKeyAlgorithm/namedCurve}}
                                       attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of <var>key</var> is <code>"P-521"</code>:
+                                      of <var>key</var> is "`P-521`":
                                     </dt>
                                     <dd>
                                       Set the {{JsonWebKey/crv}} attribute of <var>jwk</var> to
-                                      <code>"P-521"</code>
+                                      "`P-521`"
                                     </dd>
                                   </dl>
                                 </li>
@@ -10822,13 +10822,13 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to the
+                            Set the `key_ops` attribute of <var>jwk</var> to the
                             {{CryptoKey/usages}} attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -10848,7 +10848,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of <var>key</var> is not <code>"public"</code>, then [= exception/throw =] an {{InvalidAccessError}}.
+                            of <var>key</var> is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
@@ -10856,8 +10856,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             <dt>
                               If the {{EcKeyAlgorithm/namedCurve}}
                               attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of <var>key</var> is <code>"P-256"</code>, <code>"P-384"</code>
-                              or <code>"P-521"</code>:
+                              of <var>key</var> is "`P-256`", "`P-384`"
+                              or "`P-521`":
                             </dt>
                             <dd>
                               <p>
@@ -10886,7 +10886,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -10910,7 +10910,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
         <section id="aes-ctr-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"AES-CTR"</code> algorithm identifier is used to perform
+            The "`AES-CTR`" algorithm identifier is used to perform
             encryption and decryption using AES in Counter mode,
             as described in [[NIST-SP800-38A]].
           </p>
@@ -10919,7 +10919,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"AES-CTR"</code>.
+            this algorithm is "`AES-CTR`".
           </p>
           <table>
             <thead>
@@ -11048,7 +11048,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>ciphertext</var>.
                   </p>
                 </li>
@@ -11091,7 +11091,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>plaintext</var>.
                   </p>
                 </li>
@@ -11103,8 +11103,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains any entry which is not
-                    one of <code>"encrypt"</code>, <code>"decrypt"</code>,
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                    one of "`encrypt`", "`decrypt`",
+                    "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -11149,7 +11149,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-CTR"</code>.
+                    <var>algorithm</var> to "`AES-CTR`".
                   </p>
                 </li>
                 <li>
@@ -11191,8 +11191,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                    one of <code>"encrypt"</code>, <code>"decrypt"</code>,
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                    one of "`encrypt`", "`decrypt`",
+                    "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -11230,7 +11230,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
-                             <code>"oct"</code>,
+                             "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -11254,17 +11254,17 @@ dictionary AesDerivedKeyParams : Algorithm {
                             <dt>If <var>data</var> has length 128 bits:</dt>
                             <dd>
                               If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                              not <code>"A128CTR"</code>, then [= exception/throw =] a {{DataError}}.
+                              not "`A128CTR`", then [= exception/throw =] a {{DataError}}.
                             </dd>
                             <dt>If <var>data</var> has length 192 bits:</dt>
                             <dd>
                               If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                              not <code>"A192CTR"</code>, then [= exception/throw =] a {{DataError}}.
+                              not "`A192CTR`", then [= exception/throw =] a {{DataError}}.
                             </dd>
                             <dt>If <var>data</var> has length 256 bits:</dt>
                             <dd>
                               If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                              not <code>"A256CTR"</code>, then [= exception/throw =] a {{DataError}}.
+                              not "`A256CTR`", then [= exception/throw =] a {{DataError}}.
                             </dd>
                             <dt>Otherwise:</dt>
                             <dd>
@@ -11275,7 +11275,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not <code>"enc"</code>,
+                            not "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -11309,7 +11309,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new <code>{{CryptoKey}}</code> object representing an AES key with
+                    Let <var>key</var> be a new `{{CryptoKey}}` object representing an AES key with
                     value <var>data</var>.
                   </p>
                 </li>
@@ -11322,7 +11322,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-CTR"</code>.
+                    <var>algorithm</var> to "`AES-CTR`".
                   </p>
                 </li>
                 <li>
@@ -11368,7 +11368,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -11385,8 +11385,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to the
-                            string <code>"oct"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to the
+                            string "`oct`".
                           </p>
                         </li>
                         <li>
@@ -11400,28 +11400,28 @@ dictionary AesDerivedKeyParams : Algorithm {
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 128:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A128CTR"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A128CTR`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 192:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A192CTR"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A192CTR`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 256:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A256CTR"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A256CTR`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to equal the
+                            Set the `key_ops` attribute of <var>jwk</var> to equal the
                             {{CryptoKey/[[usages]]}} internal slot of
                             <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -11477,7 +11477,7 @@ dictionary AesDerivedKeyParams : Algorithm {
         <section id="aes-cbc-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"AES-CBC"</code> algorithm identifier is used to perform
+            The "`AES-CBC`" algorithm identifier is used to perform
             encryption and decryption using AES in Cipher Block Chaining mode,
             as described in [[NIST-SP800-38A]].
           </p>
@@ -11493,7 +11493,7 @@ dictionary AesDerivedKeyParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"AES-CBC"</code>.
+            this algorithm is "`AES-CBC`".
           </p>
           <table>
             <thead>
@@ -11582,7 +11582,7 @@ dictionary AesCbcParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>ciphertext</var>.
                   </p>
                 </li>
@@ -11631,7 +11631,7 @@ dictionary AesCbcParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>plaintext</var>.
                   </p>
                 </li>
@@ -11643,8 +11643,8 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains any entry which is not
-                     one of <code>"encrypt"</code>, <code>"decrypt"</code>,
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                     one of "`encrypt`", "`decrypt`",
+                    "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -11689,7 +11689,7 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-CBC"</code>.
+                    <var>algorithm</var> to "`AES-CBC`".
                   </p>
                 </li>
                 <li>
@@ -11731,8 +11731,8 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                    one of <code>"encrypt"</code>, <code>"decrypt"</code>,
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                    one of "`encrypt`", "`decrypt`",
+                    "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -11770,7 +11770,7 @@ dictionary AesCbcParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
-                            <code>"oct"</code>,
+                            "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -11793,17 +11793,17 @@ dictionary AesCbcParams : Algorithm {
                           <dl class="switch">
                             <dt>If <var>data</var> has length 128 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A128CBC"</code>,
+                            not  "`A128CBC`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>If <var>data</var> has length 192 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A192CBC"</code>,
+                            not  "`A192CBC`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>If <var>data</var> has length 256 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A256CBC"</code>,
+                            not  "`A256CBC`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>Otherwise:</dt>
@@ -11816,7 +11816,7 @@ dictionary AesCbcParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not  <code>"enc"</code>,
+                            not  "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -11850,7 +11850,7 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new <code>{{CryptoKey}}</code>
+                    Let <var>key</var> be a new `{{CryptoKey}}`
                     object representing an AES key with value <var>data</var>.
                   </p>
                 </li>
@@ -11863,7 +11863,7 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-CBC"</code>.
+                    <var>algorithm</var> to "`AES-CBC`".
                   </p>
                 </li>
                 <li>
@@ -11909,7 +11909,7 @@ dictionary AesCbcParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -11928,8 +11928,8 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to the
-                            string <code>"oct"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to the
+                            string "`oct`".
                           </p>
                         </li>
                         <li>
@@ -11943,27 +11943,27 @@ dictionary AesCbcParams : Algorithm {
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 128:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A128CBC"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A128CBC`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 192:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A192CBC"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A192CBC`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 256:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A256CBC"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A256CBC`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to equal the
+                            Set the `key_ops` attribute of <var>jwk</var> to equal the
                             {{CryptoKey/usages}} attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -12019,7 +12019,7 @@ dictionary AesCbcParams : Algorithm {
         <section id="aes-gcm-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"AES-GCM"</code> algorithm identifier is used to perform
+            The "`AES-GCM`" algorithm identifier is used to perform
             authenticated encryption and decryption using AES in Galois/Counter Mode mode,
             as described in [[NIST-SP800-38D]].
           </p>
@@ -12028,7 +12028,7 @@ dictionary AesCbcParams : Algorithm {
            <h4>Registration</h4>
            <p>
              The [= recognized algorithm name =] for
-             this algorithm is <code>"AES-GCM"</code>.
+             this algorithm is "`AES-GCM`".
            </p>
            <table>
              <thead>
@@ -12162,7 +12162,7 @@ dictionary AesGcmParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>ciphertext</var>.
                   </p>
                 </li>
@@ -12260,7 +12260,7 @@ dictionary AesGcmParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     containing <var>plaintext</var>.
                   </p>
                 </li>
@@ -12272,8 +12272,8 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains any entry which is not
-                    one of <code>"encrypt"</code>, <code>"decrypt"</code>,
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                    one of "`encrypt`", "`decrypt`",
+                    "`wrapKey`" or "`unwrapKey`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -12318,7 +12318,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-GCM"</code>.
+                    <var>algorithm</var> to "`AES-GCM`".
                   </p>
                 </li>
                 <li>
@@ -12360,8 +12360,8 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                    one of <code>"encrypt"</code>, <code>"decrypt"</code>,
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                    one of "`encrypt`", "`decrypt`",
+                    "`wrapKey`" or "`unwrapKey`",
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                   </p>
@@ -12399,7 +12399,7 @@ dictionary AesGcmParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
-                            <code>"oct"</code>,
+                            "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -12422,17 +12422,17 @@ dictionary AesGcmParams : Algorithm {
                           <dl class="switch">
                             <dt>If <var>data</var> has length 128 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A128GCM"</code>,
+                            not  "`A128GCM`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>If <var>data</var> has length 192 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A192GCM"</code>,
+                            not  "`A192GCM`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>If <var>data</var> has length 256 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A256GCM"</code>,
+                            not  "`A256GCM`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>Otherwise:</dt>
@@ -12445,7 +12445,7 @@ dictionary AesGcmParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not  <code>"enc"</code>,
+                            not  "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -12479,7 +12479,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new <code>{{CryptoKey}}</code>
+                    Let <var>key</var> be a new `{{CryptoKey}}`
                     object representing an AES key with value <var>data</var>.
                   </p>
                 </li>
@@ -12492,7 +12492,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-GCM"</code>.
+                    <var>algorithm</var> to "`AES-GCM`".
                   </p>
                 </li>
                 <li>
@@ -12538,7 +12538,7 @@ dictionary AesGcmParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -12555,8 +12555,8 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to the
-                            string <code>"oct"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to the
+                            string "`oct`".
                           </p>
                         </li>
                         <li>
@@ -12570,28 +12570,28 @@ dictionary AesGcmParams : Algorithm {
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 128:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A128GCM"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A128GCM`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 192:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A192GCM"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A192GCM`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 256:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A256GCM"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A256GCM`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to equal the
+                            Set the `key_ops` attribute of <var>jwk</var> to equal the
                             {{CryptoKey/usages}} attribute of
                             <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -12645,7 +12645,7 @@ dictionary AesGcmParams : Algorithm {
         <section id="aes-kw-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"AES-KW"</code> algorithm identifier is used to perform
+            The "`AES-KW`" algorithm identifier is used to perform
             key wrapping using AES, as
             described in [[RFC3394]].
           </p>
@@ -12654,7 +12654,7 @@ dictionary AesGcmParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"AES-KW"</code>.
+            this algorithm is "`AES-KW`".
           </p>
           <table>
             <thead>
@@ -12757,7 +12757,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains any entry which is not one of
-                    <code>"wrapKey"</code> or <code>"unwrapKey"</code>, then [= exception/throw =] a {{SyntaxError}}.
+                    "`wrapKey`" or "`unwrapKey`", then [= exception/throw =] a {{SyntaxError}}.
                   </p>
                 </li>
                 <li>
@@ -12796,7 +12796,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-KW"</code>.
+                    <var>algorithm</var> to "`AES-KW`".
                   </p>
                 </li>
                 <li>
@@ -12838,7 +12838,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                     one of <code>"wrapKey"</code> or <code>"unwrapKey"</code>,
+                     one of "`wrapKey`" or "`unwrapKey`",
 
                             then [= exception/throw =] a
                             {{SyntaxError}}.
@@ -12878,7 +12878,7 @@ dictionary AesGcmParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
-                            <code>"oct"</code>,
+                            "`oct`",
                               then [= exception/throw =] a
                               {{DataError}}.
                           </p>
@@ -12901,17 +12901,17 @@ dictionary AesGcmParams : Algorithm {
                           <dl class="switch">
                             <dt>If <var>data</var> has length 128 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A128KW"</code>,
+                            not  "`A128KW`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>If <var>data</var> has length 192 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A192KW"</code>,
+                            not  "`A192KW`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>If <var>data</var> has length 256 bits:</dt>
                             <dd>If the {{JsonWebKey/alg}} field of <var>jwk</var> is present, and is
-                            not  <code>"A256KW"</code>,
+                            not  "`A256KW`",
                               then [= exception/throw =] a
                               {{DataError}}.</dd>
                             <dt>Otherwise:</dt>
@@ -12924,7 +12924,7 @@ dictionary AesGcmParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not  <code>"enc"</code>,
+                            not  "`enc`",
                               then [= exception/throw =] a
                               {{DataError}}.
                           </p>
@@ -12959,7 +12959,7 @@ dictionary AesGcmParams : Algorithm {
                   <p>
                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing an AES key with value <var>data</var>.
                   </p>
                 </li>
@@ -12972,7 +12972,7 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"AES-KW"</code>.
+                    <var>algorithm</var> to "`AES-KW`".
                   </p>
                 </li>
                 <li>
@@ -13018,7 +13018,7 @@ dictionary AesGcmParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing
+                            of `this` [[HTML]], and containing
                             <var>data</var>.
                           </p>
                         </li>
@@ -13035,8 +13035,8 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to the
-                            string <code>"oct"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to the
+                            string "`oct`".
                           </p>
                         </li>
                         <li>
@@ -13050,27 +13050,27 @@ dictionary AesGcmParams : Algorithm {
                           <dl class="switch">
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 128:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A128KW"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A128KW`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 192:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A192KW"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A192KW`".</dd>
                             <dt>If the {{AesKeyAlgorithm/length}} attribute of
                             <var>key</var> is 256:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"A256KW"</code>.</dd>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`A256KW`".</dd>
                           </dl>
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to equal the
+                            Set the `key_ops` attribute of <var>jwk</var> to equal the
                             {{CryptoKey/usages}} attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -13124,7 +13124,7 @@ dictionary AesGcmParams : Algorithm {
         <section id="hmac-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>HMAC</code> algorithm calculates and verifies hash-based message
+            The `HMAC` algorithm calculates and verifies hash-based message
             authentication codes according to [[FIPS-198-1]]
             using the SHA hash functions defined in this specification.
           </p>
@@ -13141,7 +13141,7 @@ dictionary AesGcmParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"HMAC"</code>.
+            this algorithm is "`HMAC`".
           </p>
           <table>
             <thead>
@@ -13237,7 +13237,7 @@ dictionary HmacKeyGenParams : Algorithm {
                   <p>
                     Return a new {{ArrayBuffer}} object, associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and containing the
+                    of `this` [[HTML]], and containing the
                     bytes of <var>mac</var>.
                   </p>
                 </li>
@@ -13268,8 +13268,8 @@ dictionary HmacKeyGenParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If <var>usages</var> contains any entry which is not <code>"sign"</code> or
-                    <code>"verify"</code>, then [= exception/throw =] a {{SyntaxError}}.
+                    If <var>usages</var> contains any entry which is not "`sign`" or
+                    "`verify`", then [= exception/throw =] a {{SyntaxError}}.
                   </p>
                 </li>
                 <li>
@@ -13328,7 +13328,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"HMAC"</code>.
+                    <var>algorithm</var> to "`HMAC`".
                   </p>
                 </li>
                 <li>
@@ -13385,7 +13385,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains an entry which is not
-                    <code>"sign"</code> or <code>"verify"</code>,
+                    "`sign`" or "`verify`",
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -13427,7 +13427,7 @@ dictionary HmacKeyGenParams : Algorithm {
                         <li>
                           <p>
                             If the {{JsonWebKey/kty}} field of <var>jwk</var> is not
-                            <code>"oct"</code>,
+                            "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -13457,44 +13457,44 @@ dictionary HmacKeyGenParams : Algorithm {
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
                               of <var>hash</var> is
-                              <code>"SHA-1"</code>:
+                              "`SHA-1`":
                             </dt>
                             <dd>
                               If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
-                              and is not <code>"HS1"</code>,
+                              and is not "`HS1`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
                               of <var>hash</var> is
-                              <code>"SHA-256"</code>:
+                              "`SHA-256`":
                             </dt>
                             <dd>
                               If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
-                              and is not <code>"HS256"</code>,
+                              and is not "`HS256`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
                               of <var>hash</var> is
-                              <code>"SHA-384"</code>:
+                              "`SHA-384`":
                             </dt>
                             <dd>
                               If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
-                              and is not <code>"HS384"</code>,
+                              and is not "`HS384`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
                             <dt>
                               If the {{KeyAlgorithm/name}} attribute
                               of <var>hash</var> is
-                              <code>"SHA-512"</code>:
+                              "`SHA-512`":
                             </dt>
                             <dd>
                               If the {{JsonWebKey/alg}} field of <var>jwk</var> is present
-                              and is not <code>"HS512"</code>,
+                              and is not "`HS512`",
                               then [= exception/throw =] a
                               {{DataError}}.
                             </dd>
@@ -13517,7 +13517,7 @@ dictionary HmacKeyGenParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> is non-empty and the {{JsonWebKey/use}} field of <var>jwk</var> is present and is
-                            not  <code>"sign"</code>,
+                            not  "`sign`",
                             then [= exception/throw =] a
                             {{DataError}}.
                           </p>
@@ -13600,7 +13600,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let <var>key</var> be a new <code>{{CryptoKey}}</code>
+                    Let <var>key</var> be a new `{{CryptoKey}}`
                     object representing an HMAC key with the first <var>length</var>
                     bits of <var>data</var>.
                   </p>
@@ -13614,7 +13614,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"HMAC"</code>.
+                    <var>algorithm</var> to "`HMAC`".
                   </p>
                 </li>
                 <li>
@@ -13671,7 +13671,7 @@ dictionary HmacKeyGenParams : Algorithm {
                           <p>
                             Let <var>result</var> be a new {{ArrayBuffer}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and containing <var>data</var>.
+                            of `this` [[HTML]], and containing <var>data</var>.
                           </p>
                         </li>
                       </ol>
@@ -13687,8 +13687,8 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>kty</code> attribute of <var>jwk</var> to the
-                            string <code>"oct"</code>.
+                            Set the `kty` attribute of <var>jwk</var> to the
+                            string "`oct`".
                           </p>
                         </li>
                         <li>
@@ -13714,21 +13714,21 @@ dictionary HmacKeyGenParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is <code>"SHA-1"</code>:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"HS1"</code>.</dd>
+                            <var>hash</var> is "`SHA-1`":</dt>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`HS1`".</dd>
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is <code>"SHA-256"</code>:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"HS256"</code>.</dd>
+                            <var>hash</var> is "`SHA-256`":</dt>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`HS256`".</dd>
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is <code>"SHA-384"</code>:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"HS384"</code>.</dd>
+                            <var>hash</var> is "`SHA-384`":</dt>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`HS384`".</dd>
                             <dt>If the {{KeyAlgorithm/name}} attribute of
-                            <var>hash</var> is <code>"SHA-512"</code>:</dt>
-                            <dd>Set the <code>alg</code> attribute of <var>jwk</var> to
-                            the string <code>"HS512"</code>.</dd>
+                            <var>hash</var> is "`SHA-512`":</dt>
+                            <dd>Set the `alg` attribute of <var>jwk</var> to
+                            the string "`HS512`".</dd>
                             <dt>
                               Otherwise, the {{KeyAlgorithm/name}} attribute
                               of <var>hash</var> is defined in
@@ -13747,7 +13747,7 @@ dictionary HmacKeyGenParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <code>alg</code> attribute of <var>jwk</var> to
+                                    Set the `alg` attribute of <var>jwk</var> to
                                     <var>alg</var>.
                                   </p>
                                 </li>
@@ -13757,13 +13757,13 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <code>key_ops</code> attribute of <var>jwk</var> to equal the
+                            Set the `key_ops` attribute of <var>jwk</var> to equal the
                             {{CryptoKey/usages}} attribute of <var>key</var>.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <code>ext</code> attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
+                            Set the `ext` attribute of <var>jwk</var> to equal the {{CryptoKey/[[extractable]]}} internal slot
                             of <var>key</var>.
                           </p>
                         </li>
@@ -13846,10 +13846,10 @@ dictionary HmacKeyGenParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The <a href="#recognized-algorithm-name">recognized algorithm names</a> are
-            <code id="alg-sha-1">"SHA-1"</code>,
-            <code id="alg-sha-256">"SHA-256"</code>,
-            <code id="alg-sha-384">"SHA-384"</code>, and
-            <code id="alg-sha-512">"SHA-512"</code> for the respective SHA algorithms.
+            "<code id="alg-sha-1">SHA-1</code>",
+            "<code id="alg-sha-256">SHA-256</code>",
+            "<code id="alg-sha-384">SHA-384</code>", and
+            "<code id="alg-sha-512">SHA-512</code>" for the respective SHA algorithms.
           </p>
           <table>
             <thead>
@@ -13879,7 +13879,7 @@ dictionary HmacKeyGenParams : Algorithm {
                     <dt>
                       If the {{Algorithm/name}} member of
                       <var>normalizedAlgorithm</var> is a cases-sensitive string match for
-                      <code>"SHA-1"</code>:
+                      "`SHA-1`":
                     </dt>
                     <dd>
                       Let <var>result</var> be the result of performing the SHA-1 hash function
@@ -13889,7 +13889,7 @@ dictionary HmacKeyGenParams : Algorithm {
                     <dt>
                       If the {{Algorithm/name}} member of
                       <var>normalizedAlgorithm</var> is a cases-sensitive string match for
-                      <code>"SHA-256"</code>:
+                      "`SHA-256`":
                     </dt>
                     <dd>
                       Let <var>result</var> be the result of performing the SHA-256 hash function
@@ -13899,7 +13899,7 @@ dictionary HmacKeyGenParams : Algorithm {
                     <dt>
                       If the {{Algorithm/name}} member of
                       <var>normalizedAlgorithm</var> is a cases-sensitive string match for
-                      <code>"SHA-384"</code>:
+                      "`SHA-384`":
                     </dt>
                     <dd>
                       Let <var>result</var> be the result of performing the SHA-384 hash function
@@ -13909,7 +13909,7 @@ dictionary HmacKeyGenParams : Algorithm {
                     <dt>
                       If the {{Algorithm/name}} member of
                       <var>normalizedAlgorithm</var> is a cases-sensitive string match for
-                      <code>"SHA-512"</code>:
+                      "`SHA-512`":
                     </dt>
                     <dd>
                       Let <var>result</var> be the result of performing the SHA-1 hash function
@@ -13939,7 +13939,7 @@ dictionary HmacKeyGenParams : Algorithm {
         <section id="hkdf-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"HKDF"</code> algorithm identifier is used to
+            The "`HKDF`" algorithm identifier is used to
             perform key derivation using the extraction-then-expansion approach described in
             [[RFC5869]] and
             using the SHA hash functions defined in this specification.
@@ -13954,7 +13954,7 @@ dictionary HmacKeyGenParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =]
-            for this algorithm is <code>"HKDF"</code>.
+            for this algorithm is "`HKDF`".
           </p>
           <table>
             <thead>
@@ -14089,7 +14089,7 @@ dictionary HkdfParams : Algorithm {
                         <li>
                           <p>
                             If <var>usages</var> contains a value that is not
-                             <code>"deriveKey"</code> or <code>"deriveBits"</code>,
+                             "`deriveKey`" or "`deriveBits`",
 
                                 then [= exception/throw =] a
                                 {{SyntaxError}}.
@@ -14097,7 +14097,7 @@ dictionary HkdfParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            If <var>extractable</var> is not <code>false</code>,
+                            If <var>extractable</var> is not `false`,
                             then [= exception/throw =] a
                             {{SyntaxError}}.
                           </p>
@@ -14106,7 +14106,7 @@ dictionary HkdfParams : Algorithm {
                           <p>
                             Let <var>key</var> be a new {{CryptoKey}} associated with the
                             [= relevant global object =]
-                            of <code>this</code> [[HTML]], and
+                            of `this` [[HTML]], and
                             representing the key data provided in <var>keyData</var>.
                           </p>
                         </li>
@@ -14119,7 +14119,7 @@ dictionary HkdfParams : Algorithm {
                         <li>
                           <p>
                             Set the {{CryptoKey/[[extractable]]}} internal slot of
-                            <var>key</var> to <code>false</code>.
+                            <var>key</var> to `false`.
                           </p>
                         </li>
                         <li>
@@ -14131,7 +14131,7 @@ dictionary HkdfParams : Algorithm {
                         <li>
                           <p>
                             Set the {{KeyAlgorithm/name}} attribute of
-                            <var>algorithm</var> to <code>"HKDF"</code>.
+                            <var>algorithm</var> to "`HKDF`".
                           </p>
                         </li>
                         <li>
@@ -14175,7 +14175,7 @@ dictionary HkdfParams : Algorithm {
         <section id="pbkdf2-description" class="informative">
           <h4>Description</h4>
           <p>
-            The <code>"PBKDF2"</code> algorithm identifier is used to
+            The "`PBKDF2`" algorithm identifier is used to
             perform key derivation using the PKCS#5 password-based key
             derivation function version 2, as defined in
             [[RFC8018]] using HMAC as the pseudo-random function,
@@ -14192,7 +14192,7 @@ dictionary HkdfParams : Algorithm {
           <h4>Registration</h4>
           <p>
             The [= recognized algorithm name =] for
-            this algorithm is <code>"PBKDF2"</code>.
+            this algorithm is "`PBKDF2`".
           </p>
           <table>
             <thead>
@@ -14294,13 +14294,13 @@ dictionary Pbkdf2Params : Algorithm {
                 <li>
                   <p>
                     If <var>usages</var> contains a value that is not
-                    <code>"deriveKey"</code>  or <code>"deriveBits"</code>, then
+                    "`deriveKey`"  or "`deriveBits`", then
                     [= exception/throw =] a {{SyntaxError}}.
                   </p>
                 </li>
                 <li>
                   <p>
-                    If <var>extractable</var> is not <code>false</code>,
+                    If <var>extractable</var> is not `false`,
                     then [= exception/throw =] a
                     {{SyntaxError}}.
                   </p>
@@ -14309,7 +14309,7 @@ dictionary Pbkdf2Params : Algorithm {
                   <p>
                     Let <var>key</var> be a new {{CryptoKey}} associated with the
                     [= relevant global object =]
-                    of <code>this</code> [[HTML]], and
+                    of `this` [[HTML]], and
                     representing <var>keyData</var>.
                   </p>
                 </li>
@@ -14322,7 +14322,7 @@ dictionary Pbkdf2Params : Algorithm {
                 <li>
                   <p>
                     Set the {{CryptoKey/[[extractable]]}} internal slot of
-                    <var>key</var> to <code>false</code>.
+                    <var>key</var> to `false`.
                   </p>
                 </li>
                 <li>
@@ -14334,7 +14334,7 @@ dictionary Pbkdf2Params : Algorithm {
                 <li>
                   <p>
                     Set the {{KeyAlgorithm/name}} attribute of
-                    <var>algorithm</var> to <code>"PBKDF2"</code>.
+                    <var>algorithm</var> to "`PBKDF2`".
                   </p>
                 </li>
                 <li>
@@ -15093,9 +15093,9 @@ const filename = `${crypto.randomUUID()}.txt`;
               <td>rsaEncryption (1.2.840.113549.1.1.1)</td>
               <td>RSAPublicKey</td>
               <td>
-                <code>"RSASSA-PKCS1-v1_5"</code>,
-                <code>"RSA-PSS"</code>, or
-                <code>"RSA-OAEP"</code>
+                "`RSASSA-PKCS1-v1_5`",
+                "`RSA-PSS`", or
+                "`RSA-OAEP`"
               </td>
               <td>
                 [[RFC3279]],
@@ -15106,7 +15106,7 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-RSASSA-PSS (1.2.840.113549.1.1.10)</td>
               <td>RSAPublicKey</td>
-              <td><code>"RSA-PSS"</code></td>
+              <td>"`RSA-PSS`"</td>
               <td>
                 [[RFC4055]],
                 [[RFC5756]]
@@ -15115,7 +15115,7 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-RSAES-OAEP (1.2.840.113549.1.1.7)</td>
               <td>RSAPublicKey</td>
-              <td><code>"RSA-OAEP"</code></td>
+              <td>"`RSA-OAEP`"</td>
               <td>
                 [[RFC4055]],
                 [[RFC5756]]
@@ -15124,19 +15124,19 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-ecPublicKey (1.2.840.10045.2.1)</td>
               <td>ECPoint</td>
-              <td><code>"ECDH"</code> or <code>"ECDSA"</code></td>
+              <td>"`ECDH`" or "`ECDSA`"</td>
               <td>[[RFC5480]]</td>
             </tr>
             <tr>
               <td>id-ecDH (1.3.132.1.12)</td>
               <td>ECPoint</td>
-              <td><code>"ECDH"</code></td>
+              <td>"`ECDH`"</td>
               <td>[[RFC5480]]</td>
             </tr>
             <tr>
               <td>id-dsa (1.2.840.10040.4.1)</td>
               <td>DSAPublicKey</td>
-              <td><code>"DSA"</code></td>
+              <td>"`DSA`"</td>
               <td>[[RFC3279]]</td>
             </tr>
           </tbody>
@@ -15145,14 +15145,14 @@ const filename = `${crypto.randomUUID()}.txt`;
           <p>
             For "id-RSASSA-PSS" and "id-RSAES-OAEP",
             [[RFC5756]] recommends implementations should not include parameters
-            when PSS is used with a <code>subjectPublicKeyInfo</code>, and MUST NOT include parameters when OAEP
-            is used. However, when OAEP is used as part of a key transport (as an <code>AlgorithmIdentifier</code>),
+            when PSS is used with a `subjectPublicKeyInfo`, and MUST NOT include parameters when OAEP
+            is used. However, when OAEP is used as part of a key transport (as an `AlgorithmIdentifier`),
             implementations MUST include the parameters.
           </p>
           <p>
             The {{KeyFormat/"spki"}} key format in this specification implies
-            <code>subjectPublicKeyInfo</code> and thus may not be appropriate when what is needed is an
-            <code>AlgorithmIdentifier</code> for transport.
+            `subjectPublicKeyInfo` and thus may not be appropriate when what is needed is an
+            `AlgorithmIdentifier` for transport.
           </p>
         </div>
       </section>
@@ -15176,9 +15176,9 @@ const filename = `${crypto.randomUUID()}.txt`;
               <td>rsaEncryption (1.2.840.113549.1.1.1)</td>
               <td>RSAPrivateKey</td>
               <td>
-                <code>"RSASSA-PKCS1-v1_5"</code>,
-                <code>"RSA-PSS"</code>, or
-                <code>"RSA-OAEP"</code>
+                "`RSASSA-PKCS1-v1_5`",
+                "`RSA-PSS`", or
+                "`RSA-OAEP`"
               </td>
               <td>
                 [[RFC3447]],
@@ -15188,7 +15188,7 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-RSASSA-PSS (1.2.840.113549.1.1.10)</td>
               <td>RSAPrivateKey</td>
-              <td><code>"RSA-PSS"</code></td>
+              <td>"`RSA-PSS`"</td>
               <td>
                 [[RFC3447]],
                 [[RFC4055]],
@@ -15198,7 +15198,7 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-RSAES-OAEP (1.2.840.113549.1.1.7)</td>
               <td>RSAPrivateKey</td>
-              <td><code>"RSA-OAEP"</code></td>
+              <td>"`RSA-OAEP`"</td>
               <td>
                 [[RFC3447]],
                 [[RFC4055]],
@@ -15208,7 +15208,7 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-ecPublicKey (1.2.840.10045.2.1)</td>
               <td>ECPrivateKey</td>
-              <td><code>"ECDH"</code> or <code>"ECDSA"</code></td>
+              <td>"`ECDH`" or "`ECDSA`"</td>
               <td>
                 [[RFC5480]],
                 [[RFC5915]],
@@ -15218,7 +15218,7 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-ecDH (1.3.132.1.12)</td>
               <td>ECPrivateKey</td>
-              <td><code>"ECDH"</code></td>
+              <td>"`ECDH`"</td>
               <td>
                 [[RFC5480]],
                 [[RFC5915]],
@@ -15228,7 +15228,7 @@ const filename = `${crypto.randomUUID()}.txt`;
             <tr>
               <td>id-dsa (1.2.840.10040.4.1)</td>
               <td>INTEGER</td>
-              <td><code>"DSA"</code></td>
+              <td>"`DSA`"</td>
               <td>[[RFC5958]]</td>
             </tr>
           </tbody>


### PR DESCRIPTION
Use `|variable_name|` instead of `<var>` elements, and backticks (\`) instead of `<code>` elements.

Also, place the quotes in string literals outside the monotext formatted string value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: connect ETIMEDOUT 128.30.52.89:443 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 28, 2022, 7:06 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebcrypto%2Fc1b9049d5ac5b1c9ee96f6ccaefda1a174ab8312%2Fspec%2FOverview.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcrypto%23309.)._
</details>
