### PR TITLE
Refer to byte/bit sequences instead of octet/bit strings

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -12070,8 +12070,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCtrParams/counter}} member of
-                    |normalizedAlgorithm| does not have length 16
-                    bytes,
+                    |normalizedAlgorithm| does not have
+                    a [= byte sequence/length =] of 16 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -12110,8 +12110,8 @@ dictionary AesDerivedKeyParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCtrParams/counter}} member of
-                    |normalizedAlgorithm| does not have length 16
-                    bytes,
+                    |normalizedAlgorithm| does not have
+                    a [= byte sequence/length =] of 16 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -12611,8 +12611,8 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCbcParams/iv}} member of
-                    |normalizedAlgorithm| does not have length 16
-                    bytes,
+                    |normalizedAlgorithm| does not have
+                    a [= byte sequence/length =] of 16 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -12647,8 +12647,8 @@ dictionary AesCbcParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesCbcParams/iv}} member of
-                    |normalizedAlgorithm| does not have length 16
-                    bytes,
+                    |normalizedAlgorithm| does not have
+                    a [= byte sequence/length =] of 16 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -13147,8 +13147,8 @@ dictionary AesGcmParams : Algorithm {
               <ol>
                 <li>
                   <p>
-                    If |plaintext| has a length greater than 2^39 - 256
-                    bytes,
+                    If |plaintext| has a [= byte sequence/length =]
+                    greater than 2^39 - 256 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -13156,8 +13156,8 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/iv}} member of
-                    |normalizedAlgorithm| has a length greater than 2^64 - 1
-                    bytes,
+                    |normalizedAlgorithm| has a [= byte sequence/length =]
+                    greater than 2^64 - 1 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -13165,7 +13165,8 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/additionalData}} member
-                    of |normalizedAlgorithm| is present and has a length
+                    of |normalizedAlgorithm| is present and has a
+                    [= byte sequence/length =]
                     greater than 2^64 - 1 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
@@ -13249,8 +13250,8 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/iv}} member of
-                    |normalizedAlgorithm| has a length greater than 2^64 - 1
-                    bytes,
+                    |normalizedAlgorithm| has a [= byte sequence/length =]
+                    greater than 2^64 - 1 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>
@@ -13258,9 +13259,9 @@ dictionary AesGcmParams : Algorithm {
                 <li>
                   <p>
                     If the {{AesGcmParams/additionalData}} member
-                    of |normalizedAlgorithm| is present and has a length
-                    greater than 2^64 - 1
-                    bytes,
+                    of |normalizedAlgorithm| is present and has a
+                    [= byte sequence/length =]
+                    greater than 2^64 - 1 bytes,
                     then [= exception/throw =] an
                     {{OperationError}}.
                   </p>


### PR DESCRIPTION
Builds on top of #396.

Refer to Infra's [byte sequence](https://infra.spec.whatwg.org/#byte-sequence)s instead of defining our own octet string concept, and rename bit strings to bit sequences to match. Also, link to Infra's [byte sequence/length](https://infra.spec.whatwg.org/#byte-sequence-length) where appropriate, and properly define the length in bits.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/397.html" title="Last updated on Jan 9, 2025, 9:05 AM UTC (071f8b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/397/b965a99...071f8b9.html" title="Last updated on Jan 9, 2025, 9:05 AM UTC (071f8b9)">Diff</a>