### PR TITLE
Remove reference to DSA OID

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14256,12 +14256,6 @@ const filename = `${crypto.randomUUID()}.txt`;
               <td>"`ECDH`" or "`ECDSA`"</td>
               <td>[[RFC5480]]</td>
             </tr>
-            <tr>
-              <td>id-dsa (1.2.840.10040.4.1)</td>
-              <td>DSAPublicKey</td>
-              <td>"`DSA`"</td>
-              <td>[[RFC3279]]</td>
-            </tr>
           </tbody>
         </table>
         <div class=note>
@@ -14309,12 +14303,6 @@ const filename = `${crypto.randomUUID()}.txt`;
               <td>
                 [[RFC5480]]
               </td>
-            </tr>
-            <tr>
-              <td>id-dsa (1.2.840.10040.4.1)</td>
-              <td>INTEGER</td>
-              <td>"`DSA`"</td>
-              <td>[[RFC5958]]</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
DSA has never been in the spec; remove stale references to its OID.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/326.html" title="Last updated on Apr 25, 2023, 12:59 PM UTC (8bb9140)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/326/7090bd0...8bb9140.html" title="Last updated on Apr 25, 2023, 12:59 PM UTC (8bb9140)">Diff</a>