### PR TITLE
Allow `length=0` in HKDF and PBKDF2 derive bits operations

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13281,6 +13281,13 @@ dictionary Pbkdf2Params : Algorithm {
                 </li>
                 <li>
                   <p>
+                    If |length| is zero, return the result of
+                    [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                    containing an empty [= byte sequence =].
+                  </p>
+                </li>
+                <li>
+                  <p>
                     Let |prf| be the MAC Generation function described in Section 4 of
                     [[FIPS-198-1]] using the hash function
                     described by the {{Pbkdf2Params/hash}} member of

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13045,7 +13045,7 @@ dictionary HkdfParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If |length| is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                    If |length| is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>
@@ -13270,7 +13270,7 @@ dictionary Pbkdf2Params : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If |length| is null or zero, or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                    If |length| is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
                   </p>
                 </li>
                 <li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13100,7 +13100,8 @@ dictionary HkdfParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return |result|.
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |result|.
                   </p>
                 </li>
               </ol>
@@ -13315,7 +13316,8 @@ dictionary Pbkdf2Params : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return |result|
+                    Return the result of [= ArrayBuffer/create | creating =]
+                    an {{ArrayBuffer}} containing |result|.
                   </p>
                 </li>
               </ol>


### PR DESCRIPTION
Fixes #370.

This PR reverts #275, and addresses #274 in an alternative way, namely by explicitly returning an empty `ArrayBuffer` for PBKDF2 when `length=0` (as RFC 8018 does not allow `dkLen=0`).

Additionally, explicitly return an `ArrayBuffer` in all cases (the algorithm registrations already stated this, but the operations did not).

<!--

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation issues:

 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Deno (https://github.com/denoland/deno/issues/)
 * [ ] Node.js (https://github.com/nodejs/node/issues/)
 * [ ] workerd (https://github.com/cloudflare/workerd/issues/)
 * [ ] Vercel Edge Runtime (https://github.com/vercel/edge-runtime/issues/)

-->