### PR TITLE
Reintroduce `alg` JWK field for Ed25519 keys

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10751,6 +10751,14 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                         </li>
                         <li>
                           <p>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present and is
+                            not "`Ed25519`" or "`EdDSA`",
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                          </p>
+                        </li>
+                        <li>
+                          <p>
                             If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
                             not "`sig`",
                             then [= exception/throw =] a
@@ -11035,6 +11043,12 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                           <p>
                             Set the `kty` attribute of |jwk| to
                             "`OKP`".
+                          </p>
+                        </li>
+                        <li>
+                          <p>
+                            Set the `alg` attribute of |jwk| to
+                            "`Ed25519`".
                           </p>
                         </li>
                         <li>
@@ -15873,7 +15887,8 @@ dictionary Pbkdf2Params : Algorithm {
                 <td>
 <pre class=js>
 { kty: "OKP",
-  crv: "Ed25519" }
+  crv: "Ed25519",
+  alg: "Ed25519" }
 </pre>
                 </td>
                 <td>


### PR DESCRIPTION
With https://datatracker.ietf.org/doc/draft-ietf-jose-fully-specified-algorithms/ submitted to IESG for Publication we can add the new "alg" to the Ed25519 JWK export while accepting both old and new in JWK import.

I don't think this is strictly necessary but I'm opening this here as an option in hopes that it will strike at least one of the objections raised prior by @davidben that (I think?) continues to block the unflagging of Ed25519 in Chromium.

Refs https://github.com/WICG/webcrypto-secure-curves/pull/24
Refs https://github.com/w3c/webcrypto/pull/362#issuecomment-2030785823
Refs https://issues.chromium.org/issues/40074061


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto/pull/401.html" title="Last updated on Mar 7, 2025, 11:08 AM UTC (39874bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/401/efe2685...panva:39874bd.html" title="Last updated on Mar 7, 2025, 11:08 AM UTC (39874bd)">Diff</a>