### PR TITLE
Throw on truncation in the ECDH derive bits operation

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -8808,24 +8808,17 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <dl class="switch">
-                    <dt>If |length| is null:</dt>
-                    <dd>Return |secret|</dd>
-                    <dt>Otherwise:</dt>
+                    <dt>
+                      If |length| is not null, and not equal to the length of |secret| in bits:
+                    </dt>
                     <dd>
-                      <dl class="switch">
-                        <dt>
-                          If the length of |secret| in bits is less than
-                          |length|:
-                        </dt>
-                        <dd>
-                          [= exception/throw =] an
-                          {{OperationError}}.
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          Return an [= octet string containing =] the first |length| bits of |secret|.
-                        </dd>
-                      </dl>
+                      [= exception/throw =] an {{OperationError}}.
+                    </dd>
+                    <dt>
+                      Otherwise:
+                    </dt>
+                    <dd>
+                      Return |secret|.
                     </dd>
                   </dl>
                 </li>


### PR DESCRIPTION
Throw on truncation in the ECDH derive bits operation, as discussed in #369.

Truncating the derived value in ECDH does not really make sense, and from Chromium's usage statistics, there is [very low usage](https://chromestatus.com/metrics/feature/timeline/popularity/4746) of truncation, so this change should be relatively low risk.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/351.html" title="Last updated on Sep 19, 2024, 10:35 PM UTC (5bdfd07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/351/0eed687...5bdfd07.html" title="Last updated on Sep 19, 2024, 10:35 PM UTC (5bdfd07)">Diff</a>