### PR TITLE
Throw in AES-CBC decrypt operation for odd ciphertext lengths

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -12712,6 +12712,12 @@ dictionary AesCbcParams : Algorithm {
               </li>
               <li>
                 <p>
+                  If the length of |ciphertext| is zero or is not a multiple
+                  of 16 bytes, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |paddedPlaintext| be the result of performing the CBC Decryption
                   operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCbcParams/iv}} member of |normalizedAlgorithm| as
                   the |IV| input parameter and


### PR DESCRIPTION
If the ciphertext is not a positive multiple of 16 bytes, return an `OperationError`.

Fixes #381.

Most implementations already return an `OperationError` in this case, except Safari, which currently returns an empty `ArrayBuffer` for the test case in #381. @nmahendru let me know if this change seems reasonable to you.

<!--

The following implementers have shown interest:

 * …
 * …

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation issues:

 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Deno (https://github.com/denoland/deno/issues/)
 * [ ] Node.js (https://github.com/nodejs/node/issues/)
 * [ ] workerd (https://github.com/cloudflare/workerd/issues/)
 * [ ] Vercel Edge Runtime (https://github.com/vercel/edge-runtime/issues/)
-->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/382.html" title="Last updated on Mar 7, 2025, 4:46 PM UTC (52eed0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/382/c8b273d...52eed0f.html" title="Last updated on Mar 7, 2025, 4:46 PM UTC (52eed0f)">Diff</a>