### PR TITLE
Remove superfluous text in the HKDF derive bits operation

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13055,16 +13055,7 @@ dictionary HkdfParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |extractKey| be a key equal to |n| zero bits where
-                    |n| is the size of the output of the hash function described by the
-                    {{HkdfParams/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |keyDerivationKey| be the secret represented by {{CryptoKey/[[handle]]}} internal slot of |key|
-                    as the message.
+                    Let |keyDerivationKey| be the secret represented by {{CryptoKey/[[handle]]}} internal slot of |key|.
                   </p>
                 </li>
                 <li>


### PR DESCRIPTION
Fixes #371.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/372.html" title="Last updated on Oct 21, 2024, 5:20 PM UTC (a87a9b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/372/4a6e3e8...a87a9b0.html" title="Last updated on Oct 21, 2024, 5:20 PM UTC (a87a9b0)">Diff</a>