### PR TITLE
Clarify that the `saltLength` parameter of RSA-PSS is in bytes, not bits

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -4963,7 +4963,7 @@ dictionary RsaPssParams : Algorithm {
   required [EnforceRange] unsigned long saltLength;
 };
           </pre>
-          <p>The <dfn data-idl data-dfn-for=RsaPssParams id="dfn-RsaPssParams-saltLength">saltLength</dfn> member represents the desired length of the random salt.</p>
+          <p>The <dfn data-idl data-dfn-for=RsaPssParams id="dfn-RsaPssParams-saltLength">saltLength</dfn> member represents the desired length of the random salt in bytes.</p>
         </section>
         <section id="rsa-pss-operations">
           <h4>Operations</h4>


### PR DESCRIPTION
This parameter trips me every time, everything in webcrypto is in bits and yet this is in bytes and is not called out.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto/pull/400.html" title="Last updated on Mar 7, 2025, 11:19 AM UTC (1a57452)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/400/efe2685...panva:1a57452.html" title="Last updated on Mar 7, 2025, 11:19 AM UTC (1a57452)">Diff</a>