### PR TITLE
Add missing algorithm `length` property in HMAC key generation

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14393,6 +14393,12 @@ dictionary HmacKeyGenParams : Algorithm {
                 </li>
                 <li>
                   <p>
+                    Set the {{HmacKeyAlgorithm/length}} attribute of
+                    |algorithm| to |length|.
+                  </p>
+                </li>
+                <li>
+                  <p>
                     Let |hash| be a new
                     {{KeyAlgorithm}}.
                   </p>


### PR DESCRIPTION
Fixes #392.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/394.html" title="Last updated on Dec 31, 2024, 1:26 PM UTC (cf5b25b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/394/2fecff8...cf5b25b.html" title="Last updated on Dec 31, 2024, 1:26 PM UTC (cf5b25b)">Diff</a>