### PR TITLE
Refer to relevant realm instead of relevant global object

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -2060,7 +2060,7 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be a new {{ArrayBuffer}}
+                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
                   containing the result of performing the derive bits operation
                   specified by |normalizedAlgorithm| using |baseKey|,
                   |algorithm| and |length|.
@@ -2422,7 +2422,7 @@ interface SubtleCrypto {
                       </li>
                       <li>
                         <p>
-                          Let |bytes| be the byte sequence the results from converting
+                          Let |bytes| be the [= byte sequence =] containing the result of converting
                           |json|, a JavaScript String comprised of UTF-16 code points, to
                           UTF-8 code points.
                         </p>
@@ -3664,7 +3664,8 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |signature|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |signature|.
                   </p>
                 </li>
               </ol>
@@ -4365,7 +4366,8 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -4430,7 +4432,8 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -4697,7 +4700,8 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |signature|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |signature|.
                   </p>
                 </li>
               </ol>
@@ -5389,7 +5393,8 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -5454,7 +5459,8 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -5724,7 +5730,8 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |ciphertext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -5775,7 +5782,8 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |plaintext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -6416,7 +6424,8 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -6481,7 +6490,8 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -6827,7 +6837,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new empty {{ArrayBuffer}}.
+                            Let |result| be an empty [= byte sequence =].
                           </p>
                         </li>
                         <li>
@@ -6868,7 +6878,8 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |result|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |result|.
                   </p>
                 </li>
               </ol>
@@ -8040,7 +8051,8 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -8195,7 +8207,8 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -8371,7 +8384,8 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -9944,7 +9958,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -10103,7 +10118,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |ciphertext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -10143,7 +10159,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |plaintext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -10417,7 +10434,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -10628,7 +10646,8 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |ciphertext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -10674,7 +10693,8 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |plaintext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -10949,7 +10969,8 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -11199,7 +11220,8 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |ciphertext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -11294,7 +11316,8 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |plaintext|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -11569,7 +11592,8 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -12044,7 +12068,8 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -12260,7 +12285,8 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} containing |mac|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |mac|.
                   </p>
                 </li>
               </ol>
@@ -12691,7 +12717,8 @@ dictionary HmacKeyGenParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} containing |data|.
+                            Let |result| be the result of [= ArrayBuffer/create | creating =]
+                            an {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1328,8 +1328,7 @@ interface SubtleCrypto {
           <h3>Methods and Parameters</h3>
           <p>
             Unless otherwise stated, objects created by the methods defined in this section shall be associated with the
-            [= relevant global object =]
-            of `this` [[HTML]].
+            [= relevant realm =] of [= this =].
           </p>
           <div class=note>
             <p>
@@ -2062,9 +2061,6 @@ interface SubtleCrypto {
               <li>
                 <p>
                   Let |result| be a new {{ArrayBuffer}}
-                  associated with the
-                  [= relevant global object =]
-                  of `this` [[HTML]], and
                   containing the result of performing the derive bits operation
                   specified by |normalizedAlgorithm| using |baseKey|,
                   |algorithm| and |length|.
@@ -2724,8 +2720,7 @@ interface SubtleCrypto {
             this results in termination of execution of the sub-algorithm and all ancestor algorithms
             until one is reached that explicitly describes procedures for catching exceptions.
             The error object thrown shall be associated with the
-            [= relevant global object =]</a>
-            of `this` [[HTML]].
+            [= relevant realm =] of [= this =].
           </p>
         </section>
       </section>
@@ -2900,6 +2895,10 @@ dictionary CryptoKeyPair {
             Additionally, upon initialization, conforming User Agents must perform the
             [= define an algorithm =] steps for each of
             the supported operations, registering their IDL parameter type as indicated.
+          </p>
+          <p>
+            Unless otherwise stated, objects created by the operations defined in this specification
+            shall be associated with the [= relevant realm =] of [= this =].
           </p>
         </section>
 
@@ -3665,10 +3664,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and containing the
-                    bytes of |signature|.
+                    Return a new {{ArrayBuffer}} containing |signature|.
                   </p>
                 </li>
               </ol>
@@ -3777,9 +3773,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 <li>
                   <p>
                     Let |publicKey| be a new {{CryptoKey}}
-                    object, associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and representing the public key of the generated key pair.
+                    representing the public key of the generated key pair.
                   </p>
                 </li>
                 <li>
@@ -3809,9 +3803,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |privateKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |privateKey| be a new {{CryptoKey}}
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -3929,9 +3921,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |key| be a new {{CryptoKey}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and
+                            Let |key| be a new {{CryptoKey}}
                             that represents the RSA public key identified by
                             |publicKey|.
                           </p>
@@ -3999,9 +3989,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |key| be a new {{CryptoKey}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and
+                            Let |key| be a new {{CryptoKey}}
                             that represents the RSA private key identified by
                             |rsaPrivateKey|.
                           </p>
@@ -4377,10 +4365,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -4445,10 +4430,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -4715,10 +4697,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and containing the
-                    bytes of |signature|.
+                    Return a new {{ArrayBuffer}} containing |signature|.
                   </p>
                 </li>
               </ol>
@@ -4826,9 +4805,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |publicKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |publicKey| be a new {{CryptoKey}}
                     representing the public key of the generated key pair.
                   </p>
                 </li>
@@ -4859,9 +4836,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |privateKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |privateKey| be a new {{CryptoKey}}
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -4980,9 +4955,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |key| be a new {{CryptoKey}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and
+                            Let |key| be a new {{CryptoKey}}
                             that represents the RSA public key identified by
                             |publicKey|.
                           </p>
@@ -5048,9 +5021,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |key| be a new {{CryptoKey}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and
+                            Let |key| be a new {{CryptoKey}}
                             that represents the RSA private key identified by
                             |rsaPrivateKey|.
                           </p>
@@ -5418,10 +5389,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -5486,10 +5454,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -5759,10 +5724,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |ciphertext|.
+                    Return a new {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -5813,10 +5775,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |plaintext|.
+                    Return a new {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -5890,9 +5849,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |publicKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |publicKey| be a new {{CryptoKey}}
                     representing the public key of the generated key pair.
                   </p>
                 </li>
@@ -5924,9 +5881,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |privateKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |privateKey| be a new {{CryptoKey}}
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -6047,9 +6002,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |key| be a new {{CryptoKey}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and
+                            Let |key| be a new {{CryptoKey}}
                             that represents the RSA public key identified by
                             |publicKey|.
                           </p>
@@ -6115,9 +6068,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |key| be a new {{CryptoKey}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and
+                            Let |key| be a new {{CryptoKey}}
                             that represents the RSA private key identified by
                             |rsaPrivateKey|.
                           </p>
@@ -6465,10 +6416,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -6533,10 +6481,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -6882,9 +6827,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new empty {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]].
+                            Let |result| be a new empty {{ArrayBuffer}}.
                           </p>
                         </li>
                         <li>
@@ -6925,10 +6868,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and containing the
-                    bytes of |result|.
+                    Return a new {{ArrayBuffer}} containing |result|.
                   </p>
                 </li>
               </ol>
@@ -7088,9 +7028,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |publicKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |publicKey| be a new {{CryptoKey}}
                     representing the public key of the generated key pair.
                   </p>
                 </li>
@@ -7121,9 +7059,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |privateKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |privateKey| be a new {{CryptoKey}}
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -7313,9 +7249,7 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let |key| be a new {{CryptoKey}} associated with the
-                                    [= relevant global object =]
-                                    of `this` [[HTML]], and
+                                    Let |key| be a new {{CryptoKey}}
                                     that represents |publicKey|.
                                   </p>
                                 </li>
@@ -7519,9 +7453,7 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let |key| be a new {{CryptoKey}} associated with the
-                                    [= relevant global object =]
-                                    of `this` [[HTML]], and
+                                    Let |key| be a new {{CryptoKey}}
                                     that represents the Elliptic Curve private key identified by
                                     performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
                                   </p>
@@ -7884,10 +7816,8 @@ dictionary EcKeyImportParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let |key| be a new {{CryptoKey}} associated with the
-                                    [= relevant global object =]
-                                    of `this` [[HTML]], and
-                                    that represents |Q|
+                                    Let |key| be a new {{CryptoKey}}
+                                    that represents |Q|.
                                   </p>
                                 </li>
                               </ol>
@@ -8110,10 +8040,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -8268,10 +8195,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -8447,10 +8371,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -8621,9 +8542,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |publicKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |publicKey| be a new {{CryptoKey}}
                     representing the public key of the generated key pair.
                   </p>
                 </li>
@@ -8653,9 +8572,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |privateKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |privateKey| be a new {{CryptoKey}}
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -8965,9 +8882,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let |key| be a new {{CryptoKey}} associated with the
-                                    [= relevant global object =]
-                                    of `this` [[HTML]], and
+                                    Let |key| be a new {{CryptoKey}}
                                     that represents |publicKey|.
                                   </p>
                                 </li>
@@ -9174,9 +9089,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let |key| be a new {{CryptoKey}} associated with the
-                                    [= relevant global object =]
-                                    of `this` [[HTML]], and
+                                    Let |key| be a new {{CryptoKey}}
                                     that represents the Elliptic Curve private key identified by
                                     performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
                                   </p>
@@ -9491,9 +9404,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Let |key| be a new {{CryptoKey}} associated with the
-                                    [= relevant global object =]
-                                    of `this` [[HTML]], and
+                                    Let |key| be a new {{CryptoKey}}
                                     that represents |Q|.
                                   </p>
                                 </li>
@@ -10033,10 +9944,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -10195,10 +10103,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |ciphertext|.
+                    Return a new {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -10238,10 +10143,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |plaintext|.
+                    Return a new {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -10515,10 +10417,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -10729,10 +10628,7 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |ciphertext|.
+                    Return a new {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -10778,10 +10674,7 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |plaintext|.
+                    Return a new {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -11056,10 +10949,7 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -11309,10 +11199,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |ciphertext|.
+                    Return a new {{ArrayBuffer}} containing |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -11407,10 +11294,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
-                    containing |plaintext|.
+                    Return a new {{ArrayBuffer}} containing |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -11685,10 +11569,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -12106,9 +11987,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |key| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |key| be a new {{CryptoKey}}
                     representing an AES key with value |data|.
                   </p>
                 </li>
@@ -12165,10 +12044,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -12384,10 +12260,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} object, associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and containing the
-                    bytes of |mac|.
+                    Return a new {{ArrayBuffer}} containing |mac|.
                   </p>
                 </li>
               </ol>
@@ -12818,9 +12691,7 @@ dictionary HmacKeyGenParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing |data|.
+                            Let |result| be a new {{ArrayBuffer}} containing |data|.
                           </p>
                         </li>
                       </ol>
@@ -13253,9 +13124,7 @@ dictionary HkdfParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |key| be a new {{CryptoKey}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and
+                            Let |key| be a new {{CryptoKey}}
                             representing the key data provided in |keyData|.
                           </p>
                         </li>
@@ -13456,9 +13325,7 @@ dictionary Pbkdf2Params : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |key| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |key| be a new {{CryptoKey}}
                     representing |keyData|.
                   </p>
                 </li>


### PR DESCRIPTION
For created objects, `this`'s relevant realm is of interest, rather than its relevant global object. 

Also, link out to WebIDL's `this` definition instead of referencing it explicitly.

Also, note that objects are created in the relevant realm of `this` by default, rather than mentioning it everywhere.

And finally, refer to the "create an ArrayBuffer" algorithm of WebIDL, rather than constructing `ArrayBuffer` objects ourselves.

Resolves #346.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/347.html" title="Last updated on Aug 18, 2023, 7:28 AM UTC (46aefca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/347/0eed687...46aefca.html" title="Last updated on Aug 18, 2023, 7:28 AM UTC (46aefca)">Diff</a>