### PR TITLE
Fix RSA-OAEP and RSA-PSS typos for JWK

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -5502,14 +5502,14 @@ dictionary RsaPssParams : Algorithm {
                                 <li>
                                   <p>
                                     Let |privateKey| represent the
-                                    RSA public key identified by interpreting |jwk|
-                                    according to Section 6.3.1 of JSON Web
+                                    RSA private key identified by interpreting |jwk|
+                                    according to Section 6.3.2 of JSON Web
                                     Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If |privateKey| can be determined to not be a valid RSA public key
+                                    If |privateKey| can be determined to not be a valid RSA private key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.
@@ -6529,13 +6529,13 @@ dictionary RsaOaepParams : Algorithm {
                                 <li>
                                   <p>
                                     Let |privateKey| represent the
-                                    RSA public key identified by interpreting |jwk|
-                                    according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
+                                    RSA private key identified by interpreting |jwk|
+                                    according to Section 6.3.2 of JSON Web Algorithms [[JWA]].
                                   </p>
                                 </li>
                                 <li>
                                   <p>
-                                    If |privateKey| can be determined to not be a valid RSA public key
+                                    If |privateKey| can be determined to not be a valid RSA private key
                                     according to [[RFC3447]],
                                     then [= exception/throw =] a
                                     {{DataError}}.


### PR DESCRIPTION
Fixes some simple typos in the RSA-OAEP and RSA-PSS JWK import operations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/devgianlu/webcrypto/pull/391.html" title="Last updated on Dec 26, 2024, 5:26 PM UTC (1a3b9af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/391/0ac8c1b...devgianlu:1a3b9af.html" title="Last updated on Dec 26, 2024, 5:26 PM UTC (1a3b9af)">Diff</a>