### PR TITLE
Accept (async) iterables in `crypto.subtle.digest`

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1271,7 +1271,7 @@ interface SubtleCrypto {
   );
   Promise&lt;ArrayBuffer> digest(
     AlgorithmIdentifier algorithm,
-    BufferSource data
+    (BufferSource or async_sequence&lt;BufferSource>) data
   );
 
   Promise&lt;(CryptoKey or CryptoKeyPair)> generateKey(
@@ -1858,11 +1858,136 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |data| be the result of
-                  [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the `data` parameter passed to the
+                  Let |data| be the `data` parameter passed to the
                   {{SubtleCrypto/digest()}} method.
                 </p>
+              </li>
+              <li>
+                <p>
+                  Let |bytesPromise| be a new Promise.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |data| is a {{BufferSource}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |bytes| be the result of
+                          [= get a copy of the buffer source |
+                          getting a copy of the bytes held by =] |data|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Resolve |bytesPromise| with |bytes|.
+                        </p>
+                      </li>
+                  </dd>
+                  <dt>
+                    Otherwise:
+                  </dt>
+                  <dd>
+                    <div class=note>
+                      <p>
+                        In this case, |data| is an [= async sequence type | async sequence =] of {{BufferSource}}s.
+                      </p>
+                    </div>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |bytes| be an empty [= byte sequence =].
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |iterator| be the result of [= open an async sequence | opening =] |data|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred, reject |bytesPromise| with
+                          |iterator| and terminate these steps.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |getValueSteps| be the following list of steps:
+                        </p>
+                        <ol>
+                          <li>
+                            <p>
+                              Let |next| be the result of [= get an async iterator next value | getting the next value =] of |iterator|.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              [= promise/React =] to |next|:
+                            </p>
+                            <dl class="switch">
+                              <dt>If |next| was rejected with |reason|:</dt>
+                              <dd>
+                                <ol>
+                                  <li>
+                                    <p>
+                                      Reject |bytesPromise| with |reason|.
+                                    </p>
+                                  </li>
+                                </ol>
+                              </dd>
+                              <dt>If |next| was fulfilled with |value|:</dt>
+                              <dd>
+                                <ol>
+                                  <li>
+                                    <p>
+                                      If |value| is [= end of iteration =],
+                                      resolve |bytesPromise| with |bytes|
+                                      and terminate these steps.
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p>
+                                      Append the result of [= get a copy of the buffer source |
+                                      getting a copy of the bytes held by =] |value|
+                                      to |bytes|.
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p>
+                                      Perform |getValueSteps|.
+                                    </p>
+                                  </li>
+                                </ol>
+                              </dd>
+                            </dl>
+                          </li>
+                        </ol>
+                      </li>
+                      <li>
+                        <p>
+                          [= Queue a microtask =] to perform |getValueSteps|.
+                        </p>
+                      </li>
+                    </ol>
+                    <div class=note>
+                      <p>
+                        The implementation may wish to compute the hash digest
+                        incrementally, instead of waiting until all data is
+                        available, in order to conserve memory.
+                      </p>
+                      <p>
+                        Additionally, if the |iterator| returned by
+                        [= open an async sequence | opening =] |data|
+                        is the iterator defined by <a data-cite="streams#readablestream">`ReadableStream`</a>,
+                        the implementation may wish to optimize the steps
+                        above, for example by reading the stream directly,
+                        and/or <a data-cite="streams#transferrable-streams">transferring</a>
+                        the stream to the [= in parallel | parallel =] steps below.
+                      </p>
+                    </div>
+                  </dd>
+                </dl>
               </li>
               <li>
                 <p>
@@ -1891,29 +2016,51 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |digest| be the result of performing the digest
-                  operation specified by |normalizedAlgorithm| using
-                  |algorithm|, with |data|
-                  as |message|.
+                  [= promise/React =] to |bytesPromise|:
                 </p>
-              </li>
-              <li>
-                <p>
-                  [= Queue a global task =] on the [= crypto task source =],
-                  given |realm|'s global object, to perform the remaining steps.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
-                  in |realm|, containing |digest|.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Resolve |promise| with
-                  |result|.
-                </p>
+                <dl class="switch">
+                  <dt>If |bytesPromise| was rejected with |reason|:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          [= exception/Throw =] |reason|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |bytesPromise| was fulfilled with value |bytes|:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |digest| be the result of performing the digest
+                          operation specified by |normalizedAlgorithm| using
+                          |algorithm|, with |bytes|
+                          as |message|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          [= Queue a global task =] on the [= crypto task source =],
+                          given |realm|'s global object, to perform the remaining steps.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of [= ArrayBuffer/create | creating =] an {{ArrayBuffer}}
+                          in |realm|, containing |digest|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Resolve |promise| with
+                          |result|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                </dl>
               </li>
             </ol>
           </section>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1982,7 +1982,7 @@ interface SubtleCrypto {
                         is the iterator defined by <a data-cite="streams#readablestream">`ReadableStream`</a>,
                         the implementation may wish to optimize the steps
                         above, for example by reading the stream directly,
-                        and/or <a data-cite="streams#transferrable-streams">transferring</a>
+                        and/or <a data-cite="streams#rs-transfer">transferring</a>
                         the stream to the [= in parallel | parallel =] steps below.
                       </p>
                     </div>


### PR DESCRIPTION
Addresses part of https://github.com/w3c/webcrypto/issues/73 by accepting an iterable or async iterable (such as a `ReadableStream`) of `BufferSource`s in `crypto.subtle.digest`, in order to enable incremental/streaming hashing.

(In the future, we could do something similar for `crypto.subtle.sign` and `crypto.subtle.verify` fairly easily, but I started with `crypto.subtle.digest` since it seems most important and I wanted to check whether folks are happy with this direction first.)

Note that the spec text doesn't _require_ incremental/streaming hashing because [FIPS-180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) defines the SHA functions as single-shot functions which take a complete message, even though it is very common for implementations to provide a streaming API.

~Note also that the Web IDL isn't super pretty because it doesn't support syntax like~
```webidl
Promise<ArrayBuffer> digest(
  AlgorithmIdentifier algorithm,
  (BufferSource or iterable<BufferSource> or async iterable<BufferSource>) data
);
```
~so instead we do~
```webidl
typedef object IterableOfBufferSources;
typedef object AsyncIterableOfBufferSources;

Promise<ArrayBuffer> digest(
  AlgorithmIdentifier algorithm,
  (BufferSource or IterableOfBufferSources or AsyncIterableOfBufferSources) data
);
```
~and check the types involved in the calling function.~

Edit: the following is supported now:
```webidl
Promise<ArrayBuffer> digest(
  AlgorithmIdentifier algorithm,
  (BufferSource or async_sequence<BufferSource>) data
);
```
so we use that now.

Finally, I've left the language around running [in parallel](https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel) for now, even though [it's not completely clear whether we want/need it](https://github.com/w3c/webcrypto/issues/389). However, when accepting async iterables specifically, we need to return a Promise and queue a task to resolve it anyway, so for this specific functionality it probably doesn't matter that much.

AFAICT, due to the loose definition of running [in parallel](https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel), implementations are already free to do the hashing on the same thread if they wish (e.g. if the overhead of using multiple threads isn't worth it).

Finally, I didn't include `ECMAScript` in the list of `xref`'ed specs, because it caused a bunch of ambiguities for `TypeError` and `SyntaxError`, increasing the number of required manual citations more than I had to do here.

(Apologies for the long list of review requests, but since this is a fairly significant new feature I wanted to make sure everybody's on board with this.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/390.html" title="Last updated on Aug 6, 2026, 5:24 PM UTC (bcd984d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/390/27b3faa...bcd984d.html" title="Last updated on Aug 6, 2026, 5:24 PM UTC (bcd984d)">Diff</a>