### PR TITLE
Make return types of SubtleCrypto methods more specific

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1231,52 +1231,77 @@ enum KeyFormat { "raw", "spki", "pkcs8", "jwk" };
 
 [SecureContext,Exposed=(Window,Worker)]
 interface SubtleCrypto {
-  Promise&lt;any> encrypt(AlgorithmIdentifier algorithm,
-                       CryptoKey key,
-                       BufferSource data);
-  Promise&lt;any> decrypt(AlgorithmIdentifier algorithm,
-                       CryptoKey key,
-                       BufferSource data);
-  Promise&lt;any> sign(AlgorithmIdentifier algorithm,
-                    CryptoKey key,
-                    BufferSource data);
-  Promise&lt;any> verify(AlgorithmIdentifier algorithm,
-                      CryptoKey key,
-                      BufferSource signature,
-                      BufferSource data);
-  Promise&lt;any> digest(AlgorithmIdentifier algorithm,
-                      BufferSource data);
+  Promise&lt;ArrayBuffer> encrypt(
+    AlgorithmIdentifier algorithm,
+    CryptoKey key,
+    BufferSource data
+  );
+  Promise&lt;ArrayBuffer> decrypt(
+    AlgorithmIdentifier algorithm,
+    CryptoKey key,
+    BufferSource data
+  );
+  Promise&lt;ArrayBuffer> sign(
+    AlgorithmIdentifier algorithm,
+    CryptoKey key,
+    BufferSource data
+  );
+  Promise&lt;boolean> verify(
+    AlgorithmIdentifier algorithm,
+    CryptoKey key,
+    BufferSource signature,
+    BufferSource data
+  );
+  Promise&lt;ArrayBuffer> digest(
+    AlgorithmIdentifier algorithm,
+    BufferSource data
+  );
 
-  Promise&lt;any> generateKey(AlgorithmIdentifier algorithm,
-                          boolean extractable,
-                          sequence&lt;KeyUsage> keyUsages );
-  Promise&lt;any> deriveKey(AlgorithmIdentifier algorithm,
-                         CryptoKey baseKey,
-                         AlgorithmIdentifier derivedKeyType,
-                         boolean extractable,
-                         sequence&lt;KeyUsage> keyUsages );
-  Promise&lt;ArrayBuffer> deriveBits(AlgorithmIdentifier algorithm,
-                          CryptoKey baseKey,
-                          optional unsigned long? length = null);
+  Promise&lt;(CryptoKey or CryptoKeyPair)> generateKey(
+    AlgorithmIdentifier algorithm,
+    boolean extractable,
+    sequence&lt;KeyUsage> keyUsages
+  );
+  Promise&lt;CryptoKey> deriveKey(
+    AlgorithmIdentifier algorithm,
+    CryptoKey baseKey,
+    AlgorithmIdentifier derivedKeyType,
+    boolean extractable,
+    sequence&lt;KeyUsage> keyUsages
+  );
+  Promise&lt;ArrayBuffer> deriveBits(
+    AlgorithmIdentifier algorithm,
+    CryptoKey baseKey,
+    optional unsigned long? length = null
+  );
 
-  Promise&lt;CryptoKey> importKey(KeyFormat format,
-                         (BufferSource or JsonWebKey) keyData,
-                         AlgorithmIdentifier algorithm,
-                         boolean extractable,
-                         sequence&lt;KeyUsage> keyUsages );
-  Promise&lt;any> exportKey(KeyFormat format, CryptoKey key);
+  Promise&lt;CryptoKey> importKey(
+    KeyFormat format,
+    (BufferSource or JsonWebKey) keyData,
+    AlgorithmIdentifier algorithm,
+    boolean extractable,
+    sequence&lt;KeyUsage> keyUsages
+  );
+  Promise&lt;(ArrayBuffer or JsonWebKey)> exportKey(
+    KeyFormat format,
+    CryptoKey key
+  );
 
-  Promise&lt;any> wrapKey(KeyFormat format,
-                       CryptoKey key,
-                       CryptoKey wrappingKey,
-                       AlgorithmIdentifier wrapAlgorithm);
-  Promise&lt;CryptoKey> unwrapKey(KeyFormat format,
-                         BufferSource wrappedKey,
-                         CryptoKey unwrappingKey,
-                         AlgorithmIdentifier unwrapAlgorithm,
-                         AlgorithmIdentifier unwrappedKeyAlgorithm,
-                         boolean extractable,
-                         sequence&lt;KeyUsage> keyUsages );
+  Promise&lt;ArrayBuffer> wrapKey(
+    KeyFormat format,
+    CryptoKey key,
+    CryptoKey wrappingKey,
+    AlgorithmIdentifier wrapAlgorithm
+  );
+  Promise&lt;CryptoKey> unwrapKey(
+    KeyFormat format,
+    BufferSource wrappedKey,
+    CryptoKey unwrappingKey,
+    AlgorithmIdentifier unwrapAlgorithm,
+    AlgorithmIdentifier unwrappedKeyAlgorithm,
+    boolean extractable,
+    sequence&lt;KeyUsage> keyUsages
+  );
 };
         </pre>
         <div class=note>


### PR DESCRIPTION
Also, reformat the WebIDL.

Resolves https://github.com/w3c/webcrypto/issues/293.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/388.html" title="Last updated on Dec 19, 2024, 1:24 PM UTC (197723b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/388/90feb1e...197723b.html" title="Last updated on Dec 19, 2024, 1:24 PM UTC (197723b)">Diff</a>