### PR TITLE
Explicitly set CryptoKey.type to "secret" in AES and HMAC operations

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10228,6 +10228,12 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
                     slot of |key| to |algorithm|.
                   </p>
@@ -10758,6 +10764,12 @@ dictionary AesCbcParams : Algorithm {
                     |algorithm| to equal the
                     {{AesKeyGenParams/length}} member of
                     |normalizedAlgorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
                   </p>
                 </li>
                 <li>
@@ -11380,6 +11392,12 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
                     Set the {{CryptoKey/[[algorithm]]}} internal
                     slot of |key| to |algorithm|.
                   </p>
@@ -11852,6 +11870,12 @@ dictionary AesGcmParams : Algorithm {
                     |algorithm| to equal the
                     {{AesKeyGenParams/length}} property of
                     |normalizedAlgorithm|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
                   </p>
                 </li>
                 <li>
@@ -12390,6 +12414,12 @@ dictionary HmacKeyGenParams : Algorithm {
                   <p>
                     Set the {{HmacKeyAlgorithm/hash}} attribute
                     of |algorithm| to |hash|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
                   </p>
                 </li>
                 <li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10387,6 +10387,12 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
                     Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
@@ -10924,6 +10930,12 @@ dictionary AesCbcParams : Algorithm {
                   <p>
                     Let |key| be a new {{CryptoKey}}
                     object representing an AES key with value |data|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
                   </p>
                 </li>
                 <li>
@@ -11552,6 +11564,12 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
+                  </p>
+                </li>
+                <li>
+                  <p>
                     Let |algorithm| be a new
                     {{AesKeyAlgorithm}}.
                   </p>
@@ -12030,6 +12048,12 @@ dictionary AesGcmParams : Algorithm {
                   <p>
                     Let |key| be a new {{CryptoKey}}
                     representing an AES key with value |data|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
                   </p>
                 </li>
                 <li>
@@ -12674,6 +12698,12 @@ dictionary HmacKeyGenParams : Algorithm {
                     Let |key| be a new {{CryptoKey}}
                     object representing an HMAC key with the first |length|
                     bits of |data|.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Set the {{CryptoKey/[[type]]}} internal slot of
+                    |key| to {{KeyType/"secret"}}.
                   </p>
                 </li>
                 <li>


### PR DESCRIPTION
Closes #376

This maps de-facto behavior of most (if not all) implementors, and is already strongly suggested by other parts of the spec: https://w3c.github.io/webcrypto/#dom-keytype

This is already tested as part of WPT: https://github.com/web-platform-tests/wpt/blob/272064ebf9a3d313a2d4db8bb9ce2790648aa162/WebCryptoAPI/generateKey/successes.js#L70


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BenWiederhake/webcrypto/pull/378.html" title="Last updated on Oct 25, 2024, 10:03 AM UTC (e8e4655)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/378/d68a54a...BenWiederhake:e8e4655.html" title="Last updated on Oct 25, 2024, 10:03 AM UTC (e8e4655)">Diff</a>