### PR TITLE
Remove nonsensical test in AES-CBC export key operation

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10977,12 +10977,7 @@ dictionary AesCbcParams : Algorithm {
                     <dd>
                       <ol>
                         <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
+                          <p>Let |jwk| be a new {{JsonWebKey}} dictionary.</p>
                         </li>
                         <li>
                           <p>


### PR DESCRIPTION
Closes #374

Since this is a pure spec bug (I believe), there is no need to track issues in implementations.

EDIT: I guess the easiest way to move forward is to mark this change as non-substantive? I'm unsure, please clarify.