### PR TITLE
Queue tasks to resolve or reject promises

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1420,7 +1420,13 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Resolve |promise| with |ciphertext|.
+                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                  containing |ciphertext|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Resolve |promise| with |result|.
                 </p>
               </li>
             </ol>
@@ -1510,8 +1516,14 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                  containing |plaintext|.
+                </p>
+              </li>
+              <li>
+                <p>
                   Resolve |promise| with
-                  |plaintext|.
+                  |result|.
                 </p>
               </li>
             </ol>
@@ -1591,9 +1603,15 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be the result of performing the sign operation
+                  Let |signature| be the result of performing the sign operation
                   specified by |normalizedAlgorithm| using |key| and
                   |algorithm| and with |data| as |message|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                  containing |signature|.
                 </p>
               </li>
               <li>
@@ -1760,10 +1778,16 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be the result of performing the digest
+                  Let |digest| be the result of performing the digest
                   operation specified by |normalizedAlgorithm| using
                   |algorithm|, with |data|
                   as |message|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                  containing |digest|.
                 </p>
               </li>
               <li>
@@ -2073,10 +2097,15 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  containing the result of performing the derive bits operation
+                  Let |bits| be the result of performing the derive bits operation
                   specified by |normalizedAlgorithm| using |baseKey|,
                   |algorithm| and |length|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                  containing |bits|.
                 </p>
               </li>
               <li>
@@ -2480,6 +2509,12 @@ interface SubtleCrypto {
                     {{NotSupportedError}}.
                   </dd>
                 </dl>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                  containing |result|.
+                </p>
               </li>
               <li>
                 <p>
@@ -3596,7 +3631,7 @@ dictionary CryptoKeyPair {
               <tr>
                 <td>sign</td>
                 <td>None</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>verify</td>
@@ -3705,8 +3740,7 @@ dictionary RsaHashedImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |signature|.
+                    Return |signature|.
                   </p>
                 </li>
               </ol>
@@ -4668,7 +4702,7 @@ dictionary RsaHashedImportParams : Algorithm {
               <tr>
                 <td>sign</td>
                 <td>{{RsaPssParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>verify</td>
@@ -4741,8 +4775,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |signature|.
+                    Return |signature|.
                   </p>
                 </li>
               </ol>
@@ -5687,12 +5720,12 @@ dictionary RsaPssParams : Algorithm {
               <tr>
                 <td>encrypt</td>
                 <td>{{RsaOaepParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>decrypt</td>
                 <td>{{RsaOaepParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>generateKey</td>
@@ -5771,8 +5804,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |ciphertext|.
+                    Return |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -5823,8 +5855,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |plaintext|.
+                    Return |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -6736,7 +6767,7 @@ dictionary RsaOaepParams : Algorithm {
               <tr>
                 <td>sign</td>
                 <td>{{EcdsaParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>verify</td>
@@ -6919,8 +6950,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |result|.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -10046,7 +10076,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
               <tr>
                 <td>sign</td>
                 <td>None</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>verify</td>
@@ -10087,7 +10117,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Perform the Ed25519 signing process, as specified in [[RFC8032]],
+                    Let |result| be the result of performing the Ed25519
+                    signing process, as specified in [[RFC8032]],
                     Section 5.1.6, with |message| as |M|,
                     using the Ed25519 private key associated with |key|.
                   </p>
@@ -10104,11 +10135,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return a new {{ArrayBuffer}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and containing the
-                    bytes of the signature resulting from performing
-                    the Ed25519 signing process.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -11785,12 +11812,12 @@ dictionary EcdhKeyDeriveParams : Algorithm {
               <tr>
                 <td>encrypt</td>
                 <td>{{AesCtrParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>decrypt</td>
                 <td>{{AesCtrParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>generateKey</td>
@@ -11898,8 +11925,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |ciphertext|.
+                    Return |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -11939,8 +11965,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |plaintext|.
+                    Return |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -12365,12 +12390,12 @@ dictionary AesDerivedKeyParams : Algorithm {
               <tr>
                 <td>encrypt</td>
                 <td>{{AesCbcParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>decrypt</td>
                 <td>{{AesCbcParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>generateKey</td>
@@ -12438,8 +12463,7 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |ciphertext|.
+                    Return |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -12485,8 +12509,7 @@ dictionary AesCbcParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |plaintext|.
+                    Return |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -12901,12 +12924,12 @@ dictionary AesCbcParams : Algorithm {
                <tr>
                  <td>encrypt</td>
                  <td>{{AesGcmParams}}</td>
-                 <td>{{ArrayBuffer}}</td>
+                 <td>[= octet string =]</td>
                </tr>
                <tr>
                  <td>decrypt</td>
                  <td>{{AesGcmParams}}</td>
-                 <td>{{ArrayBuffer}}</td>
+                 <td>[= octet string =]</td>
                </tr>
                <tr>
                  <td>generateKey</td>
@@ -13019,8 +13042,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |ciphertext|.
+                    Return |ciphertext|.
                   </p>
                 </li>
               </ol>
@@ -13115,8 +13137,7 @@ dictionary AesGcmParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |plaintext|.
+                    Return |plaintext|.
                   </p>
                 </li>
               </ol>
@@ -13533,12 +13554,12 @@ dictionary AesGcmParams : Algorithm {
               <tr>
                 <td>wrapKey</td>
                 <td>None</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>unwrapKey</td>
                 <td>None</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>generateKey</td>
@@ -14028,7 +14049,7 @@ dictionary AesGcmParams : Algorithm {
               <tr>
                 <td>sign</td>
                 <td>None</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>verify</td>
@@ -14108,8 +14129,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |mac|.
+                    Return |mac|.
                   </p>
                 </li>
               </ol>
@@ -14745,7 +14765,7 @@ dictionary HmacKeyGenParams : Algorithm {
               <tr>
                 <td>digest</td>
                 <td>None</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
             </tbody>
           </table>
@@ -14807,8 +14827,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |result|.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -14851,7 +14870,7 @@ dictionary HmacKeyGenParams : Algorithm {
               <tr>
                 <td>deriveBits</td>
                 <td>{{HkdfParams}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>importKey</td>
@@ -14942,8 +14961,7 @@ dictionary HkdfParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |result|.
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -15073,7 +15091,7 @@ dictionary HkdfParams : Algorithm {
               <tr>
                 <td>deriveBits</td>
                 <td>{{Pbkdf2Params}}</td>
-                <td>{{ArrayBuffer}}</td>
+                <td>[= octet string =]</td>
               </tr>
               <tr>
                 <td>importKey</td>
@@ -15118,9 +15136,7 @@ dictionary Pbkdf2Params : Algorithm {
                 </li>
                 <li>
                   <p>
-                    If |length| is zero, return the result of
-                    [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                    containing an empty [= byte sequence =].
+                    If |length| is zero, return an empty [= byte sequence =].
                   </p>
                 </li>
                 <li>
@@ -15152,8 +15168,7 @@ dictionary Pbkdf2Params : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of [= ArrayBuffer/create | creating =]
-                    an {{ArrayBuffer}} containing |result|.
+                    Return |result|.
                   </p>
                 </li>
               </ol>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -4477,7 +4477,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -4543,7 +4543,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -5500,7 +5500,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -5566,7 +5566,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -6526,7 +6526,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -6592,7 +6592,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -8149,7 +8149,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -8304,7 +8304,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -10774,7 +10774,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -10827,7 +10827,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -11614,7 +11614,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>
@@ -11667,7 +11667,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be the result of DER-encoding |data|.
                           </p>
                         </li>
                       </ol>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1324,12 +1324,30 @@ interface SubtleCrypto {
           </dl>
         </section>
 
+        <section id="subtlecrypto-interface-tasksource">
+          <h3>Task Source</h3>
+          <dl>
+            <dt id="dfn-crypto-task-source">The <dfn>crypto task source</dfn></dt>
+            <dd>
+              This [= task source =] is used to queue tasks to resolve
+              or reject promises created in response to calls to methods
+              of {{SubtleCrypto}}.
+            </dd>
+          </dl>
+          <div class=note>
+            This specification makes no specific requirements on the
+            ordering of responses to calls to methods of {{SubtleCrypto}},
+            neither between multiple calls, nor between calls and tasks
+            from other [= task source | task sources =].
+            This task source is merely used to [= queue a task =] to
+            resolve or reject the relevant promise whenever the
+            cryptographic operation is completed, in order to
+            <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-for-spec-authors">prevent race conditions</a>.
+          </div>
+        </section>
+
         <section id="subtlecrypto-interface-methods">
           <h3>Methods and Parameters</h3>
-          <p>
-            Unless otherwise stated, objects created by the methods defined in this section shall be associated with the
-            [= relevant realm =] of [= this =].
-          </p>
           <div class=note>
             <p>
               All errors are reported asynchronously by rejecting the returned
@@ -1379,6 +1397,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -1391,9 +1414,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -1420,8 +1444,14 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  containing |ciphertext|.
+                  in |realm|, containing |ciphertext|.
                 </p>
               </li>
               <li>
@@ -1474,21 +1504,27 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return |promise| and the remaining steps [= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -1516,8 +1552,14 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  containing |plaintext|.
+                  in |realm|, containing |plaintext|.
                 </p>
               </li>
               <li>
@@ -1569,6 +1611,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -1581,9 +1628,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -1610,8 +1658,14 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  containing |signature|.
+                  in |realm|, containing |signature|.
                 </p>
               </li>
               <li>
@@ -1671,21 +1725,27 @@ interface SubtleCrypto {
 
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
                 <p>
-                  Return |promise| and perform the remaining steps[= in parallel =].
+                  Return |promise| and perform the remaining steps [= in parallel =].
                 </p>
               </li>
               <li>
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -1709,6 +1769,12 @@ interface SubtleCrypto {
                   specified by |normalizedAlgorithm| using |key|,
                   |algorithm| and
                   |signature| and with |data| as |message|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
                 </p>
               </li>
               <li>
@@ -1759,6 +1825,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -1771,9 +1842,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -1786,8 +1858,14 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  containing |digest|.
+                  in |realm|, containing |digest|.
                 </p>
               </li>
               <li>
@@ -1831,6 +1909,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -1843,9 +1926,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -1878,7 +1962,13 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object in |realm|,
                   as defined by [[WebIDL]].
                 </p>
               </li>
@@ -1950,6 +2040,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -1962,9 +2057,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -2028,7 +2124,13 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object in |realm|,
                   as defined by [[WebIDL]].
                 </p>
               </li>
@@ -2074,7 +2176,12 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |promise| be a new Promise object.
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |promise| be a new Promise.
                 </p>
               </li>
               <li>
@@ -2086,9 +2193,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -2116,8 +2224,14 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  containing |bits|.
+                  in |realm|, containing |bits|.
                 </p>
               </li>
               <li>
@@ -2208,6 +2322,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -2220,9 +2339,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -2256,7 +2376,13 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object in |realm|,
                   as defined by [[WebIDL]].
                 </p>
               </li>
@@ -2296,6 +2422,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -2308,9 +2439,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -2334,6 +2466,12 @@ interface SubtleCrypto {
                 </p>
               </li>
               <li>
+                <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
                 <dl class="switch">
                   <dt>
                     If |format| is equal to the strings {{KeyFormat/"raw"}},
@@ -2341,13 +2479,13 @@ interface SubtleCrypto {
                   </dt>
                   <dd>
                     Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                    containing |result|.
+                    in |realm|, containing |result|.
                   </dd>
                   <dt>
                     If |format| is equal to the string {{KeyFormat/"jwk"}}:
                   </dt>
                   <dd>
-                    Let |result| be the result of converting |result| to an ECMAScript Object,
+                    Let |result| be the result of converting |result| to an ECMAScript Object in |realm|,
                     as defined by [[WebIDL]].
                   </dd>
                 </dl>
@@ -2406,6 +2544,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -2418,9 +2561,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -2542,8 +2686,14 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  containing |result|.
+                  in |realm|, containing |result|.
                 </p>
               </li>
               <li>
@@ -2627,6 +2777,11 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |realm| be the [= relevant realm =] of [= this =].
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |promise| be a new Promise.
                 </p>
               </li>
@@ -2639,9 +2794,10 @@ interface SubtleCrypto {
                 <p>
                   If the following steps or referenced procedures say to
                   [= exception/throw =] an error,
-                  reject |promise| with
-                  the returned error and then
-                  [= terminate the algorithm =].
+                  [= queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object,
+                  to reject |promise| with the returned error;
+                  and then [= terminate the algorithm =].
                 </p>
               </li>
               <li>
@@ -2737,7 +2893,13 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  [= Queue a global task =] on the [= crypto task source =],
+                  given |realm|'s global object, to perform the remaining steps.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object in |realm|,
                   as defined by [[WebIDL]].
                 </p>
               </li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -2477,20 +2477,13 @@ interface SubtleCrypto {
                     {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
                   </dt>
                   <dd>
-                    Set |bytes| be set to |key|.
+                    Let |bytes| be set to |key|.
                   </dd>
                   <dt>
                     If |format| is equal to the string {{KeyFormat/"jwk"}}:
                   </dt>
                   <dd>
                     <ol>
-                      <li>
-                        <p>
-                          Convert |key| to an ECMAScript Object, as specified in [[WEBIDL]],
-                          performing the conversion in the
-                          context of a new global object.
-                        </p>
-                      </li>
                       <li>
                         <p>
                           Let |json| be the result of representing |key| as a

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -4438,7 +4438,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `SubjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -4493,13 +4493,14 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be the result of encoding a privateKeyInfo structure
+                            Let |data| be an instance of the `PrivateKeyInfo`
+                            ASN.1 structure defined in [[RFC5208]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the |version| field to 0.
+                                Set the |version| field to `0`.
                               </p>
                             </li>
                             <li>
@@ -5460,7 +5461,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `SubjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -5515,18 +5516,19 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be the result of encoding a privateKeyInfo structure
+                            Let |data| be an instance of the `PrivateKeyInfo`
+                            ASN.1 structure defined in [[RFC5208]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the |version| field to 0.
+                                Set the |version| field to `0`.
                               </p>
                             </li>
                             <li>
                               <p>
-                                Set the |privateKeyAlgorithm| field to an
+                                Set the |privateKeyAlgorithm| field to a
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
@@ -6485,7 +6487,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `SubjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -6540,18 +6542,19 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be the result of encoding a privateKeyInfo structure
+                            Let |data| be an instance of the `PrivateKeyInfo`
+                            ASN.1 structure defined in [[RFC5208]]
                             with the following properties:
                           </p>
                           <ul>
                             <li>
                               <p>
-                                Set the |version| field to 0.
+                                Set the |version| field to `0`.
                               </p>
                             </li>
                             <li>
                               <p>
-                                Set the |privateKeyAlgorithm| field to an
+                                Set the |privateKeyAlgorithm| field to a
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
@@ -8029,7 +8032,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `SubjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -8162,8 +8165,8 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `privateKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
+                            Let |data| be an instance of the `PrivateKeyInfo`
+                            ASN.1 structure defined in [[RFC5208]]
                             with the following properties:
                           </p>
                           <ul>
@@ -8174,7 +8177,7 @@ dictionary EcKeyImportParams : Algorithm {
                             </li>
                             <li>
                               <p>
-                                Set the |privateKeyAlgorithm| field to an
+                                Set the |privateKeyAlgorithm| field to a
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
@@ -9608,7 +9611,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `SubjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -9735,8 +9738,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `privateKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
+                            Let |data| be an instance of the `PrivateKeyInfo`
+                            ASN.1 structure defined in [[RFC5208]]
                             with the following properties:
                           </p>
                           <ul>
@@ -9747,7 +9750,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                             </li>
                             <li>
                               <p>
-                                Set the |privateKeyAlgorithm| field to an
+                                Set the |privateKeyAlgorithm| field to a
                                 `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
                                 following properties:
                               </p>
@@ -10742,7 +10745,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `SubjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -10787,7 +10790,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `privateKeyInfo`
+                            Let |data| be an instance of the `PrivateKeyInfo`
                             ASN.1 structure defined in [[RFC5208]]
                             with the following properties:
                           </p>
@@ -11582,7 +11585,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `subjectPublicKeyInfo`
+                            Let |data| be an instance of the `SubjectPublicKeyInfo`
                             ASN.1 structure defined in [[RFC5280]]
                             with the following properties:
                           </p>
@@ -11627,7 +11630,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |data| be an instance of the `privateKeyInfo`
+                            Let |data| be an instance of the `PrivateKeyInfo`
                             ASN.1 structure defined in [[RFC5208]]
                             with the following properties:
                           </p>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -2621,7 +2621,7 @@ interface SubtleCrypto {
                     {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
                   </dt>
                   <dd>
-                    Let |bytes| be set to |key|.
+                    Let |bytes| be |key|.
                   </dd>
                   <dt>
                     If |format| is equal to the string {{KeyFormat/"jwk"}}:
@@ -2849,7 +2849,7 @@ interface SubtleCrypto {
                     {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
                   </dt>
                   <dd>
-                    Let |key| be set to |bytes|.
+                    Let |key| be |bytes|.
                   </dd>
                   <dt>
                     If |format| is equal to the string {{KeyFormat/"jwk"}}:
@@ -4836,7 +4836,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -5851,7 +5851,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -6890,7 +6890,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -8594,7 +8594,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -8641,7 +8641,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -10163,7 +10163,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -10212,7 +10212,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -11046,7 +11046,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -11071,7 +11071,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -11886,7 +11886,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -11911,7 +11911,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -12403,7 +12403,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -12461,7 +12461,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -12946,7 +12946,7 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -13000,7 +13000,7 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -13572,7 +13572,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -13630,7 +13630,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -14058,7 +14058,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -14115,7 +14115,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -14716,7 +14716,7 @@ dictionary HmacKeyGenParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            Let |result| be set to |data|.
+                            Let |result| be |data|.
                           </p>
                         </li>
                       </ol>
@@ -14814,7 +14814,7 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be set to |jwk|.
+                            Let |result| be |jwk|.
                           </p>
                         </li>
                       </ol>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -2664,7 +2664,7 @@ interface SubtleCrypto {
                 <dl class="switch">
                   <dt>If |normalizedAlgorithm| supports an unwrap key operation:</dt>
                   <dd>
-                    Let |key| be the result of performing the unwrap key operation
+                    Let |bytes| be the result of performing the unwrap key operation
                     specified by |normalizedAlgorithm| using |algorithm|,
                     |unwrappingKey| as |key| and |wrappedKey| as
                     |ciphertext|.
@@ -2674,7 +2674,7 @@ interface SubtleCrypto {
                     operation:
                   </dt>
                   <dd>
-                    Let |key| be the result of performing the decrypt operation specified
+                    Let |bytes| be the result of performing the decrypt operation specified
                     by |normalizedAlgorithm| using |algorithm|,
                     |unwrappingKey| as |key| and |wrappedKey| as
                     |ciphertext|.
@@ -2693,14 +2693,14 @@ interface SubtleCrypto {
                     {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
                   </dt>
                   <dd>
-                    Set |bytes| be set to |key|.
+                    Let |key| be set to |bytes|.
                   </dd>
                   <dt>
                     If |format| is equal to the string {{KeyFormat/"jwk"}}:
                   </dt>
                   <dd>
-                    Let |bytes| be the result of executing the
-                    [= parse a JWK =] algorithm, with |key|
+                    Let |key| be the result of executing the
+                    [= parse a JWK =] algorithm, with |bytes|
                     as the `data` to be parsed.
                   </dd>
                 </dl>
@@ -2712,7 +2712,7 @@ interface SubtleCrypto {
                   |unwrappedKeyAlgorithm| as |algorithm|, |format|,
                   |usages|
                   and |extractable| and with
-                  |bytes| as |keyData|.
+                  |key| as |keyData|.
                 </p>
               </li>
               <li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1878,6 +1878,12 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  as defined by [[WebIDL]].
+                </p>
+              </li>
+              <li>
+                <p>
                   Resolve |promise| with
                   |result|.
                 </p>
@@ -2018,6 +2024,12 @@ interface SubtleCrypto {
                   Set the {{CryptoKey/[[usages]]}} internal
                   slot of |result| to the [= normalized
                     value =] of |usages|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  as defined by [[WebIDL]].
                 </p>
               </li>
               <li>
@@ -2244,6 +2256,12 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  as defined by [[WebIDL]].
+                </p>
+              </li>
+              <li>
+                <p>
                   Resolve |promise| with
                   |result|.
                 </p>
@@ -2314,6 +2332,25 @@ interface SubtleCrypto {
                   specified by the {{CryptoKey/[[algorithm]]}}
                   internal slot of |key| using |key| and |format|.
                 </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If |format| is equal to the strings {{KeyFormat/"raw"}},
+                    {{KeyFormat/"pkcs8"}}, or {{KeyFormat/"spki"}}:
+                  </dt>
+                  <dd>
+                    Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                    containing |result|.
+                  </dd>
+                  <dt>
+                    If |format| is equal to the string {{KeyFormat/"jwk"}}:
+                  </dt>
+                  <dd>
+                    Let |result| be the result of converting |result| to an ECMAScript Object,
+                    as defined by [[WebIDL]].
+                  </dd>
+                </dl>
               </li>
               <li>
                 <p>
@@ -2703,6 +2740,12 @@ interface SubtleCrypto {
                   Set the {{CryptoKey/[[usages]]}} internal
                   slot of |result| to the [= normalized
                     value =] of |usages|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of converting |result| to an ECMAScript Object,
+                  as defined by [[WebIDL]].
                 </p>
               </li>
               <li>
@@ -4441,8 +4484,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -4507,8 +4549,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -4639,8 +4680,7 @@ dictionary RsaHashedImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -4963,8 +5003,7 @@ dictionary RsaPssParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of converting |result| to an ECMAScript Object,
-                    as defined by [[WebIDL]].
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -5467,8 +5506,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -5533,8 +5571,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -5657,8 +5694,7 @@ dictionary RsaPssParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -6011,8 +6047,7 @@ dictionary RsaOaepParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of converting |result| to an ECMAScript Object, as
-                    defined by [[WebIDL]].
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -6496,8 +6531,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -6562,8 +6596,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -6699,8 +6732,7 @@ dictionary RsaOaepParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -7190,8 +7222,7 @@ dictionary EcKeyImportParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of converting |result| to an ECMAScript Object, as
-                    defined by [[WebIDL]].
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -8122,8 +8153,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -8278,8 +8308,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -8407,8 +8436,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -8455,8 +8483,7 @@ dictionary EcKeyImportParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -8707,8 +8734,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of converting |result| to an ECMAScript Object, as
-                    defined by [[WebIDL]].
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -9979,8 +10005,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -10029,8 +10054,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -10229,9 +10253,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |publicKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |publicKey| be a new {{CryptoKey}}
                     representing the public key of the generated key pair.
                   </p>
                 </li>
@@ -10262,9 +10284,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |privateKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |privateKey| be a new {{CryptoKey}}
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -10313,8 +10333,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of converting |result| to an ECMAScript Object, as
-                    defined by [[WebIDL]].
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -10759,10 +10778,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -10815,10 +10831,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -10875,8 +10888,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -10901,10 +10913,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -11082,9 +11091,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |publicKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |publicKey| be a new {{CryptoKey}}
                     representing the public key of the generated key pair.
                   </p>
                 </li>
@@ -11114,9 +11121,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Let |privateKey| be a new {{CryptoKey}} associated with the
-                    [= relevant global object =]
-                    of `this` [[HTML]], and
+                    Let |privateKey| be a new {{CryptoKey}}
                     representing the private key of the generated key pair.
                   </p>
                 </li>
@@ -11166,8 +11171,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 </li>
                 <li>
                   <p>
-                    Return the result of converting |result| to an ECMAScript Object, as
-                    defined by [[WebIDL]].
+                    Return |result|.
                   </p>
                 </li>
               </ol>
@@ -11614,10 +11618,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -11670,10 +11671,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -11730,8 +11728,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -11756,10 +11753,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be a new {{ArrayBuffer}} associated with the
-                            [= relevant global object =]
-                            of `this` [[HTML]], and containing
-                            |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -12251,8 +12245,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -12310,8 +12303,7 @@ dictionary AesDerivedKeyParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -12796,8 +12788,7 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -12851,8 +12842,7 @@ dictionary AesCbcParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -13424,8 +13414,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -13483,8 +13472,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -13912,8 +13900,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -13970,8 +13957,7 @@ dictionary AesGcmParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>
@@ -14572,8 +14558,7 @@ dictionary HmacKeyGenParams : Algorithm {
                       <ol>
                         <li>
                           <p>
-                            Let |result| be the result of [= ArrayBuffer/create | creating =]
-                            an {{ArrayBuffer}} containing |data|.
+                            Let |result| be set to |data|.
                           </p>
                         </li>
                       </ol>
@@ -14671,8 +14656,7 @@ dictionary HmacKeyGenParams : Algorithm {
                         </li>
                         <li>
                           <p>
-                            Let |result| be the result of converting |jwk|
-                            to an ECMAScript Object, as defined by [[WebIDL]].
+                            Let |result| be set to |jwk|.
                           </p>
                         </li>
                       </ol>


### PR DESCRIPTION
Addresses #368 by creating a "crypto task source" and queueing tasks on that task source in order to resolve or reject all promises created in response to calls to methods of `SubtleCrypto` while running in parallel, to prevent race conditions.

In addition, create or convert to ECMAScript objects in those tasks, inside the top-level methods, rather than inside the internal operations; and let all internal operations consistently return IDL objects instead of ECMAScript objects (`deriveBits` already did this, but the others did not).

Finally, clarify some of the affected spec language and the types involved.

@dontcallmedom and/or @tidoust, could you please additionally review the [last commit](https://github.com/w3c/webcrypto/pull/386/commits/c62cd3d450f1a0a7a6331dac3e443fcea136d912), in particular?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/386.html" title="Last updated on Dec 16, 2024, 4:51 PM UTC (6929546)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/386/fe7d587...6929546.html" title="Last updated on Dec 16, 2024, 4:51 PM UTC (6929546)">Diff</a>