### PR TITLE
Make deriveBits length parameter optional and nullable

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1257,7 +1257,7 @@ interface SubtleCrypto {
                          sequence&lt;KeyUsage> keyUsages );
   Promise&lt;ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm,
                           CryptoKey baseKey,
-                          unsigned long length);
+                          optional unsigned long? length = null);
 
   Promise&lt;CryptoKey> importKey(KeyFormat format,
                          (BufferSource or JsonWebKey) keyData,


### PR DESCRIPTION
Fixes #322, fixes #329. This is marked as a draft since there is not yet consensus in those issues that this is the solution we should go with, but having a concrete proposal might help move the process along.

---

This change allows omitting the `length` parameter from calls to `deriveBits`, defaulting to `null`, and also allows passing `null` explicitly (as the web platform tests already do).

The "derive bits" operations already handle `null` as it can also be returned by the "get key length" operations.

In the case of ECDH, the operation returns the entire derived key; in the case of HKDF and PBKDF2, the operation returns an error.

This is technically speaking a breaking change, since currently passing `null` explicitly should cause it to be converted to `0`, causing an empty `ArrayBuffer` to be returned. However, the only implementation that actually does so (Chromium) is willing to change this. Additionally, returning the entire value (for ECDH) seems more expected and more useful than returning an empty value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/345.html" title="Last updated on May 31, 2023, 9:38 AM UTC (2b3bca8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/345/0eed687...2b3bca8.html" title="Last updated on May 31, 2023, 9:38 AM UTC (2b3bca8)">Diff</a>