### PR TITLE
Remove dead writes to CryptoKey.extractable in HKDF/PBKDF2.importKey

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13148,12 +13148,6 @@ dictionary HkdfParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Set the {{CryptoKey/[[extractable]]}} internal slot of
-                            |key| to `false`.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
                             Let |algorithm| be a new
                             {{KeyAlgorithm}} object.
                           </p>
@@ -13345,12 +13339,6 @@ dictionary Pbkdf2Params : Algorithm {
                   <p>
                     Set the {{CryptoKey/[[type]]}} internal slot of
                     |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal slot of
-                    |key| to `false`.
                   </p>
                 </li>
                 <li>


### PR DESCRIPTION
When these steps execute, it is know due to an earlier step that the argument 'extractable' is false, and that the internal slot will not be read before being overwritten again by SubtleCrypto.importKey:

https://w3c.github.io/webcrypto/#SubtleCrypto-method-importKey

Therefore, it is a dead write. Removing it makes it more similar to all other importKey operations, which do not write the [[extractable]] internal slot either.

Closes #377

As it is a dead write, there is no change in behavior. (Or at least there should be no change in behavior; maybe my reasoning is buggy, but I don't expect it.)

As such, there is no need to extend/adapt the WPT tests. Also, these tests already cover the `extractable` slot extensively.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BenWiederhake/webcrypto/pull/379.html" title="Last updated on Oct 25, 2024, 10:29 AM UTC (c3d26fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/379/d68a54a...BenWiederhake:c3d26fb.html" title="Last updated on Oct 25, 2024, 10:29 AM UTC (c3d26fb)">Diff</a>