### PR TITLE
Add Curve25519

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -3349,6 +3349,36 @@ dictionary CryptoKeyPair {
               <td></td>
             </tr>
             <tr>
+              <td><a href="#ed25519">Ed25519</a></td>
+              <td></td>
+              <td></td>
+              <td>✔</td>
+              <td>✔</td>
+              <td></td>
+              <td>✔</td>
+              <td></td>
+              <td></td>
+              <td>✔</td>
+              <td>✔</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><a href="#x25519">X25519</a></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td>✔</td>
+              <td>✔</td>
+              <td>✔</td>
+              <td>✔</td>
+              <td>✔</td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
               <td><a href="#aes-ctr">AES-CTR</a></td>
               <td>✔</td>
               <td>✔</td>
@@ -9975,6 +10005,1713 @@ dictionary EcdhKeyDeriveParams : Algorithm {
         </section>
       </section>
 
+      <section id="ed25519">
+        <h3>Ed25519</h3>
+        <section id="ed25519-description" class="informative">
+          <h4>Description</h4>
+          <p>
+            The "`Ed25519`" algorithm identifier is used to perform signing
+            and verification using the Ed25519 algorithm specified in
+            [[RFC8032]].
+          </p>
+        </section>
+        <section id="ed25519-registration">
+          <h4>Registration</h4>
+          <p>
+            The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
+            for this algorithm is "`Ed25519`".
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
+                <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
+                <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>sign</td>
+                <td>None</td>
+                <td>{{ArrayBuffer}}</td>
+              </tr>
+              <tr>
+                <td>verify</td>
+                <td>None</td>
+                <td>boolean</td>
+              </tr>
+              <tr>
+                <td>generateKey</td>
+                <td>None</td>
+                <td>{{CryptoKeyPair}}</td>
+              </tr>
+              <tr>
+                <td>importKey</td>
+                <td>None</td>
+                <td>{{CryptoKey}}</td>
+              </tr>
+              <tr>
+                <td>exportKey</td>
+                <td>None</td>
+                <td>object</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="ed25519-operations">
+          <h4>Operations</h4>
+          <dl>
+            <dt>Sign</dt>
+            <dd>
+              When signing, the following algorithm should be used:
+              <ol>
+                <li>
+                  <p>
+                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Perform the Ed25519 signing process, as specified in [[RFC8032]],
+                    Section 5.1.6, with |message| as |M|,
+                    using the Ed25519 private key associated with |key|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Return a new {{ArrayBuffer}} associated with the
+                    [= relevant global object =]
+                    of `this` [[HTML]], and containing the
+                    bytes of the signature resulting from performing
+                    the Ed25519 signing process.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+            <dt>Verify</dt>
+            <dd>
+              When verifying, the following algorithm should be used:
+              <ol>
+                <li>
+                  <p>
+                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If the key data of |key| represents an invalid point or a small-order element
+                    on the Elliptic Curve of Ed25519, return `false`.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If the point R, encoded in the first half of |signature|,
+                    represents an invalid point or a small-order element
+                    on the Elliptic Curve of Ed25519, return `false`.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Perform the Ed25519 verification steps, as specified in [[RFC8032]],
+                    Section 5.1.7, using the cofactorless (unbatched) equation,
+                    `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|,
+                    using the Ed25519 public key associated with |key|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |result| be a boolean with the value `true` if the signature is valid
+                    and the value `false` otherwise.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Return |result|.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+            <dt>Generate Key</dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If |usages| contains a value which is not
+                    one of "`sign`" or "`verify`",
+                    then [= exception/throw =] a
+                    {{SyntaxError}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Generate an Ed25519 key pair, as defined in [[RFC8032]], section 5.1.5.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |algorithm| be a new {{KeyAlgorithm}} object.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{KeyAlgorithm/name}} attribute of
+                    |algorithm| to "`Ed25519`".
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |publicKey| be a new {{CryptoKey}} associated with the
+                    [= relevant global object =]
+                    of `this` [[HTML]], and
+                    representing the public key of the generated key pair.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |publicKey| to "`public`"
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    slot of |publicKey| to |algorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    slot of |publicKey| to true.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+                    |publicKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
+                    of |usages| and `[ "verify" ]`.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |privateKey| be a new {{CryptoKey}} associated with the
+                    [= relevant global object =]
+                    of `this` [[HTML]], and
+                    representing the private key of the generated key pair.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |privateKey| to {{KeyType/"private"}}
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    slot of |privateKey| to |algorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    slot of |privateKey| to |extractable|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+                    |privateKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
+                    of |usages| and `[ "sign" ]`.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |result| be a new {{CryptoKeyPair}}
+                    dictionary.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKeyPair/publicKey}} attribute
+                    of |result| to be |publicKey|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKeyPair/privateKey}} attribute
+                    of |result| to be |privateKey|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Return the result of converting |result| to an ECMAScript Object, as
+                    defined by [[WebIDL]].
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>Import Key</dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>Let |keyData| be the key data to be imported.</p>
+                </li>
+                <li>
+                  <dl class="switch">
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If |usages| contains a value which is not
+                            "`verify`"
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |spki| be the result of running the
+                            <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                            algorithm over |keyData|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If an error occurred while parsing,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `algorithm` object identifier field of the
+                            `algorithm` AlgorithmIdentifier field of |spki| is
+                            not equal to the `id-Ed25519`
+                            object identifier defined in [[RFC8410]],
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `parameters` field of the `algorithm`
+                            AlgorithmIdentifier field of |spki| is present,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |publicKey| be the Ed25519 public key identified by
+                            the `subjectPublicKey` field of |spki|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |key| be a new {{CryptoKey}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and
+                            that represents |publicKey|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| to "`public`"
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new {{KeyAlgorithm}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`Ed25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If |usages| contains a value which is not
+                            "`sign`"
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |privateKeyInfo| be the result of running the
+                            <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
+                            algorithm over |keyData|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If an error occurs while parsing,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `algorithm` object identifier field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                            |privateKeyInfo| is not equal to the
+                            `id-Ed25519` object identifier defined in [[RFC8410]],
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `parameters` field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                            of |privateKeyInfo| is present,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
+                            algorithm, with |data| as the `privateKey` field
+                            of |privateKeyInfo|, |structure| as the ASN.1
+                            `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If an error occurred while parsing,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |key| be a new {{CryptoKey}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and
+                            that represents the Ed25519 private key identified by |curvePrivateKey|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| to {{KeyType/"private"}}
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new {{KeyAlgorithm}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`Ed25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <dl class="switch">
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                            <dt>Otherwise:</dt>
+                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                          </dl>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/d}} field is present and |usages| contains
+                            a value which is not
+                            "`sign`", or,
+                            if the {{JsonWebKey/d}} field is not present and |usages| contains
+                            a value which is not
+                            "`verify`"
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
+                            "`OKP`",
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/crv}} field of |jwk| is not
+                            "`Ed25519`",
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                            not "`sig`",
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                            is invalid according to the requirements of JSON Web
+                            Key [[JWK]], or it does not contain all of the specified |usages|
+                            values,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <dl class="switch">
+                            <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                            <dd>
+                              <ol>
+                                <li>
+                                  <p>
+                                    If |jwk| does not meet the requirements of Section 2
+                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Let |key| be a new {{CryptoKey}} object that represents the
+                                    Ed25519 private key identified by interpreting
+                                    |jwk| according to Section 2 of [[RFC8037]].
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    internal slot of |Key| to {{KeyType/"private"}}.
+                                  </p>
+                                </li>
+                              </ol>
+                            </dd>
+                            <dt>Otherwise:</dt>
+                            <dd>
+                              <ol>
+                                <li>
+                                  <p>
+                                    If |jwk| does not meet the requirements of Section 2
+                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Let |key| be a new {{CryptoKey}} object that represents the
+                                    Ed25519 public key identified by interpreting
+                                    |jwk| according to Section 2 of [[RFC8037]].
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    internal slot of |Key| to {{KeyType/"public"}}.
+                                  </p>
+                                </li>
+                              </ol>
+                            </dd>
+                          </dl>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`Ed25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If |usages| contains a value which is not
+                            "`verify`"
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new {{KeyAlgorithm}} object.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`Ed25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |key| be a new {{CryptoKey}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and
+                            representing the key data provided in |keyData|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| to "`public`"
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <p>
+                        [= exception/throw =] a
+                        {{NotSupportedError}}.
+                      </p>
+                    </dd>
+                  </dl>
+                </li>
+                <li>
+                  <p>
+                    Return |key|
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>Export Key</dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    Let |key| be the {{CryptoKey}} to be
+                    exported.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
+                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                  </p>
+                </li>
+                <li>
+                  <dl class="switch">
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            ASN.1 structure defined in [[RFC5280]]
+                            with the following properties:
+                          </p>
+                          <ul>
+                            <li>
+                              <p>
+                                Set the |algorithm| field to an
+                                `AlgorithmIdentifier` ASN.1 type with the following
+                                properties:
+                              </p>
+                              <ul>
+                                <li>
+                                  <p>
+                                    Set the |algorithm| object identifier to the
+                                    `id-Ed25519` OID defined in [[RFC8410]].
+                                  </p>
+                                </li>
+                              </ul>
+                            </li>
+                            <li>
+                              <p>
+                                Set the |subjectPublicKey| field to |keyData|.
+                              </p>
+                            </li>
+                          </ul>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be a new {{ArrayBuffer}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and containing
+                            |data|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |data| be an instance of the `privateKeyInfo`
+                            ASN.1 structure defined in [[RFC5208]]
+                            with the following properties:
+                          </p>
+                          <ul>
+                            <li>
+                              <p>
+                                Set the |version| field to `0`.
+                              </p>
+                            </li>
+                            <li>
+                              <p>
+                                Set the |privateKeyAlgorithm| field to a
+                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                                following properties:
+                              </p>
+                              <ul>
+                                <li>
+                                  <p>
+                                    Set the |algorithm| object identifier to the
+                                    `id-Ed25519` OID defined in [[RFC8410]].
+                                  </p>
+                                </li>
+                              </ul>
+                            </li>
+                            <li>
+                              <p>
+                                Set the |privateKey| field to the result of DER-encoding
+                                a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
+                                Ed25519 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                                |key|
+                              </p>
+                            </li>
+                          </ul>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be a new {{ArrayBuffer}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and containing
+                            |data|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            Let |jwk| be a new {{JsonWebKey}}
+                            dictionary.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `kty` attribute of |jwk| to
+                            "`OKP`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `crv` attribute of |jwk| to
+                            "`Ed25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                            definition in Section 2 of [[RFC8037]].
+                          </p>
+                        </li>
+                        <li>
+                          <dl class="switch">
+                            <dt>
+                              If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                              of |key| is {{KeyType/"private"}}
+                            </dt>
+                            <dd>
+                              Set the {{JsonWebKey/d}} attribute of |jwk| according to the
+                              definition in Section 2 of [[RFC8037]].
+                            </dd>
+                          </dl>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
+                            of |key|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be the result of converting |jwk|
+                            to an ECMAScript Object, as defined by [[WebIDL]].
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>
+                      If |format| is {{KeyFormat/"raw"}}:
+                    </dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a> representing the Ed25519
+                            public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                            |key|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be a new {{ArrayBuffer}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and containing
+                            |data|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <p>
+                        [= exception/throw =] a
+                        {{NotSupportedError}}.
+                      </p>
+                    </dd>
+                  </dl>
+                </li>
+                <li>
+                  <p>
+                    Return |result|.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+          </dl>
+        </section>
+      </section>
+
+      <section id="x25519">
+        <h3>X25519</h3>
+        <section id="x25519-description" class="informative">
+          <h4>Description</h4>
+          <p>
+            The "`X25519`" algorithm identifier is used to perform
+            key agreement using the X25519 algorithm specified in
+            [[RFC7748]].
+          </p>
+        </section>
+        <section id="x25519-registration">
+          <h4>Registration</h4>
+          <p>
+            The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
+            for this algorithm is "`X25519`".
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
+                <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
+                <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>deriveBits</td>
+                <td>{{EcdhKeyDeriveParams}}</td>
+                <td><a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a></td>
+              </tr>
+              <tr>
+                <td>generateKey</td>
+                <td>None</td>
+                <td>{{CryptoKeyPair}}</td>
+              </tr>
+              <tr>
+                <td>importKey</td>
+                <td>None</td>
+                <td>{{CryptoKey}}</td>
+              </tr>
+              <tr>
+                <td>exportKey</td>
+                <td>None</td>
+                <td>object</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="x25519-operations">
+          <h4>Operations</h4>
+          <dl>
+            <dt>Derive Bits</dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |publicKey| be the
+                    {{EcdhKeyDeriveParams/public}} member of
+                    |normalizedAlgorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If the {{KeyAlgorithm/name}} attribute of
+                    the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
+                    |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
+                    |key|, then [= exception/throw =] an {{InvalidAccessError}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |secret| be the result of performing the X25519 function specified in
+                    [[RFC7748]] Section 5 with |key| as the X25519 private key |k|
+                    and the X25519 public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a>
+                    internal slot of |publicKey| as the X25519 public key |u|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If |secret| is the all-zero value,
+                    then [= exception/throw =] a {{OperationError}}.
+                    This check must be performed in constant-time, as per [[RFC7748]] Section 6.1.
+                  </p>
+                </li>
+                <li>
+                  <dl class="switch">
+                    <dt>If |length| is null:</dt>
+                    <dd>Return |secret|</dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <dl class="switch">
+                        <dt>
+                          If the length of |secret| in bits is less than
+                          |length|:
+                        </dt>
+                        <dd>
+                          [= exception/throw =] an
+                          {{OperationError}}.
+                        </dd>
+                        <dt>Otherwise:</dt>
+                        <dd>
+                          Return an <a data-cite="WebCryptoAPI#octet-string-containing">octet string containing</a> the first |length| bits of |secret|.
+                        </dd>
+                      </dl>
+                    </dd>
+                  </dl>
+                </li>
+              </ol>
+            </dd>
+            <dt>Generate Key</dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    If |usages| contains an entry which is not
+                    "`deriveKey`" or "`deriveBits`"
+                    then [= exception/throw =] a
+                    {{SyntaxError}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Generate an X25519 key pair, with the private key being 32 random bytes,
+                    and the public key being `X25519(a, 9)`,
+                    as defined in [[RFC7748]], section 6.1.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |algorithm| be a new {{KeyAlgorithm}} object.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{KeyAlgorithm/name}} attribute of
+                    |algorithm| to "`X25519`".
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |publicKey| be a new {{CryptoKey}} associated with the
+                    [= relevant global object =]
+                    of `this` [[HTML]], and
+                    representing the public key of the generated key pair.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |publicKey| to "`public`"
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    slot of |publicKey| to |algorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    slot of |publicKey| to true.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+                    |publicKey| to be the empty list.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |privateKey| be a new {{CryptoKey}} associated with the
+                    [= relevant global object =]
+                    of `this` [[HTML]], and
+                    representing the private key of the generated key pair.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    |privateKey| to {{KeyType/"private"}}
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    slot of |privateKey| to |algorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    slot of |privateKey| to |extractable|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+                    |privateKey| to be the
+                    <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a> of
+                    |usages| and `[ "deriveKey", "deriveBits" ]`.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Let |result| be a new {{CryptoKeyPair}}
+                    dictionary.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKeyPair/publicKey}} attribute
+                    of |result| to be |publicKey|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKeyPair/privateKey}} attribute
+                    of |result| to be |privateKey|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Return the result of converting |result| to an ECMAScript Object, as
+                    defined by [[WebIDL]].
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>Import Key</dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>Let |keyData| be the key data to be imported.</p>
+                </li>
+                <li>
+                  <dl class="switch">
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If |usages| is not empty
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |spki| be the result of running the
+                            <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                            algorithm over |keyData|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If an error occurred while parsing,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `algorithm` object identifier field of the
+                            `algorithm` AlgorithmIdentifier field of |spki| is
+                            not equal to the `id-X25519`
+                            object identifier defined in [[RFC8410]],
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `parameters` field of the `algorithm`
+                            AlgorithmIdentifier field of |spki| is present,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |publicKey| be the X25519 public key identified by
+                            the `subjectPublicKey` field of |spki|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |key| be a new {{CryptoKey}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and
+                            that represents |publicKey|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| to "`public`"
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new {{KeyAlgorithm}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`X25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If |usages| contains an entry which is not
+                            "`deriveKey`" or "`deriveBits`"
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |privateKeyInfo| be the result of running the
+                            <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
+                            algorithm over |keyData|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If an error occurs while parsing,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `algorithm` object identifier field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                            |privateKeyInfo| is not equal to the
+                            `id-X25519` object identifier defined in [[RFC8410]],
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the `parameters` field of the
+                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                            of |privateKeyInfo| is present,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
+                            algorithm, with |data| as the `privateKey` field
+                            of |privateKeyInfo|, |structure| as the ASN.1
+                            `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If an error occurred while parsing,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |key| be a new {{CryptoKey}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and
+                            that represents the X25519 private key identified by |curvePrivateKey|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| to {{KeyType/"private"}}
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new {{KeyAlgorithm}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`X25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <dl class="switch">
+                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                            <dt>Otherwise:</dt>
+                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                          </dl>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/d}} field is present and if |usages|
+                            contains an entry which is not
+                            "`deriveKey`" or "`deriveBits`"
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/d}} field is not present and if |usages| is not
+                            empty
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/kty}} field of |jwk| is not
+                            "`OKP`",
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/crv}} field of |jwk| is not
+                            "`X25519`",
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                            and is not equal to "`enc`" then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                            is invalid according to the requirements of JSON Web
+                            Key [[JWK]], or it does not contain all of the specified |usages|
+                            values,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            If the {{JsonWebKey/ext}} field of |jwk| is present and
+                            has the value false and |extractable| is true,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <dl class="switch">
+                            <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                            <dd>
+                              <ol>
+                                <li>
+                                  <p>
+                                    If |jwk| does not meet the requirements of Section 2
+                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Let |key| be a new {{CryptoKey}} object that represents the
+                                    X25519 private key identified by interpreting
+                                    |jwk| according to Section 2 of [[RFC8037]].
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    internal slot of |Key| to {{KeyType/"private"}}.
+                                  </p>
+                                </li>
+                              </ol>
+                            </dd>
+                            <dt>Otherwise:</dt>
+                            <dd>
+                              <ol>
+                                <li>
+                                  <p>
+                                    If |jwk| does not meet the requirements of Section 2
+                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Let |key| be a new {{CryptoKey}} object that represents the
+                                    X25519 public key identified by interpreting
+                                    |jwk| according to Section 2 of [[RFC8037]].
+                                  </p>
+                                </li>
+                                <li>
+                                  <p>
+                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    internal slot of |Key| to {{KeyType/"public"}}.
+                                  </p>
+                                </li>
+                              </ol>
+                            </dd>
+                          </dl>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`X25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If |usages| is not empty
+                            then [= exception/throw =] a
+                            {{SyntaxError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |algorithm| be a new {{KeyAlgorithm}} object.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{KeyAlgorithm/name}} attribute of
+                            |algorithm| to "`X25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |key| be a new {{CryptoKey}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and
+                            representing the key data provided in |keyData|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| to "`public`"
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            internal slot of |key| to |algorithm|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <p>
+                        [= exception/throw =] a
+                        {{NotSupportedError}}.
+                      </p>
+                    </dd>
+                  </dl>
+                </li>
+                <li>
+                  <p>
+                    Return |key|
+                  </p>
+                </li>
+              </ol>
+            </dd>
+
+            <dt>Export Key</dt>
+            <dd>
+              <ol>
+                <li>
+                  <p>
+                    Let |key| be the {{CryptoKey}} to be
+                    exported.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
+                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                  </p>
+                </li>
+                <li>
+                  <dl class="switch">
+                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            ASN.1 structure defined in [[RFC5280]]
+                            with the following properties:
+                          </p>
+                          <ul>
+                            <li>
+                              <p>
+                                Set the |algorithm| field to an
+                                `AlgorithmIdentifier` ASN.1 type with the following
+                                properties:
+                              </p>
+                              <ul>
+                                <li>
+                                  <p>
+                                    Set the |algorithm| object identifier to the
+                                    `id-X25519` OID defined in [[RFC8410]].
+                                  </p>
+                                </li>
+                              </ul>
+                            </li>
+                            <li>
+                              <p>
+                                Set the |subjectPublicKey| field to |keyData|.
+                              </p>
+                            </li>
+                          </ul>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be a new {{ArrayBuffer}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and containing
+                            |data|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |data| be an instance of the `privateKeyInfo`
+                            ASN.1 structure defined in [[RFC5208]]
+                            with the following properties:
+                          </p>
+                          <ul>
+                            <li>
+                              <p>
+                                Set the |version| field to `0`.
+                              </p>
+                            </li>
+                            <li>
+                              <p>
+                                Set the |privateKeyAlgorithm| field to a
+                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                                following properties:
+                              </p>
+                              <ul>
+                                <li>
+                                  <p>
+                                    Set the |algorithm| object identifier to the
+                                    `id-X25519` OID defined in [[RFC8410]].
+                                  </p>
+                                </li>
+                              </ul>
+                            </li>
+                            <li>
+                              <p>
+                                Set the |privateKey| field to the result of DER-encoding
+                                a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
+                                X25519 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                                |key|
+                              </p>
+                            </li>
+                          </ul>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be a new {{ArrayBuffer}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and containing
+                            |data|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            Let |jwk| be a new {{JsonWebKey}}
+                            dictionary.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `kty` attribute of |jwk| to
+                            "`OKP`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `crv` attribute of |jwk| to
+                            "`X25519`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                            definition in Section 2 of [[RFC8037]].
+                          </p>
+                        </li>
+                        <li>
+                          <dl class="switch">
+                            <dt>
+                              If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                              of |key| is {{KeyType/"private"}}
+                            </dt>
+                            <dd>
+                              Set the {{JsonWebKey/d}} attribute of |jwk| according to the
+                              definition in Section 2 of [[RFC8037]].
+                            </dd>
+                          </dl>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
+                            of |key|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be the result of converting |jwk|
+                            to an ECMAScript Object, as defined by [[WebIDL]].
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>
+                      If |format| is {{KeyFormat/"raw"}}:
+                    </dt>
+                    <dd>
+                      <ol>
+                        <li>
+                          <p>
+                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a> representing the X25519
+                            public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                            |key|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Let |result| be a new {{ArrayBuffer}} associated with the
+                            [= relevant global object =]
+                            of `this` [[HTML]], and containing
+                            |data|.
+                          </p>
+                        </li>
+                      </ol>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <p>
+                        [= exception/throw =] a
+                        {{NotSupportedError}}.
+                      </p>
+                    </dd>
+                  </dl>
+                </li>
+                <li>
+                  <p>
+                    Return |result|.
+                  </p>
+                </li>
+              </ol>
+            </dd>
+          </dl>
+        </section>
+      </section>
+
       <section id="aes-ctr">
         <h3>AES-CTR</h3>
         <section id="aes-ctr-description" class="informative">
@@ -13408,6 +15145,52 @@ dictionary Pbkdf2Params : Algorithm {
 
       <section id="examples-section">
         <h2>JavaScript Example Code</h2>
+        <section id="example-key-exchange">
+          <h2>Usage Example</h2>
+          <p>
+            This example generates two X25519 key pairs, one for Alice and one for Bob, performs
+            a key agreement between them, derives a 256-bit AES-GCM key from the result using
+            HKDF with SHA-256, and encrypts and decrypts some data with it.
+          </p>
+          <pre class="example js" title="X25519 key agreement">
+            // Generate a key pair for Alice.
+            const alice_x25519_key = await crypto.subtle.generateKey('X25519', false /* extractable */, ['deriveKey']);
+            const alice_private_key = alice_x25519_key.privateKey;
+
+            // Normally, the public key would be sent by Bob to Alice in advance over some authenticated channel.
+            // In this example, we'll generate another key pair and use its public key instead.
+            const bob_x25519_key = await crypto.subtle.generateKey('X25519', false /* extractable */, ['deriveKey']);
+            const bob_public_key = bob_x25519_key.publicKey;
+
+            // Perform the key agreement.
+            const alice_x25519_params = { name: 'X25519', public: bob_public_key };
+            const alice_shared_key = await crypto.subtle.deriveKey(alice_x25519_params, alice_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
+
+            // Derive a symmetric key from the result.
+            const salt = crypto.getRandomValues(new Uint8Array(32));
+            const info = new TextEncoder().encode('X25519 key agreement for an AES-GCM-256 key');
+            const hkdf_params = { name: 'HKDF', hash: 'SHA-256', salt, info };
+            const gcm_params = { name: 'AES-GCM', length: 256 };
+            const alice_symmetric_key = await crypto.subtle.deriveKey(hkdf_params, alice_shared_key, gcm_params, false /* extractable */, ['encrypt', 'decrypt']);
+
+            // Encrypt some data with the symmetric key, and send it to Bob. The IV must be passed along as well.
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const message = new TextEncoder().encode('Hi Bob!');
+            const encrypted = await crypto.subtle.encrypt({ ...gcm_params, iv }, alice_symmetric_key, message);
+
+            // On Bob's side, Alice's public key and Bob's private key are used, instead.
+            // To get the same result, Alice and Bob must agree on using the same salt and info.
+            const alice_public_key = alice_x25519_key.publicKey;
+            const bob_private_key = bob_x25519_key.privateKey;
+            const bob_x25519_params = { name: 'X25519', public: alice_public_key };
+            const bob_shared_key = await crypto.subtle.deriveKey(bob_x25519_params, bob_private_key, 'HKDF', false /* extractable */, ['deriveKey']);
+            const bob_symmetric_key = await crypto.subtle.deriveKey(hkdf_params, bob_shared_key, gcm_params, false /* extractable */, ['encrypt', 'decrypt']);
+
+            // On Bob's side, the data can be decrypted.
+            const decrypted = await crypto.subtle.decrypt({ ...gcm_params, iv }, bob_symmetric_key, encrypted);
+            const decrypted_message = new TextDecoder().decode(decrypted);
+          </pre>
+        </section>
         <section id="examples-signing">
           <h3>Generate a signing key pair, sign some data</h3>
 
@@ -13844,6 +15627,32 @@ const filename = `${crypto.randomUUID()}.txt`;
               <tr>
                 <td>
 <pre class=js>
+{ kty: "OKP",
+  crv: "Ed25519" }
+</pre>
+                </td>
+                <td>
+<pre class=js>
+{ name: "Ed25519" }
+</pre>
+                </td>
+              </tr>
+              <tr>
+                <td>
+<pre class=js>
+{ kty: "OKP",
+  crv: "X25519" }
+</pre>
+                </td>
+                <td>
+<pre class=js>
+{ name: "X25519" }
+</pre>
+                </td>
+              </tr>
+              <tr>
+                <td>
+<pre class=js>
 { kty: "oct",
   alg: "A128CTR" }
 </pre>
@@ -14148,6 +15957,26 @@ const filename = `${crypto.randomUUID()}.txt`;
               <td>"`ECDH`" or "`ECDSA`"</td>
               <td>[[RFC5480]]</td>
             </tr>
+            <tr>
+              <td>id-Ed25519 (1.3.101.112)</td>
+              <td>BIT STRING</td>
+              <td>
+                "`Ed25519`"
+              </td>
+              <td>
+                [[RFC8410]]
+              </td>
+            </tr>
+            <tr>
+              <td>id-X25519 (1.3.101.110)</td>
+              <td>BIT STRING</td>
+              <td>
+                "`X25519`"
+              </td>
+              <td>
+                [[RFC8410]]
+              </td>
+            </tr>
           </tbody>
         </table>
         <div class=note>
@@ -14194,6 +16023,26 @@ const filename = `${crypto.randomUUID()}.txt`;
               <td>"`ECDH`" or "`ECDSA`"</td>
               <td>
                 [[RFC5480]]
+              </td>
+            </tr>
+            <tr>
+              <td>id-Ed25519 (1.3.101.112)</td>
+              <td>CurvePrivateKey</td>
+              <td>
+                "`Ed25519`"
+              </td>
+              <td>
+                [[RFC8410]]
+              </td>
+            </tr>
+            <tr>
+              <td>id-X25519 (1.3.101.110)</td>
+              <td>CurvePrivateKey</td>
+              <td>
+                "`X25519`"
+              </td>
+              <td>
+                [[RFC8410]]
               </td>
             </tr>
           </tbody>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10018,15 +10018,15 @@ dictionary EcdhKeyDeriveParams : Algorithm {
         <section id="ed25519-registration">
           <h4>Registration</h4>
           <p>
-            The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
-            for this algorithm is "`Ed25519`".
+            The [= recognized algorithm name =] for
+            this algorithm is "`Ed25519`".
           </p>
           <table>
             <thead>
               <tr>
-                <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
-                <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
-                <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
+                <th><a href="#supported-operations">Operation</a></th>
+                <th><a href="#algorithm-specific-params">Parameters</a></th>
+                <th><a href="#algorithm-result">Result</a></th>
               </tr>
             </thead>
             <tbody>
@@ -10068,7 +10068,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    If the {{CryptoKey/[[type]]}} internal slot of
                     |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
@@ -10096,7 +10096,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    If the {{CryptoKey/[[type]]}} internal slot of
                     |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
@@ -10171,26 +10171,26 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    Set the {{CryptoKey/[[type]]}} internal slot of
                     |publicKey| to "`public`"
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    Set the {{CryptoKey/[[algorithm]]}} internal
                     slot of |publicKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    Set the {{CryptoKey/[[extractable]]}} internal
                     slot of |publicKey| to true.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                    |publicKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
+                    Set the {{CryptoKey/[[usages]]}} internal slot of
+                    |publicKey| to be the [= usage intersection =]
                     of |usages| and `[ "verify" ]`.
                   </p>
                 </li>
@@ -10204,26 +10204,26 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    Set the {{CryptoKey/[[type]]}} internal slot of
                     |privateKey| to {{KeyType/"private"}}
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    Set the {{CryptoKey/[[algorithm]]}} internal
                     slot of |privateKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    Set the {{CryptoKey/[[extractable]]}} internal
                     slot of |privateKey| to |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
-                    |privateKey| to be the <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a>
+                    Set the {{CryptoKey/[[usages]]}} internal slot of
+                    |privateKey| to be the [= usage intersection =]
                     of |usages| and `[ "sign" ]`.
                   </p>
                 </li>
@@ -10276,7 +10276,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Let |spki| be the result of running the
-                            <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                            [= parse a subjectPublicKeyInfo =]
                             algorithm over |keyData|.
                           </p>
                         </li>
@@ -10321,7 +10321,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            Set the {{CryptoKey/[[type]]}} internal slot
                             of |key| to "`public`"
                           </p>
                         </li>
@@ -10338,7 +10338,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -10358,7 +10358,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Let |privateKeyInfo| be the result of running the
-                            <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
+                            [= parse a privateKeyInfo =]
                             algorithm over |keyData|.
                           </p>
                         </li>
@@ -10390,7 +10390,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
+                            Let |curvePrivateKey| be the result of performing the
+                            [= parse an ASN.1 structure =]
                             algorithm, with |data| as the `privateKey` field
                             of |privateKeyInfo|, |structure| as the ASN.1
                             `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
@@ -10413,7 +10414,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            Set the {{CryptoKey/[[type]]}} internal slot
                             of |key| to {{KeyType/"private"}}
                           </p>
                         </li>
@@ -10430,7 +10431,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -10521,7 +10522,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    Set the {{CryptoKey/[[type]]}}
                                     internal slot of |Key| to {{KeyType/"private"}}.
                                   </p>
                                 </li>
@@ -10545,7 +10546,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    Set the {{CryptoKey/[[type]]}}
                                     internal slot of |Key| to {{KeyType/"public"}}.
                                   </p>
                                 </li>
@@ -10566,7 +10567,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -10604,13 +10605,13 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            Set the {{CryptoKey/[[type]]}} internal slot
                             of |key| to "`public`"
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -10644,7 +10645,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
@@ -10655,7 +10656,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            If the {{CryptoKey/[[type]]}} internal slot
                             of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
@@ -10703,7 +10704,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            If the {{CryptoKey/[[type]]}} internal slot
                             of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
@@ -10738,7 +10739,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               <p>
                                 Set the |privateKey| field to the result of DER-encoding
                                 a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                                Ed25519 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                                Ed25519 private key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 |key|
                               </p>
                             </li>
@@ -10784,7 +10785,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                              If the {{CryptoKey/[[type]]}} internal slot
                               of |key| is {{KeyType/"private"}}
                             </dt>
                             <dd>
@@ -10800,7 +10801,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
+                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
                             of |key|.
                           </p>
                         </li>
@@ -10819,14 +10820,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            If the {{CryptoKey/[[type]]}} internal slot
                             of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a> representing the Ed25519
-                            public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                            Let |data| be an [= octet string =] representing the Ed25519
+                            public key represented by the {{CryptoKey/[[handle]]}} internal slot of
                             |key|.
                           </p>
                         </li>
@@ -10873,22 +10874,22 @@ dictionary EcdhKeyDeriveParams : Algorithm {
         <section id="x25519-registration">
           <h4>Registration</h4>
           <p>
-            The <a data-cite="WebCryptoAPI#recognized-algorithm-name">recognized algorithm name</a>
-            for this algorithm is "`X25519`".
+            The [= recognized algorithm name =] for
+            this algorithm is "`X25519`".
           </p>
           <table>
             <thead>
               <tr>
-                <th><a data-cite="WebCryptoAPI#supported-operations">Operation</a></th>
-                <th><a data-cite="WebCryptoAPI#algorithm-specific-params">Parameters</a></th>
-                <th><a data-cite="WebCryptoAPI#algorithm-result">Result</a></th>
+                <th><a href="#supported-operations">Operation</a></th>
+                <th><a href="#algorithm-specific-params">Parameters</a></th>
+                <th><a href="#algorithm-result">Result</a></th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>deriveBits</td>
                 <td>{{EcdhKeyDeriveParams}}</td>
-                <td><a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a></td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>generateKey</td>
@@ -10917,7 +10918,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    If the {{CryptoKey/[[type]]}} internal slot of
                     |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
@@ -10930,15 +10931,15 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    If the {{CryptoKey/[[type]]}} internal slot of
                     |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
                 <li>
                   <p>
                     If the {{KeyAlgorithm/name}} attribute of
-                    the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
-                    |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal slot of
+                    the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
                     |key|, then [= exception/throw =] an {{InvalidAccessError}}.
                   </p>
                 </li>
@@ -10946,7 +10947,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                   <p>
                     Let |secret| be the result of performing the X25519 function specified in
                     [[RFC7748]] Section 5 with |key| as the X25519 private key |k|
-                    and the X25519 public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a>
+                    and the X25519 public key represented by the {{CryptoKey/[[handle]]}}
                     internal slot of |publicKey| as the X25519 public key |u|.
                   </p>
                 </li>
@@ -10974,7 +10975,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </dd>
                         <dt>Otherwise:</dt>
                         <dd>
-                          Return an <a data-cite="WebCryptoAPI#octet-string-containing">octet string containing</a> the first |length| bits of |secret|.
+                          Return an [= octet string containing =] the first |length| bits of |secret|.
                         </dd>
                       </dl>
                     </dd>
@@ -11021,25 +11022,25 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    Set the {{CryptoKey/[[type]]}} internal slot of
                     |publicKey| to "`public`"
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    Set the {{CryptoKey/[[algorithm]]}} internal
                     slot of |publicKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    Set the {{CryptoKey/[[extractable]]}} internal
                     slot of |publicKey| to true.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+                    Set the {{CryptoKey/[[usages]]}} internal slot of
                     |publicKey| to be the empty list.
                   </p>
                 </li>
@@ -11053,27 +11054,27 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot of
+                    Set the {{CryptoKey/[[type]]}} internal slot of
                     |privateKey| to {{KeyType/"private"}}
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a> internal
+                    Set the {{CryptoKey/[[algorithm]]}} internal
                     slot of |privateKey| to |algorithm|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal
+                    Set the {{CryptoKey/[[extractable]]}} internal
                     slot of |privateKey| to |extractable|.
                   </p>
                 </li>
                 <li>
                   <p>
-                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-usages">[[\usages]]</a> internal slot of
+                    Set the {{CryptoKey/[[usages]]}} internal slot of
                     |privateKey| to be the
-                    <a data-cite="WebCryptoAPI#concept-usage-intersection">usage intersection</a> of
+                    [= usage intersection =] of
                     |usages| and `[ "deriveKey", "deriveBits" ]`.
                   </p>
                 </li>
@@ -11125,7 +11126,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Let |spki| be the result of running the
-                            <a data-cite="WebCryptoAPI#concept-parse-a-spki">parse a subjectPublicKeyInfo</a>
+                            [= parse a subjectPublicKeyInfo =]
                             algorithm over |keyData|.
                           </p>
                         </li>
@@ -11170,7 +11171,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            Set the {{CryptoKey/[[type]]}} internal slot
                             of |key| to "`public`"
                           </p>
                         </li>
@@ -11187,7 +11188,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -11207,7 +11208,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <p>
                             Let |privateKeyInfo| be the result of running the
-                            <a data-cite="WebCryptoAPI#concept-parse-a-privateKeyInfo">parse a privateKeyInfo</a>
+                            [= parse a privateKeyInfo =]
                             algorithm over |keyData|.
                           </p>
                         </li>
@@ -11239,7 +11240,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |curvePrivateKey| be the result of performing the <a data-cite="WebCryptoAPI#concept-parse-an-asn1-structure">parse an ASN.1 structure</a>
+                            Let |curvePrivateKey| be the result of performing the
+                            [= parse an ASN.1 structure =]
                             algorithm, with |data| as the `privateKey` field
                             of |privateKeyInfo|, |structure| as the ASN.1
                             `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
@@ -11262,7 +11264,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            Set the {{CryptoKey/[[type]]}} internal slot
                             of |key| to {{KeyType/"private"}}
                           </p>
                         </li>
@@ -11279,7 +11281,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -11374,7 +11376,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    Set the {{CryptoKey/[[type]]}}
                                     internal slot of |Key| to {{KeyType/"private"}}.
                                   </p>
                                 </li>
@@ -11398,7 +11400,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                 </li>
                                 <li>
                                   <p>
-                                    Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a>
+                                    Set the {{CryptoKey/[[type]]}}
                                     internal slot of |Key| to {{KeyType/"public"}}.
                                   </p>
                                 </li>
@@ -11419,7 +11421,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -11456,13 +11458,13 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            Set the {{CryptoKey/[[type]]}} internal slot
                             of |key| to "`public`"
                           </p>
                         </li>
                         <li>
                           <p>
-                            Set the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-algorithm">[[\algorithm]]</a>
+                            Set the {{CryptoKey/[[algorithm]]}}
                             internal slot of |key| to |algorithm|.
                           </p>
                         </li>
@@ -11496,7 +11498,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    If the underlying cryptographic key material represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of |key|
+                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
                     cannot be accessed, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
@@ -11507,7 +11509,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            If the {{CryptoKey/[[type]]}} internal slot
                             of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
@@ -11555,7 +11557,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            If the {{CryptoKey/[[type]]}} internal slot
                             of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
@@ -11590,7 +11592,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               <p>
                                 Set the |privateKey| field to the result of DER-encoding
                                 a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                                X25519 private key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                                X25519 private key represented by the {{CryptoKey/[[handle]]}} internal slot of
                                 |key|
                               </p>
                             </li>
@@ -11636,7 +11638,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         <li>
                           <dl class="switch">
                             <dt>
-                              If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                              If the {{CryptoKey/[[type]]}} internal slot
                               of |key| is {{KeyType/"private"}}
                             </dt>
                             <dd>
@@ -11652,7 +11654,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the `ext` attribute of |jwk| to the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-extractable">[[\extractable]]</a> internal slot
+                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
                             of |key|.
                           </p>
                         </li>
@@ -11671,14 +11673,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            If the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-type">[[\type]]</a> internal slot
+                            If the {{CryptoKey/[[type]]}} internal slot
                             of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
                           </p>
                         </li>
                         <li>
                           <p>
-                            Let |data| be an <a data-cite="WebCryptoAPI#dfn-octet-string">octet string</a> representing the X25519
-                            public key represented by the <a data-cite="WebCryptoAPI#dfn-CryptoKey-slot-handle">[[\handle]]</a> internal slot of
+                            Let |data| be an [= octet string =] representing the X25519
+                            public key represented by the {{CryptoKey/[[handle]]}} internal slot of
                             |key|.
                           </p>
                         </li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10078,6 +10078,16 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                     Section 5.1.6, with |message| as |M|,
                     using the Ed25519 private key associated with |key|.
                   </p>
+                  <div class="issue">
+                    <p>
+                      Some implementations may (wish to) generate randomized signatures
+                      as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
+                      instead of deterministic signatures as per [[RFC8032]].
+                    </p>
+                    <p>
+                      See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/28">WICG/webcrypto-secure-curves issue 28</a>.
+                    </p>
+                  </div>
                 </li>
                 <li>
                   <p>
@@ -10105,6 +10115,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                     If the key data of |key| represents an invalid point or a small-order element
                     on the Elliptic Curve of Ed25519, return `false`.
                   </p>
+                  <div class="issue">
+                    <p>
+                      Not all implementations perform this check.
+                    </p>
+                    <p>
+                      See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/27">WICG/webcrypto-secure-curves issue 27</a>.
+                    </p>
+                  </div>
                 </li>
                 <li>
                   <p>
@@ -10112,6 +10130,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                     represents an invalid point or a small-order element
                     on the Elliptic Curve of Ed25519, return `false`.
                   </p>
+                  <div class="issue">
+                    <p>
+                      Not all implementations perform this check.
+                    </p>
+                    <p>
+                      See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/27">WICG/webcrypto-secure-curves issue 27</a>.
+                    </p>
+                  </div>
                 </li>
                 <li>
                   <p>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -15146,7 +15146,7 @@ dictionary Pbkdf2Params : Algorithm {
       <section id="examples-section">
         <h2>JavaScript Example Code</h2>
         <section id="example-key-exchange">
-          <h2>Usage Example</h2>
+          <h2>Generate two key pairs, derive a shared key, encrypt some data</h2>
           <p>
             This example generates two X25519 key pairs, one for Alice and one for Bob, performs
             a key agreement between them, derives a 256-bit AES-GCM key from the result using
@@ -15194,71 +15194,38 @@ dictionary Pbkdf2Params : Algorithm {
         <section id="examples-signing">
           <h3>Generate a signing key pair, sign some data</h3>
 
-        <pre class="js">
-var encoder = new TextEncoder('utf-8');
-
-// Algorithm Object
-var algorithmKeyGen = {
-  name: "RSASSA-PKCS1-v1_5",
-  // RsaHashedKeyGenParams
-  modulusLength: 2048,
-  publicExponent: new Uint8Array([0x01, 0x00, 0x01]),  // Equivalent to 65537
-  hash: {
-    name: "SHA-256"
-  }
-};
-
-var algorithmSign = {
-  name: "RSASSA-PKCS1-v1_5"
-};
-
-window.crypto.subtle.generateKey(algorithmKeyGen, false, ["sign"]).then(
-  function(key) {
-    var dataPart1 = encoder.encode("hello,");
-    var dataPart2 = encoder.encode(" world!");
-
-    return window.crypto.subtle.sign(algorithmSign, key.privateKey, [dataPart1, dataPart2]);
-  },
-  console.error.bind(console, "Unable to generate a key")
-).then(
-  console.log.bind(console, "The signature is: "),
-  console.error.bind(console, "Unable to sign")
-);
-        </pre>
+          <pre class="example js" title="Ed25519 signing">
+            const data = new TextEncoder().encode('Hello, world!');
+            const key = await crypto.subtle.generateKey('Ed25519', false, ['sign']);
+            const signature = await crypto.subtle.sign('Ed25519', key.privateKey, data);
+          </pre>
         </section>
         <section id="examples-symmetric-encryption">
-          <h3>Symmetric Encryption</h3>
-        <pre class=js>
-var encoder = new TextEncoder('utf-8');
-var clearDataArrayBufferView = encoder.encode("Plain Text Data");
-
-var aesAlgorithmKeyGen = {
-  name: "AES-CBC",
-  // AesKeyGenParams
-  length: 128
-};
-
-var aesAlgorithmEncrypt = {
-  name: "AES-CBC",
-  // AesCbcParams
-  iv: window.crypto.getRandomValues(new Uint8Array(16))
-};
-
-// Create a key generator to produce a one-time-use AES key to encrypt some data
-window.crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ["encrypt"]).then(
-  function(aesKey) {
-    return window.crypto.subtle.encrypt(aesAlgorithmEncrypt, aesKey, clearDataArrayBufferView);
-  }
-).then(console.log.bind(console, "The ciphertext is: "),
-       console.error.bind(console, "Unable to encrypt"));
-</pre>
+          <h3>Generate a symmetric key, encrypt some data</h3>
+          <pre class="example js" title="AES-GCM encryption">
+            const data = new TextEncoder().encode('Hello, world!');
+            const aesAlgorithmKeyGen = {
+              name: 'AES-GCM',
+              // AesKeyGenParams
+              length: 256
+            };
+            const aesAlgorithmEncrypt = {
+              name: 'AES-GCM',
+              // AesGcmParams
+              iv: crypto.getRandomValues(new Uint8Array(16))
+            };
+            const key = await crypto.subtle.generateKey(aesAlgorithmKeyGen, false, ['encrypt']);
+            const encrypted = await crypto.subtle.encrypt(aesAlgorithmEncrypt, key, data);
+          </pre>
+        </section>
+        <section id="examples-random-uuid">
+          <h3>Generate unique name for download</h3>
+          <pre class="example js" title="Random UUID generation">
+            const filename = `${crypto.randomUUID()}.txt`;
+          </pre>
+        </section>
       </section>
-      <section id="examples-random-uuid">
-        <h3>Generate unique name for download</h3>
-        <pre class=js>
-const filename = `${crypto.randomUUID()}.txt`;
-</pre>
-    </section>
+
     <section id="iana-section">
     <h2>IANA Considerations</h2>
         <section id="iana-section-jws-jwa">

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10535,7 +10535,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    If |jwk| does not meet the requirements of Section 2
+                                    If |jwk| does not meet the requirements of
+                                    the JWK private key format described in Section 2
                                     of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
@@ -10559,7 +10560,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    If |jwk| does not meet the requirements of Section 2
+                                    If |jwk| does not meet the requirements of
+                                    the JWK public key format described in Section 2
                                     of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
@@ -11389,7 +11391,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    If |jwk| does not meet the requirements of Section 2
+                                    If |jwk| does not meet the requirements of
+                                    the JWK private key format described in Section 2
                                     of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>
@@ -11413,7 +11416,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               <ol>
                                 <li>
                                   <p>
-                                    If |jwk| does not meet the requirements of Section 2
+                                    If |jwk| does not meet the requirements of
+                                    the JWK public key format described in Section 2
                                     of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
                                   </p>
                                 </li>


### PR DESCRIPTION
This PR copies the text on X25519 and Ed25519 from https://github.com/WICG/webcrypto-secure-curves, and updates the tables, examples and references.

X448 and Ed448 are not yet included, due to there being fewer implementations and signs of interest, at the moment.

Closes #196.

The following implementers have shown interest:

 * Chrome (https://chromestatus.com/feature/4913922408710144)
 * Firefox (https://github.com/mozilla/standards-positions/issues/271)
 * Webkit (https://github.com/WebKit/standards-positions/issues/67)

The following tasks have been completed:

 * [X] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/34399, among others)

Implementation issues:

 * [X] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1370697)
 * [X] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1804788)
 * [X] WebKit (https://bugs.webkit.org/show_bug.cgi?id=245778)
 * [X] Deno (https://github.com/denoland/deno/pull/14119)
 * [X] Node.js (https://github.com/nodejs/node/pull/36879)
 * [X] workerd (https://github.com/cloudflare/workerd/pull/500/)
 * [X] Vercel Edge Runtime (https://github.com/vercel/edge-runtime/pull/326/)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/362.html" title="Last updated on Oct 21, 2024, 5:00 PM UTC (9cd8b2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/362/d424b96...9cd8b2e.html" title="Last updated on Oct 21, 2024, 5:00 PM UTC (9cd8b2e)">Diff</a>