### PR TITLE
fix PBKDF2 get key length

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14216,7 +14216,7 @@ dictionary HkdfParams : Algorithm {
               <tr>
                 <td>Get key length</td>
                 <td>None</td>
-                <td>Integer or null</td>
+                <td>null</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
The PBKDF2 "Get key length" is simply to "Return null.", this fixes the table in 32.2

<img width="465" alt="image" src="https://user-images.githubusercontent.com/241506/161066358-fddfea6f-9180-4690-b3da-6aac88e72aac.png">


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto/pull/311.html" title="Last updated on Mar 31, 2022, 1:31 PM UTC (1c1711f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/311/63c53ef...panva:1c1711f.html" title="Last updated on Mar 31, 2022, 1:31 PM UTC (1c1711f)">Diff</a>