### PR TITLE
Fix the definition of SHA-512

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -12957,7 +12957,7 @@ dictionary HmacKeyGenParams : Algorithm {
                       "`SHA-512`":
                     </dt>
                     <dd>
-                      Let |result| be the result of performing the SHA-1 hash function
+                      Let |result| be the result of performing the SHA-512 hash function
                       defined in Section 6.4 of [[FIPS-180-4]] using
                       |message| as the input message, |M|.
                     </dd>


### PR DESCRIPTION
Refer to SHA-512 instead of SHA-1 in the definition of SHA-512.