### PR TITLE
Create sections for individual operations

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -15037,67 +15037,67 @@ dictionary HmacKeyGenParams : Algorithm {
         </section>
         <section id="sha-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Digest</dt>
-            <dd>
-              <ol>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{Algorithm/name}} member of
-                      |normalizedAlgorithm| is a cases-sensitive string match for
-                      "`SHA-1`":
-                    </dt>
-                    <dd>
-                      Let |result| be the result of performing the SHA-1 hash function
-                      defined in Section 6.1 of [[FIPS-180-4]] using
-                      |message| as the input message, |M|.
-                    </dd>
-                    <dt>
-                      If the {{Algorithm/name}} member of
-                      |normalizedAlgorithm| is a cases-sensitive string match for
-                      "`SHA-256`":
-                    </dt>
-                    <dd>
-                      Let |result| be the result of performing the SHA-256 hash function
-                      defined in Section 6.2 of [[FIPS-180-4]] using
-                      |message| as the input message, |M|.
-                    </dd>
-                    <dt>
-                      If the {{Algorithm/name}} member of
-                      |normalizedAlgorithm| is a cases-sensitive string match for
-                      "`SHA-384`":
-                    </dt>
-                    <dd>
-                      Let |result| be the result of performing the SHA-384 hash function
-                      defined in Section 6.5 of [[FIPS-180-4]] using
-                      |message| as the input message, |M|.
-                    </dd>
-                    <dt>
-                      If the {{Algorithm/name}} member of
-                      |normalizedAlgorithm| is a cases-sensitive string match for
-                      "`SHA-512`":
-                    </dt>
-                    <dd>
-                      Let |result| be the result of performing the SHA-512 hash function
-                      defined in Section 6.4 of [[FIPS-180-4]] using
-                      |message| as the input message, |M|.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+
+          <section id="sha-operations-digest">
+            <h5>Digest</h5>
+
+            <ol>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{Algorithm/name}} member of
+                    |normalizedAlgorithm| is a cases-sensitive string match for
+                    "`SHA-1`":
+                  </dt>
+                  <dd>
+                    Let |result| be the result of performing the SHA-1 hash function
+                    defined in Section 6.1 of [[FIPS-180-4]] using
+                    |message| as the input message, |M|.
+                  </dd>
+                  <dt>
+                    If the {{Algorithm/name}} member of
+                    |normalizedAlgorithm| is a cases-sensitive string match for
+                    "`SHA-256`":
+                  </dt>
+                  <dd>
+                    Let |result| be the result of performing the SHA-256 hash function
+                    defined in Section 6.2 of [[FIPS-180-4]] using
+                    |message| as the input message, |M|.
+                  </dd>
+                  <dt>
+                    If the {{Algorithm/name}} member of
+                    |normalizedAlgorithm| is a cases-sensitive string match for
+                    "`SHA-384`":
+                  </dt>
+                  <dd>
+                    Let |result| be the result of performing the SHA-384 hash function
+                    defined in Section 6.5 of [[FIPS-180-4]] using
+                    |message| as the input message, |M|.
+                  </dd>
+                  <dt>
+                    If the {{Algorithm/name}} member of
+                    |normalizedAlgorithm| is a cases-sensitive string match for
+                    "`SHA-512`":
+                  </dt>
+                  <dd>
+                    Let |result| be the result of performing the SHA-512 hash function
+                    defined in Section 6.4 of [[FIPS-180-4]] using
+                    |message| as the input message, |M|.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13201,560 +13201,570 @@ dictionary AesGcmParams : Algorithm {
         </section>
         <section id="aes-gcm-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Encrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |plaintext| has a [= byte sequence/length =]
-                    greater than 2^39 - 256 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesGcmParams/iv}} member of
-                    |normalizedAlgorithm| has a [= byte sequence/length =]
-                    greater than 2^64 - 1 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesGcmParams/additionalData}} member
-                    of |normalizedAlgorithm| is present and has a
-                    [= byte sequence/length =]
-                    greater than 2^64 - 1 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If the {{AesGcmParams/tagLength}} member of
-                    |normalizedAlgorithm| is not present:</dt>
-                    <dd>Let |tagLength| be 128.</dd>
-                    <dt>If the {{AesGcmParams/tagLength}} member of
-                    |normalizedAlgorithm| is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
-                    <dd>Let |tagLength| be equal to the
-                    {{AesGcmParams/tagLength}} member of
-                     |normalizedAlgorithm|</dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      [= exception/throw =] an
-                      {{OperationError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |additionalData| be the {{AesGcmParams/additionalData}} member of
-                    |normalizedAlgorithm| if present or an empty [= byte sequence =]
-                    otherwise.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |C| and |T| be the outputs that result from performing
-                    the Authenticated Encryption Function described in Section 7.1 of
-                    [[NIST-SP800-38D]] using AES as the block cipher, the {{AesGcmParams/iv}} member of |normalizedAlgorithm| as
-                    the |IV| input parameter,
-                    |additionalData| as the |A| input parameter,
-                    |tagLength| as the |t| pre-requisite and
-                    |plaintext| as the input plaintext.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |ciphertext| be equal to |C| | |T|,
-                    where '|' denotes concatenation.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |ciphertext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Decrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <dl class="switch">
-                    <dt>If the {{AesGcmParams/tagLength}} member of
-                    |normalizedAlgorithm| is not present:</dt>
-                    <dd>Let |tagLength| be 128.</dd>
-                    <dt>If the {{AesGcmParams/tagLength}} member of
-                    |normalizedAlgorithm| is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
-                    <dd>Let |tagLength| be equal to the
-                    {{AesGcmParams/tagLength}} member of
-                     |normalizedAlgorithm|</dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      [= exception/throw =] an
-                      {{OperationError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    If |ciphertext| has a [= length in bits =] less than |tagLength|,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesGcmParams/iv}} member of
-                    |normalizedAlgorithm| has a [= byte sequence/length =]
-                    greater than 2^64 - 1 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesGcmParams/additionalData}} member
-                    of |normalizedAlgorithm| is present and has a
-                    [= byte sequence/length =]
-                    greater than 2^64 - 1 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |tag| be the last |tagLength| bits of
-                    |ciphertext|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |actualCiphertext| be the result of removing the last |tagLength| bits
-                    from |ciphertext|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |additionalData| be the {{AesGcmParams/additionalData}} member of
-                    |normalizedAlgorithm| if present or an empty [= byte sequence =]
-                    otherwise.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Perform the Authenticated Decryption Function described in Section 7.2 of
-                    [[NIST-SP800-38D]] using AES as the block cipher,
-                    the {{AesGcmParams/iv}} member of |normalizedAlgorithm| as
-                    the |IV| input parameter,
-                    |additionalData| as the |A| input parameter,
-                    |tagLength| as the |t| pre-requisite,
-                    |actualCiphertext| as the input ciphertext, |C| and |tag| as
-                    the authentication tag, |T|.
-                  </p>
-                  <dl class="switch">
-                    <dt>If the result of the algorithm is the indication of inauthenticity,
-                    "|FAIL|":</dt>
-                    <dd>
-                      [= exception/throw =] an
-                      {{OperationError}}
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>Let |plaintext| be the output |P| of the Authenticated
-                    Decryption Function.</dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |plaintext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains any entry which is not
-                    one of "`encrypt`", "`decrypt`",
-                    "`wrapKey`" or "`unwrapKey`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm| is not equal to one of
-                    128, 192 or 256,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
 
-                <li>
-                  <p>
-                    Generate an AES key of length
-                    equal to the {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the key generation step fails,
-                    then [= exception/throw =] an
+          <section id="aes-gcm-operations-encrypt">
+            <h5>Encrypt</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |plaintext| has a [= byte sequence/length =]
+                  greater than 2^39 - 256 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesGcmParams/iv}} member of
+                  |normalizedAlgorithm| has a [= byte sequence/length =]
+                  greater than 2^64 - 1 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesGcmParams/additionalData}} member
+                  of |normalizedAlgorithm| is present and has a
+                  [= byte sequence/length =]
+                  greater than 2^64 - 1 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If the {{AesGcmParams/tagLength}} member of
+                  |normalizedAlgorithm| is not present:</dt>
+                  <dd>Let |tagLength| be 128.</dd>
+                  <dt>If the {{AesGcmParams/tagLength}} member of
+                  |normalizedAlgorithm| is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
+                  <dd>Let |tagLength| be equal to the
+                  {{AesGcmParams/tagLength}} member of
+                   |normalizedAlgorithm|</dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] an
                     {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new
-                    {{CryptoKey}} object representing the
-                    generated AES key.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-GCM`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to equal the
-                    {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |key| to be |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |key| to be |usages|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    one of "`encrypt`", "`decrypt`",
-                    "`wrapKey`" or "`unwrapKey`",
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |additionalData| be the {{AesGcmParams/additionalData}} member of
+                  |normalizedAlgorithm| if present or an empty [= byte sequence =]
+                  otherwise.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |C| and |T| be the outputs that result from performing
+                  the Authenticated Encryption Function described in Section 7.1 of
+                  [[NIST-SP800-38D]] using AES as the block cipher, the {{AesGcmParams/iv}} member of |normalizedAlgorithm| as
+                  the |IV| input parameter,
+                  |additionalData| as the |A| input parameter,
+                  |tagLength| as the |t| pre-requisite and
+                  |plaintext| as the input plaintext.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |ciphertext| be equal to |C| | |T|,
+                  where '|' denotes concatenation.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |ciphertext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-gcm-operations-decrypt">
+            <h5>Decrypt</h5>
+
+            <ol>
+              <li>
+                <dl class="switch">
+                  <dt>If the {{AesGcmParams/tagLength}} member of
+                  |normalizedAlgorithm| is not present:</dt>
+                  <dd>Let |tagLength| be 128.</dd>
+                  <dt>If the {{AesGcmParams/tagLength}} member of
+                  |normalizedAlgorithm| is one of 32, 64, 96, 104, 112, 120 or 128:</dt>
+                  <dd>Let |tagLength| be equal to the
+                  {{AesGcmParams/tagLength}} member of
+                   |normalizedAlgorithm|</dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] an
+                    {{OperationError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  If |ciphertext| has a [= length in bits =] less than |tagLength|,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesGcmParams/iv}} member of
+                  |normalizedAlgorithm| has a [= byte sequence/length =]
+                  greater than 2^64 - 1 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesGcmParams/additionalData}} member
+                  of |normalizedAlgorithm| is present and has a
+                  [= byte sequence/length =]
+                  greater than 2^64 - 1 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |tag| be the last |tagLength| bits of
+                  |ciphertext|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |actualCiphertext| be the result of removing the last |tagLength| bits
+                  from |ciphertext|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |additionalData| be the {{AesGcmParams/additionalData}} member of
+                  |normalizedAlgorithm| if present or an empty [= byte sequence =]
+                  otherwise.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the Authenticated Decryption Function described in Section 7.2 of
+                  [[NIST-SP800-38D]] using AES as the block cipher,
+                  the {{AesGcmParams/iv}} member of |normalizedAlgorithm| as
+                  the |IV| input parameter,
+                  |additionalData| as the |A| input parameter,
+                  |tagLength| as the |t| pre-requisite,
+                  |actualCiphertext| as the input ciphertext, |C| and |tag| as
+                  the authentication tag, |T|.
+                </p>
+                <dl class="switch">
+                  <dt>If the result of the algorithm is the indication of inauthenticity,
+                  "|FAIL|":</dt>
+                  <dd>
+                    [= exception/throw =] an
+                    {{OperationError}}
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>Let |plaintext| be the output |P| of the Authenticated
+                  Decryption Function.</dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |plaintext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-gcm-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains any entry which is not
+                  one of "`encrypt`", "`decrypt`",
+                  "`wrapKey`" or "`unwrapKey`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm| is not equal to one of
+                  128, 192 or 256,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  Generate an AES key of length
+                  equal to the {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the key generation step fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new
+                  {{CryptoKey}} object representing the
+                  generated AES key.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-GCM`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to equal the
+                  {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |key| to be |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |key| to be |usages|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-gcm-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  one of "`encrypt`", "`decrypt`",
+                  "`wrapKey`" or "`unwrapKey`",
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the [= length in bits =] of |data| is not 128, 192 or 256
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                          "`oct`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |jwk| does not meet the requirements of
+                          Section 6.4 of JSON Web Algorithms [[JWA]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be the [= byte sequence =] obtained by decoding the
+                          {{JsonWebKey/k}} field of |jwk|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the [= length in bits =] of |data| is 128:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A128GCM`",
                             then [= exception/throw =] a
-                            {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the [= length in bits =] of |data| is not 128, 192 or 256
+                            {{DataError}}.</dd>
+                          <dt>If the [= length in bits =] of |data| is 192:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A192GCM`",
                             then [= exception/throw =] a
+                            {{DataError}}.</dd>
+                          <dt>If the [= length in bits =] of |data| is 256:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A256GCM`",
+                            then [= exception/throw =] a
+                            {{DataError}}.</dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                            "`oct`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |jwk| does not meet the requirements of
-                            Section 6.4 of JSON Web Algorithms [[JWA]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be the [= byte sequence =] obtained by decoding the
-                            {{JsonWebKey/k}} field of |jwk|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the [= length in bits =] of |data| is 128:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A128GCM`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>If the [= length in bits =] of |data| is 192:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A192GCM`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>If the [= length in bits =] of |data| is 256:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A256GCM`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              [= exception/throw =] a
-                              {{DataError}}.
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not  "`enc`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not  "`enc`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new {{CryptoKey}}
+                  object representing an AES key with value |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-GCM`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to the length, in bits, of |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-gcm-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be a [= byte sequence =] containing
+                          the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to the
+                          string "`oct`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
+                          containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 128:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A128GCM`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 192:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A192GCM`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 256:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A256GCM`".</dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to equal the
+                          {{CryptoKey/usages}} attribute of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
                       {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new {{CryptoKey}}
-                    object representing an AES key with value |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-GCM`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to the length, in bits, of |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be a [= byte sequence =] containing
-                            the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to the
-                            string "`oct`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
-                            containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 128:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A128GCM`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 192:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A192GCM`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 256:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A256GCM`".</dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to equal the
-                            {{CryptoKey/usages}} attribute of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Get key length</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-gcm-operations-get-key-length">
+            <h5>Get key length</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -12654,467 +12654,477 @@ dictionary AesCbcParams : Algorithm {
         </section>
         <section id="aes-cbc-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Encrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesCbcParams/iv}} member of
-                    |normalizedAlgorithm| does not have
-                    a [= byte sequence/length =] of 16 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |paddedPlaintext| be the result of adding padding octets to
-                    |plaintext|
-                    according to the procedure defined in Section 10.3
-                    of [[RFC2315]], step 2, with a value of
-                    |k| of 16.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |ciphertext| be the result of performing the CBC Encryption
-                    operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCbcParams/iv}} member of |normalizedAlgorithm| as
-                    the |IV| input parameter and |paddedPlaintext|
-                    as the input plaintext.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |ciphertext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Decrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesCbcParams/iv}} member of
-                    |normalizedAlgorithm| does not have
-                    a [= byte sequence/length =] of 16 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |paddedPlaintext| be the result of performing the CBC Decryption
-                    operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCbcParams/iv}} member of |normalizedAlgorithm| as
-                    the |IV| input parameter and
-                    |ciphertext| as the input ciphertext.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |p| be the value of the last octet of |paddedPlaintext|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If |p| is zero or greater than 16, or if any of the last |p|
-                    octets of |paddedPlaintext| have a value which is not |p|,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |plaintext| be the result of removing |p| octets from
-                    the end of |paddedPlaintext|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |plaintext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains any entry which is not
-                     one of "`encrypt`", "`decrypt`",
-                    "`wrapKey`" or "`unwrapKey`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm| is not equal to one of
-                    128, 192 or 256,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
 
-                <li>
-                  <p>
-                    Generate an AES key of length
-                    equal to the {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the key generation step fails,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new
-                    {{CryptoKey}} object representing the
-                    generated AES key.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-CBC`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to equal the
-                    {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |key| to be |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |key| to be |usages|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    one of "`encrypt`", "`decrypt`",
-                    "`wrapKey`" or "`unwrapKey`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the [= length in bits =] of |data| is not 128, 192 or 256
+          <section id="aes-cbc-operations-encrypt">
+            <h5>Encrypt</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesCbcParams/iv}} member of
+                  |normalizedAlgorithm| does not have
+                  a [= byte sequence/length =] of 16 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |paddedPlaintext| be the result of adding padding octets to
+                  |plaintext|
+                  according to the procedure defined in Section 10.3
+                  of [[RFC2315]], step 2, with a value of
+                  |k| of 16.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |ciphertext| be the result of performing the CBC Encryption
+                  operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCbcParams/iv}} member of |normalizedAlgorithm| as
+                  the |IV| input parameter and |paddedPlaintext|
+                  as the input plaintext.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |ciphertext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-cbc-operations-decrypt">
+            <h5>Decrypt</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesCbcParams/iv}} member of
+                  |normalizedAlgorithm| does not have
+                  a [= byte sequence/length =] of 16 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |paddedPlaintext| be the result of performing the CBC Decryption
+                  operation described in Section 6.2 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCbcParams/iv}} member of |normalizedAlgorithm| as
+                  the |IV| input parameter and
+                  |ciphertext| as the input ciphertext.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |p| be the value of the last octet of |paddedPlaintext|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |p| is zero or greater than 16, or if any of the last |p|
+                  octets of |paddedPlaintext| have a value which is not |p|,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |plaintext| be the result of removing |p| octets from
+                  the end of |paddedPlaintext|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |plaintext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-cbc-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains any entry which is not
+                   one of "`encrypt`", "`decrypt`",
+                  "`wrapKey`" or "`unwrapKey`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm| is not equal to one of
+                  128, 192 or 256,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  Generate an AES key of length
+                  equal to the {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the key generation step fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new
+                  {{CryptoKey}} object representing the
+                  generated AES key.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-CBC`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to equal the
+                  {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |key| to be |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |key| to be |usages|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-cbc-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  one of "`encrypt`", "`decrypt`",
+                  "`wrapKey`" or "`unwrapKey`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the [= length in bits =] of |data| is not 128, 192 or 256
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                          "`oct`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |jwk| does not meet the requirements of
+                          Section 6.4 of JSON Web Algorithms [[JWA]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be the [= byte sequence =] obtained by decoding the
+                          {{JsonWebKey/k}} field of |jwk|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the [= length in bits =] of |data| is 128:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A128CBC`",
                             then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                            "`oct`",
+                            {{DataError}}.</dd>
+                          <dt>If the [= length in bits =] of |data| is 192:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A192CBC`",
                             then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |jwk| does not meet the requirements of
-                            Section 6.4 of JSON Web Algorithms [[JWA]],
+                            {{DataError}}.</dd>
+                          <dt>If the [= length in bits =] of |data| is 256:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A256CBC`",
                             then [= exception/throw =] a
+                            {{DataError}}.</dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be the [= byte sequence =] obtained by decoding the
-                            {{JsonWebKey/k}} field of |jwk|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the [= length in bits =] of |data| is 128:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A128CBC`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>If the [= length in bits =] of |data| is 192:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A192CBC`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>If the [= length in bits =] of |data| is 256:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A256CBC`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              [= exception/throw =] a
-                              {{DataError}}.
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not  "`enc`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not  "`enc`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new {{CryptoKey}}
+                  object representing an AES key with value |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-CBC`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to the length, in bits, of |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-cbc-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be a [= byte sequence =] containing
+                          the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>Let |jwk| be a new {{JsonWebKey}} dictionary.</p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to the
+                          string "`oct`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
+                          containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 128:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A128CBC`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 192:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A192CBC`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 256:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A256CBC`".</dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to equal the
+                          {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
-                      {{NotSupportedError}}
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new {{CryptoKey}}
-                    object representing an AES key with value |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-CBC`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to the length, in bits, of |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be a [= byte sequence =] containing
-                            the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>Let |jwk| be a new {{JsonWebKey}} dictionary.</p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to the
-                            string "`oct`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
-                            containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 128:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A128CBC`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 192:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A192CBC`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 256:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A256CBC`".</dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to equal the
-                            {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Get key length</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                      {{NotSupportedError}}.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-cbc-operations-get-key-length">
+            <h5>Get key length</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10342,821 +10342,825 @@ dictionary EcdhKeyDeriveParams : Algorithm {
 
         <section id="ed25519-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Sign</dt>
-            <dd>
-              When signing, the following algorithm should be used:
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be the result of performing the Ed25519
-                    signing process, as specified in [[RFC8032]],
-                    Section 5.1.6, with |message| as |M|,
-                    using the Ed25519 private key associated with |key|.
-                  </p>
-                  <div class="issue">
-                    <p>
-                      Some implementations may (wish to) generate randomized signatures
-                      as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
-                      instead of deterministic signatures as per [[RFC8032]].
-                    </p>
-                    <p>
-                      See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/28">WICG/webcrypto-secure-curves issue 28</a>.
-                    </p>
-                  </div>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Verify</dt>
-            <dd>
-              When verifying, the following algorithm should be used:
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the key data of |key| represents an invalid point or a small-order element
-                    on the Elliptic Curve of Ed25519, return `false`.
-                  </p>
-                  <div class="issue">
-                    <p>
-                      Not all implementations perform this check.
-                    </p>
-                    <p>
-                      See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/27">WICG/webcrypto-secure-curves issue 27</a>.
-                    </p>
-                  </div>
-                </li>
-                <li>
-                  <p>
-                    If the point R, encoded in the first half of |signature|,
-                    represents an invalid point or a small-order element
-                    on the Elliptic Curve of Ed25519, return `false`.
-                  </p>
-                  <div class="issue">
-                    <p>
-                      Not all implementations perform this check.
-                    </p>
-                    <p>
-                      See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/27">WICG/webcrypto-secure-curves issue 27</a>.
-                    </p>
-                  </div>
-                </li>
-                <li>
-                  <p>
-                    Perform the Ed25519 verification steps, as specified in [[RFC8032]],
-                    Section 5.1.7, using the cofactorless (unbatched) equation,
-                    `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|,
-                    using the Ed25519 public key associated with |key|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a boolean with the value `true` if the signature is valid
-                    and the value `false` otherwise.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains a value which is not
-                    one of "`sign`" or "`verify`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Generate an Ed25519 key pair, as defined in [[RFC8032]], section 5.1.5.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new {{KeyAlgorithm}} object.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`Ed25519`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be a new {{CryptoKey}}
-                    representing the public key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| to "`public`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |publicKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |publicKey| to true.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |publicKey| to be the [= usage intersection =]
-                    of |usages| and `[ "verify" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |privateKey| be a new {{CryptoKey}}
-                    representing the private key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |privateKey| to {{KeyType/"private"}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |privateKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |privateKey| to |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |privateKey| to be the [= usage intersection =]
-                    of |usages| and `[ "sign" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a new {{CryptoKeyPair}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/publicKey}} attribute
-                    of |result| to be |publicKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/privateKey}} attribute
-                    of |result| to be |privateKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
 
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains a value which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |spki| be the result of running the
-                            [= parse a subjectPublicKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of |spki| is
-                            not equal to the `id-Ed25519`
-                            object identifier defined in [[RFC8410]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the `algorithm`
-                            AlgorithmIdentifier field of |spki| is present,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |publicKey| be the Ed25519 public key identified by
-                            the `subjectPublicKey` field of |spki|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents |publicKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{KeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`Ed25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains a value which is not
-                            "`sign`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |privateKeyInfo| be the result of running the
-                            [= parse a privateKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurs while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            |privateKeyInfo| is not equal to the
-                            `id-Ed25519` object identifier defined in [[RFC8410]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of |privateKeyInfo| is present,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |curvePrivateKey| be the result of performing the
-                            [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the `privateKey` field
-                            of |privateKeyInfo|, |structure| as the ASN.1
-                            `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the Ed25519 private key identified by |curvePrivateKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to {{KeyType/"private"}}
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{KeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`Ed25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field is present and |usages| contains
-                            a value which is not
-                            "`sign`", or,
-                            if the {{JsonWebKey/d}} field is not present and |usages| contains
-                            a value which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                            "`OKP`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/crv}} field of |jwk| is not
-                            "`Ed25519`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/alg}} field of |jwk| is present and is
-                            not "`Ed25519`" or "`EdDSA`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not "`sig`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of JSON Web
-                            Key [[JWK]], or it does not contain all of the specified |usages|
-                            values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of
-                                    the JWK private key format described in Section 2
-                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} object that represents the
-                                    Ed25519 private key identified by interpreting
-                                    |jwk| according to Section 2 of [[RFC8037]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |Key| to {{KeyType/"private"}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of
-                                    the JWK public key format described in Section 2
-                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} object that represents the
-                                    Ed25519 public key identified by interpreting
-                                    |jwk| according to Section 2 of [[RFC8037]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |Key| to {{KeyType/"public"}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`Ed25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains a value which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{KeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`Ed25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            representing the key data provided in |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |key|
-                  </p>
-                </li>
-              </ol>
-            </dd>
+          <section id="ed25519-operations-sign">
+            <h5>Sign</h5>
 
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of performing the Ed25519
+                  signing process, as specified in [[RFC8032]],
+                  Section 5.1.6, with |message| as |M|,
+                  using the Ed25519 private key associated with |key|.
+                </p>
+                <div class="issue">
                   <p>
-                    Let |key| be the {{CryptoKey}} to be
-                    exported.
+                    Some implementations may (wish to) generate randomized signatures
+                    as per <a href="https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/">draft-irtf-cfrg-det-sigs-with-noise</a>
+                    instead of deterministic signatures as per [[RFC8032]].
                   </p>
-                </li>
-                <li>
                   <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                    See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/28">WICG/webcrypto-secure-curves issue 28</a>.
                   </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
+                </div>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ed25519-operations-verify">
+            <h5>Verify</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the key data of |key| represents an invalid point or a small-order element
+                  on the Elliptic Curve of Ed25519, return `false`.
+                </p>
+                <div class="issue">
+                  <p>
+                    Not all implementations perform this check.
+                  </p>
+                  <p>
+                    See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/27">WICG/webcrypto-secure-curves issue 27</a>.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <p>
+                  If the point R, encoded in the first half of |signature|,
+                  represents an invalid point or a small-order element
+                  on the Elliptic Curve of Ed25519, return `false`.
+                </p>
+                <div class="issue">
+                  <p>
+                    Not all implementations perform this check.
+                  </p>
+                  <p>
+                    See <a href="https://github.com/WICG/webcrypto-secure-curves/issues/27">WICG/webcrypto-secure-curves issue 27</a>.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <p>
+                  Perform the Ed25519 verification steps, as specified in [[RFC8032]],
+                  Section 5.1.7, using the cofactorless (unbatched) equation,
+                  `[S]B = R + [k]A'`, on the |signature|, with |message| as |M|,
+                  using the Ed25519 public key associated with |key|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a boolean with the value `true` if the signature is valid
+                  and the value `false` otherwise.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ed25519-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains a value which is not
+                  one of "`sign`" or "`verify`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Generate an Ed25519 key pair, as defined in [[RFC8032]], section 5.1.5.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new {{KeyAlgorithm}} object.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`Ed25519`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be a new {{CryptoKey}}
+                  representing the public key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| to "`public`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |publicKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |publicKey| to true.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |publicKey| to be the [= usage intersection =]
+                  of |usages| and `[ "verify" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |privateKey| be a new {{CryptoKey}}
+                  representing the private key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |privateKey| to {{KeyType/"private"}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |privateKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |privateKey| to |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |privateKey| to be the [= usage intersection =]
+                  of |usages| and `[ "sign" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a new {{CryptoKeyPair}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/publicKey}} attribute
+                  of |result| to be |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/privateKey}} attribute
+                  of |result| to be |privateKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ed25519-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains a value which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |spki| be the result of running the
+                          [= parse a subjectPublicKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `algorithm` AlgorithmIdentifier field of |spki| is
+                          not equal to the `id-Ed25519`
+                          object identifier defined in [[RFC8410]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the `algorithm`
+                          AlgorithmIdentifier field of |spki| is present,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |publicKey| be the Ed25519 public key identified by
+                          the `subjectPublicKey` field of |spki|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents |publicKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{KeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`Ed25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains a value which is not
+                          "`sign`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |privateKeyInfo| be the result of running the
+                          [= parse a privateKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurs while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                          |privateKeyInfo| is not equal to the
+                          `id-Ed25519` object identifier defined in [[RFC8410]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                          of |privateKeyInfo| is present,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |curvePrivateKey| be the result of performing the
+                          [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the `privateKey` field
+                          of |privateKeyInfo|, |structure| as the ASN.1
+                          `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the Ed25519 private key identified by |curvePrivateKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to {{KeyType/"private"}}
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{KeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`Ed25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field is present and |usages| contains
+                          a value which is not
+                          "`sign`", or,
+                          if the {{JsonWebKey/d}} field is not present and |usages| contains
+                          a value which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                          "`OKP`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/crv}} field of |jwk| is not
+                          "`Ed25519`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/alg}} field of |jwk| is present and is
+                          not "`Ed25519`" or "`EdDSA`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not "`sig`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of JSON Web
+                          Key [[JWK]], or it does not contain all of the specified |usages|
+                          values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of
+                                  the JWK private key format described in Section 2
+                                  of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} object that represents the
+                                  Ed25519 private key identified by interpreting
+                                  |jwk| according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |Key| to {{KeyType/"private"}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of
+                                  the JWK public key format described in Section 2
+                                  of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} object that represents the
+                                  Ed25519 public key identified by interpreting
+                                  |jwk| according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |Key| to {{KeyType/"public"}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`Ed25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains a value which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{KeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`Ed25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          representing the key data provided in |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |key|
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ed25519-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |key| be the {{CryptoKey}} to be
+                  exported.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `SubjectPublicKeyInfo`
+                          ASN.1 structure defined in [[RFC5280]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| field to an
+                              `AlgorithmIdentifier` ASN.1 type with the following
+                              properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| object identifier to the
+                                  `id-Ed25519` OID defined in [[RFC8410]].
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |subjectPublicKey| field to |keyData|.
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `PrivateKeyInfo`
+                          ASN.1 structure defined in [[RFC5208]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |version| field to `0`.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKeyAlgorithm| field to a
+                              `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                              following properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| object identifier to the
+                                  `id-Ed25519` OID defined in [[RFC8410]].
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKey| field to the result of DER-encoding
+                              a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
+                              Ed25519 private key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to
+                          "`OKP`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `alg` attribute of |jwk| to
+                          "`Ed25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `crv` attribute of |jwk| to
+                          "`Ed25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                          definition in Section 2 of [[RFC8037]].
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `SubjectPublicKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| field to an
-                                `AlgorithmIdentifier` ASN.1 type with the following
-                                properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| object identifier to the
-                                    `id-Ed25519` OID defined in [[RFC8410]].
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |subjectPublicKey| field to |keyData|.
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `PrivateKeyInfo`
-                            ASN.1 structure defined in [[RFC5208]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |version| field to `0`.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKeyAlgorithm| field to a
-                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                                following properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| object identifier to the
-                                    `id-Ed25519` OID defined in [[RFC8410]].
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKey| field to the result of DER-encoding
-                                a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                                Ed25519 private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to
-                            "`OKP`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `alg` attribute of |jwk| to
-                            "`Ed25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `crv` attribute of |jwk| to
-                            "`Ed25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                            of |key| is {{KeyType/"private"}}
+                          </dt>
+                          <dd>
+                            Set the {{JsonWebKey/d}} attribute of |jwk| according to the
                             definition in Section 2 of [[RFC8037]].
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{CryptoKey/[[type]]}} internal slot
-                              of |key| is {{KeyType/"private"}}
-                            </dt>
-                            <dd>
-                              Set the {{JsonWebKey/d}} attribute of |jwk| according to the
-                              definition in Section 2 of [[RFC8037]].
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>
-                      If |format| is {{KeyFormat/"raw"}}:
-                    </dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be a [= byte sequence =] representing the Ed25519
-                            public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>
+                    If |format| is {{KeyFormat/"raw"}}:
+                  </dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be a [= byte sequence =] representing the Ed25519
+                          public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -15388,130 +15388,134 @@ dictionary Pbkdf2Params : Algorithm {
         </section>
         <section id="pbkdf2-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Derive Bits</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |length| is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{Pbkdf2Params/iterations}} member of |normalizedAlgorithm| is zero,
-                    then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If |length| is zero, return an empty [= byte sequence =].
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |prf| be the MAC Generation function described in Section 4 of
-                    [[FIPS-198-1]] using the hash function
-                    described by the {{Pbkdf2Params/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be the result of performing the PBKDF2 operation defined
-                    in Section 5.2 of [[RFC8018]] using |prf| as the
-                    pseudo-random function, |PRF|, the password represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    as the password, |P|,
-                    the {{Pbkdf2Params/salt}} attribute of
-                    |normalizedAlgorithm| as the salt, |S|, the value of the {{Pbkdf2Params/iterations}} attribute of
-                    |normalizedAlgorithm| as the iteration count, |c|, and
-                    |length| divided by 8 as the intended key length, |dkLen|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the key derivation operation fails,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Import key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |format| is not {{KeyFormat/"raw"}}, [= exception/throw =] a {{NotSupportedError}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If |usages| contains a value that is not
-                    "`deriveKey`"  or "`deriveBits`", then
-                    [= exception/throw =] a {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If |extractable| is not `false`,
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new {{CryptoKey}}
-                    representing |keyData|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new {{KeyAlgorithm}}
-                    object.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`PBKDF2`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Get key length</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Return null.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+
+          <section id="pbkdf2-operations-derive-bits">
+            <h5>Derive Bits</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |length| is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{Pbkdf2Params/iterations}} member of |normalizedAlgorithm| is zero,
+                  then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |length| is zero, return an empty [= byte sequence =].
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |prf| be the MAC Generation function described in Section 4 of
+                  [[FIPS-198-1]] using the hash function
+                  described by the {{Pbkdf2Params/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of performing the PBKDF2 operation defined
+                  in Section 5.2 of [[RFC8018]] using |prf| as the
+                  pseudo-random function, |PRF|, the password represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  as the password, |P|,
+                  the {{Pbkdf2Params/salt}} attribute of
+                  |normalizedAlgorithm| as the salt, |S|, the value of the {{Pbkdf2Params/iterations}} attribute of
+                  |normalizedAlgorithm| as the iteration count, |c|, and
+                  |length| divided by 8 as the intended key length, |dkLen|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the key derivation operation fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="pbkdf2-operations-import-key">
+            <h5>Import key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |format| is not {{KeyFormat/"raw"}}, [= exception/throw =] a {{NotSupportedError}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |usages| contains a value that is not
+                  "`deriveKey`"  or "`deriveBits`", then
+                  [= exception/throw =] a {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |extractable| is not `false`,
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new {{CryptoKey}}
+                  representing |keyData|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new {{KeyAlgorithm}}
+                  object.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`PBKDF2`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="pbkdf2-operations-get-key-length">
+            <h5>Get key length</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Return null.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14364,629 +14364,639 @@ dictionary HmacKeyGenParams : Algorithm {
         </section>
         <section id="hmac-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Sign</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |mac| be the result of performing the MAC Generation operation
-                    described in Section 4 of [[FIPS-198-1]] using
-                    the key represented by the {{CryptoKey/[[handle]]}}
-                    internal slot of |key|, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| and |message| as the input data |text|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |mac|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Verify</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |mac| be the result of performing the MAC Generation operation
-                    described in Section 4 of [[FIPS-198-1]] using
-                    the key represented by the {{CryptoKey/[[handle]]}}
-                    internal slot of |key|, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| and |message| as the input data |text|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return true if |mac| is equal to |signature| and false
-                    otherwise.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains any entry which is not "`sign`" or
-                    "`verify`", then [= exception/throw =] a {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{HmacKeyGenParams/length}} member of
-                      |normalizedAlgorithm| is not present:
-                    </dt>
-                    <dd>
-                      Let |length| be the block size in bits of the hash function
-                      identified by the {{HmacKeyGenParams/hash}} member
-                      of |normalizedAlgorithm|.
-                    </dd>
-                    <dt>
-                      Otherwise, if the {{HmacKeyGenParams/length}}
-                      member of |normalizedAlgorithm| is non-zero:
-                    </dt>
-                    <dd>
-                      Let |length| be equal to the
-                      {{HmacKeyGenParams/length}}
-                      member of |normalizedAlgorithm|.
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      [= exception/throw =] an
-                      {{OperationError}}.
-                    </dd>
-                  </dl>
-                </li>
 
-                <li>
-                  <p>
-                    Generate a key of length |length| bits.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the key generation step fails,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new
-                    {{CryptoKey}} object representing the
-                    generated key.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{HmacKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`HMAC`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{HmacKeyAlgorithm/length}} attribute of
-                    |algorithm| to |length|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |hash| be a new
-                    {{KeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |hash| to equal the {{Algorithm/name}}
-                    member of the {{HmacKeyGenParams/hash}}
+          <section id="hmac-operations-sign">
+            <h5>Sign</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |mac| be the result of performing the MAC Generation operation
+                  described in Section 4 of [[FIPS-198-1]] using
+                  the key represented by the {{CryptoKey/[[handle]]}}
+                  internal slot of |key|, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| and |message| as the input data |text|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |mac|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="hmac-operations-verify">
+            <h5>Verify</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |mac| be the result of performing the MAC Generation operation
+                  described in Section 4 of [[FIPS-198-1]] using
+                  the key represented by the {{CryptoKey/[[handle]]}}
+                  internal slot of |key|, the hash function identified by the {{HmacKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| and |message| as the input data |text|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return true if |mac| is equal to |signature| and false
+                  otherwise.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="hmac-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains any entry which is not "`sign`" or
+                  "`verify`", then [= exception/throw =] a {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{HmacKeyGenParams/length}} member of
+                    |normalizedAlgorithm| is not present:
+                  </dt>
+                  <dd>
+                    Let |length| be the block size in bits of the hash function
+                    identified by the {{HmacKeyGenParams/hash}} member
+                    of |normalizedAlgorithm|.
+                  </dd>
+                  <dt>
+                    Otherwise, if the {{HmacKeyGenParams/length}}
+                    member of |normalizedAlgorithm| is non-zero:
+                  </dt>
+                  <dd>
+                    Let |length| be equal to the
+                    {{HmacKeyGenParams/length}}
                     member of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{HmacKeyAlgorithm/hash}} attribute
-                    of |algorithm| to |hash|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |key| to be |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |key| to be |usages|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    "`sign`" or "`verify`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |hash| be a new {{KeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set |hash| to equal the {{HmacImportParams/hash}}
-                              member of |normalizedAlgorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                            "`oct`",
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] an
+                    {{OperationError}}.
+                  </dd>
+                </dl>
+              </li>
+
+              <li>
+                <p>
+                  Generate a key of length |length| bits.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the key generation step fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new
+                  {{CryptoKey}} object representing the
+                  generated key.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{HmacKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`HMAC`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{HmacKeyAlgorithm/length}} attribute of
+                  |algorithm| to |length|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |hash| be a new
+                  {{KeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |hash| to equal the {{Algorithm/name}}
+                  member of the {{HmacKeyGenParams/hash}}
+                  member of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{HmacKeyAlgorithm/hash}} attribute
+                  of |algorithm| to |hash|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |key| to be |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |key| to be |usages|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="hmac-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  "`sign`" or "`verify`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |hash| be a new {{KeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set |hash| to equal the {{HmacImportParams/hash}}
+                            member of |normalizedAlgorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                          "`oct`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |jwk| does not meet the requirements of
+                          Section 6.4 of JSON Web Algorithms [[JWA]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be the [= byte sequence =] obtained by decoding the
+                          {{JsonWebKey/k}} field of |jwk|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the |hash| to equal the {{HmacImportParams/hash}} member of
+                          |normalizedAlgorithm|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{KeyAlgorithm/name}} attribute
+                            of |hash| is
+                            "`SHA-1`":
+                          </dt>
+                          <dd>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present
+                            and is not "`HS1`",
                             then [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |jwk| does not meet the requirements of
-                            Section 6.4 of JSON Web Algorithms [[JWA]],
+                          </dd>
+                          <dt>
+                            If the {{KeyAlgorithm/name}} attribute
+                            of |hash| is
+                            "`SHA-256`":
+                          </dt>
+                          <dd>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present
+                            and is not "`HS256`",
                             then [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be the [= byte sequence =] obtained by decoding the
-                            {{JsonWebKey/k}} field of |jwk|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the |hash| to equal the {{HmacImportParams/hash}} member of
-                            |normalizedAlgorithm|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{KeyAlgorithm/name}} attribute
-                              of |hash| is
-                              "`SHA-1`":
-                            </dt>
-                            <dd>
-                              If the {{JsonWebKey/alg}} field of |jwk| is present
-                              and is not "`HS1`",
-                              then [= exception/throw =] a
-                              {{DataError}}.
-                            </dd>
-                            <dt>
-                              If the {{KeyAlgorithm/name}} attribute
-                              of |hash| is
-                              "`SHA-256`":
-                            </dt>
-                            <dd>
-                              If the {{JsonWebKey/alg}} field of |jwk| is present
-                              and is not "`HS256`",
-                              then [= exception/throw =] a
-                              {{DataError}}.
-                            </dd>
-                            <dt>
-                              If the {{KeyAlgorithm/name}} attribute
-                              of |hash| is
-                              "`SHA-384`":
-                            </dt>
-                            <dd>
-                              If the {{JsonWebKey/alg}} field of |jwk| is present
-                              and is not "`HS384`",
-                              then [= exception/throw =] a
-                              {{DataError}}.
-                            </dd>
-                            <dt>
-                              If the {{KeyAlgorithm/name}} attribute
-                              of |hash| is
-                              "`SHA-512`":
-                            </dt>
-                            <dd>
-                              If the {{JsonWebKey/alg}} field of |jwk| is present
-                              and is not "`HS512`",
-                              then [= exception/throw =] a
-                              {{DataError}}.
-                            </dd>
-                            <dt>
-                              Otherwise, if the {{KeyAlgorithm/name}} attribute
-                              of |hash| is defined in
-                              <a href="#dfn-applicable-specification">another applicable
-                              specification</a>:
-                            </dt>
-                            <dd>
-                              Perform any [= HMAC key import steps | key
-                              import steps =] defined by
-                              <a href="#dfn-applicable-specification">other applicable
-                              specifications</a>, passing |format|, |jwk|
-                              and |hash|
-                              and obtaining |hash|.
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not  "`sign`",
+                          </dd>
+                          <dt>
+                            If the {{KeyAlgorithm/name}} attribute
+                            of |hash| is
+                            "`SHA-384`":
+                          </dt>
+                          <dd>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present
+                            and is not "`HS384`",
                             then [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
+                          </dd>
+                          <dt>
+                            If the {{KeyAlgorithm/name}} attribute
+                            of |hash| is
+                            "`SHA-512`":
+                          </dt>
+                          <dd>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present
+                            and is not "`HS512`",
                             then [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+                          </dd>
+                          <dt>
+                            Otherwise, if the {{KeyAlgorithm/name}} attribute
+                            of |hash| is defined in
+                            <a href="#dfn-applicable-specification">another applicable
+                            specification</a>:
+                          </dt>
+                          <dd>
+                            Perform any [= HMAC key import steps | key
+                            import steps =] defined by
+                            <a href="#dfn-applicable-specification">other applicable
+                            specifications</a>, passing |format|, |jwk|
+                            and |hash|
+                            and obtaining |hash|.
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not  "`sign`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |length| be the [= length in bits =] of
+                  |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |length| is zero
+                  then [= exception/throw =] a
+                  {{DataError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{HmacImportParams/length}} member of
+                    |normalizedAlgorithm| is present:
+                  </dt>
+                  <dd>
+                    <dl class="switch">
+                      <dt>
+                        If the {{HmacImportParams/length}} member of
+                        |normalizedAlgorithm| is greater than |length|:
+                      </dt>
+                      <dd>
+                        [= exception/throw =] a
+                        {{DataError}}.
+                      </dd>
+                      <dt>
+                        If the {{HmacImportParams/length}} member of
+                        |normalizedAlgorithm|, is less than or equal to
+                        |length| minus eight:
+                      </dt>
+                      <dd>
+                        [= exception/throw =] a
+                        {{DataError}}.
+                      </dd>
+                      <dt>
+                        Otherwise:
+                      </dt>
+                      <dd>
+                        Set |length| equal to the {{HmacImportParams/length}}
+                        member of |normalizedAlgorithm|.
+                      </dd>
+                    </dl>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new {{CryptoKey}}
+                  object representing an HMAC key with the first |length|
+                  bits of |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{HmacKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`HMAC`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{HmacKeyAlgorithm/length}} attribute of
+                  |algorithm| to |length|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{HmacKeyAlgorithm/hash}} attribute of
+                  |algorithm| to |hash|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="hmac-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |bits| be the raw bits of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                  |key|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |data| be a [= byte sequence containing =] |bits|.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to the
+                          string "`oct`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
+                          containing |data|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be the {{CryptoKey/[[algorithm]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |hash| be the
+                          {{HmacKeyAlgorithm/hash}} attribute of
+                          |algorithm|.
+                        </p>
+                      </li>
+
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{KeyAlgorithm/name}} attribute of
+                          |hash| is "`SHA-1`":</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`HS1`".</dd>
+                          <dt>If the {{KeyAlgorithm/name}} attribute of
+                          |hash| is "`SHA-256`":</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`HS256`".</dd>
+                          <dt>If the {{KeyAlgorithm/name}} attribute of
+                          |hash| is "`SHA-384`":</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`HS384`".</dd>
+                          <dt>If the {{KeyAlgorithm/name}} attribute of
+                          |hash| is "`SHA-512`":</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`HS512`".</dd>
+                          <dt>
+                            Otherwise, the {{KeyAlgorithm/name}} attribute
+                            of |hash| is defined in
+                            <a href="#dfn-applicable-specification">another applicable
+                            specification</a>:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= HMAC key export steps | key export steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format| and |key|
+                                  and obtaining |alg|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the `alg` attribute of |jwk| to
+                                  |alg|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to equal the
+                          {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
                       {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |length| be the [= length in bits =] of
-                    |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If |length| is zero
-                    then [= exception/throw =] a
-                    {{DataError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{HmacImportParams/length}} member of
-                      |normalizedAlgorithm| is present:
-                    </dt>
-                    <dd>
-                      <dl class="switch">
-                        <dt>
-                          If the {{HmacImportParams/length}} member of
-                          |normalizedAlgorithm| is greater than |length|:
-                        </dt>
-                        <dd>
-                          [= exception/throw =] a
-                          {{DataError}}.
-                        </dd>
-                        <dt>
-                          If the {{HmacImportParams/length}} member of
-                          |normalizedAlgorithm|, is less than or equal to
-                          |length| minus eight:
-                        </dt>
-                        <dd>
-                          [= exception/throw =] a
-                          {{DataError}}.
-                        </dd>
-                        <dt>
-                          Otherwise:
-                        </dt>
-                        <dd>
-                          Set |length| equal to the {{HmacImportParams/length}}
-                          member of |normalizedAlgorithm|.
-                        </dd>
-                      </dl>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new {{CryptoKey}}
-                    object representing an HMAC key with the first |length|
-                    bits of |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{HmacKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`HMAC`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{HmacKeyAlgorithm/length}} attribute of
-                    |algorithm| to |length|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{HmacKeyAlgorithm/hash}} attribute of
-                    |algorithm| to |hash|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |bits| be the raw bits of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                    |key|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |data| be a [= byte sequence containing =] |bits|.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to the
-                            string "`oct`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
-                            containing |data|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be the {{CryptoKey/[[algorithm]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |hash| be the
-                            {{HmacKeyAlgorithm/hash}} attribute of
-                            |algorithm|.
-                          </p>
-                        </li>
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
 
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{KeyAlgorithm/name}} attribute of
-                            |hash| is "`SHA-1`":</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`HS1`".</dd>
-                            <dt>If the {{KeyAlgorithm/name}} attribute of
-                            |hash| is "`SHA-256`":</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`HS256`".</dd>
-                            <dt>If the {{KeyAlgorithm/name}} attribute of
-                            |hash| is "`SHA-384`":</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`HS384`".</dd>
-                            <dt>If the {{KeyAlgorithm/name}} attribute of
-                            |hash| is "`SHA-512`":</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`HS512`".</dd>
-                            <dt>
-                              Otherwise, the {{KeyAlgorithm/name}} attribute
-                              of |hash| is defined in
-                              <a href="#dfn-applicable-specification">another applicable
-                              specification</a>:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= HMAC key export steps | key export steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format| and |key|
-                                    and obtaining |alg|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the `alg` attribute of |jwk| to
-                                    |alg|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to equal the
-                            {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Get key length</dt>
-            <dd>
-              <ol>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{HmacImportParams/length}} member of
-                      |normalizedDerivedKeyAlgorithm| is not present:
-                    </dt>
-                    <dd>
-                      <p>
-                        Let |length| be the block size in bits of the hash function
-                        identified by the {{HmacImportParams/hash}} member
-                        of |normalizedDerivedKeyAlgorithm|.
-                      </p>
-                    </dd>
-                    <dt>
-                      Otherwise, if the {{HmacImportParams/length}}
-                      member of |normalizedDerivedKeyAlgorithm| is non-zero:
-                    </dt>
-                    <dd>
-                      Let |length| be equal to the
-                      {{HmacImportParams/length}}
-                      member of |normalizedDerivedKeyAlgorithm|.
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      [= exception/throw =] a
-                      {{TypeError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |length|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+          <section id="hmac-operations-get-key-length">
+            <h5>Get key length</h5>
+
+            <ol>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{HmacImportParams/length}} member of
+                    |normalizedDerivedKeyAlgorithm| is not present:
+                  </dt>
+                  <dd>
+                    <p>
+                      Let |length| be the block size in bits of the hash function
+                      identified by the {{HmacImportParams/hash}} member
+                      of |normalizedDerivedKeyAlgorithm|.
+                    </p>
+                  </dd>
+                  <dt>
+                    Otherwise, if the {{HmacImportParams/length}}
+                    member of |normalizedDerivedKeyAlgorithm| is non-zero:
+                  </dt>
+                  <dd>
+                    Let |length| be equal to the
+                    {{HmacImportParams/length}}
+                    member of |normalizedDerivedKeyAlgorithm|.
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{TypeError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |length|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -11211,786 +11211,790 @@ dictionary EcdhKeyDeriveParams : Algorithm {
 
         <section id="x25519-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Derive Bits</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be the
-                    {{EcdhKeyDeriveParams/public}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{KeyAlgorithm/name}} attribute of
-                    the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key|, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |secret| be the result of performing the X25519 function specified in
-                    [[RFC7748]] Section 5 with |key| as the X25519 private key |k|
-                    and the X25519 public key represented by the {{CryptoKey/[[handle]]}}
-                    internal slot of |publicKey| as the X25519 public key |u|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If |secret| is the all-zero value,
-                    then [= exception/throw =] a {{OperationError}}.
-                    This check must be performed in constant-time, as per [[RFC7748]] Section 6.1.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |length| is null:</dt>
-                    <dd>Return |secret|</dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <dl class="switch">
-                        <dt>
-                          If the length of |secret| in bits is less than
-                          |length|:
-                        </dt>
-                        <dd>
-                          [= exception/throw =] an
-                          {{OperationError}}.
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          Return a [= byte sequence containing =] the first |length| bits of |secret|.
-                        </dd>
-                      </dl>
-                    </dd>
-                  </dl>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    "`deriveKey`" or "`deriveBits`"
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Generate an X25519 key pair, with the private key being 32 random bytes,
-                    and the public key being `X25519(a, 9)`,
-                    as defined in [[RFC7748]], section 6.1.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new {{KeyAlgorithm}} object.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`X25519`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be a new {{CryptoKey}}
-                    representing the public key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| to "`public`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |publicKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |publicKey| to true.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |publicKey| to be the empty list.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |privateKey| be a new {{CryptoKey}}
-                    representing the private key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |privateKey| to {{KeyType/"private"}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |privateKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |privateKey| to |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |privateKey| to be the
-                    [= usage intersection =] of
-                    |usages| and `[ "deriveKey", "deriveBits" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a new {{CryptoKeyPair}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/publicKey}} attribute
-                    of |result| to be |publicKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/privateKey}} attribute
-                    of |result| to be |privateKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
 
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| is not empty
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |spki| be the result of running the
-                            [= parse a subjectPublicKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of |spki| is
-                            not equal to the `id-X25519`
-                            object identifier defined in [[RFC8410]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the `algorithm`
-                            AlgorithmIdentifier field of |spki| is present,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |publicKey| be the X25519 public key identified by
-                            the `subjectPublicKey` field of |spki|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents |publicKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{KeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`X25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                            "`deriveKey`" or "`deriveBits`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |privateKeyInfo| be the result of running the
-                            [= parse a privateKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurs while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            |privateKeyInfo| is not equal to the
-                            `id-X25519` object identifier defined in [[RFC8410]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of |privateKeyInfo| is present,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |curvePrivateKey| be the result of performing the
-                            [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the `privateKey` field
-                            of |privateKeyInfo|, |structure| as the ASN.1
-                            `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the X25519 private key identified by |curvePrivateKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to {{KeyType/"private"}}
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{KeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`X25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field is present and if |usages|
-                            contains an entry which is not
-                            "`deriveKey`" or "`deriveBits`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field is not present and if |usages| is not
-                            empty
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                            "`OKP`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/crv}} field of |jwk| is not
-                            "`X25519`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
-                            and is not equal to "`enc`" then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of JSON Web
-                            Key [[JWK]], or it does not contain all of the specified |usages|
-                            values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of
-                                    the JWK private key format described in Section 2
-                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} object that represents the
-                                    X25519 private key identified by interpreting
-                                    |jwk| according to Section 2 of [[RFC8037]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |Key| to {{KeyType/"private"}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of
-                                    the JWK public key format described in Section 2
-                                    of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} object that represents the
-                                    X25519 public key identified by interpreting
-                                    |jwk| according to Section 2 of [[RFC8037]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |Key| to {{KeyType/"public"}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`X25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| is not empty
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{KeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`X25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            representing the key data provided in |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |key|
-                  </p>
-                </li>
-              </ol>
-            </dd>
+          <section id="x25519-operations-derive-bits">
+            <h5>Derive Bits</h5>
 
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |key| be the {{CryptoKey}} to be
-                    exported.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be the
+                  {{EcdhKeyDeriveParams/public}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{KeyAlgorithm/name}} attribute of
+                  the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key|, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |secret| be the result of performing the X25519 function specified in
+                  [[RFC7748]] Section 5 with |key| as the X25519 private key |k|
+                  and the X25519 public key represented by the {{CryptoKey/[[handle]]}}
+                  internal slot of |publicKey| as the X25519 public key |u|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |secret| is the all-zero value,
+                  then [= exception/throw =] a {{OperationError}}.
+                  This check must be performed in constant-time, as per [[RFC7748]] Section 6.1.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |length| is null:</dt>
+                  <dd>Return |secret|</dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <dl class="switch">
+                      <dt>
+                        If the length of |secret| in bits is less than
+                        |length|:
+                      </dt>
+                      <dd>
+                        [= exception/throw =] an
+                        {{OperationError}}.
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        Return a [= byte sequence containing =] the first |length| bits of |secret|.
+                      </dd>
+                    </dl>
+                  </dd>
+                </dl>
+              </li>
+            </ol>
+          </section>
+
+          <section id="x25519-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  "`deriveKey`" or "`deriveBits`"
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Generate an X25519 key pair, with the private key being 32 random bytes,
+                  and the public key being `X25519(a, 9)`,
+                  as defined in [[RFC7748]], section 6.1.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new {{KeyAlgorithm}} object.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`X25519`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be a new {{CryptoKey}}
+                  representing the public key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| to "`public`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |publicKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |publicKey| to true.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |publicKey| to be the empty list.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |privateKey| be a new {{CryptoKey}}
+                  representing the private key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |privateKey| to {{KeyType/"private"}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |privateKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |privateKey| to |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |privateKey| to be the
+                  [= usage intersection =] of
+                  |usages| and `[ "deriveKey", "deriveBits" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a new {{CryptoKeyPair}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/publicKey}} attribute
+                  of |result| to be |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/privateKey}} attribute
+                  of |result| to be |privateKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="x25519-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| is not empty
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |spki| be the result of running the
+                          [= parse a subjectPublicKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `algorithm` AlgorithmIdentifier field of |spki| is
+                          not equal to the `id-X25519`
+                          object identifier defined in [[RFC8410]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the `algorithm`
+                          AlgorithmIdentifier field of |spki| is present,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |publicKey| be the X25519 public key identified by
+                          the `subjectPublicKey` field of |spki|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents |publicKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{KeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`X25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                          "`deriveKey`" or "`deriveBits`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |privateKeyInfo| be the result of running the
+                          [= parse a privateKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurs while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                          |privateKeyInfo| is not equal to the
+                          `id-X25519` object identifier defined in [[RFC8410]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                          of |privateKeyInfo| is present,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |curvePrivateKey| be the result of performing the
+                          [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the `privateKey` field
+                          of |privateKeyInfo|, |structure| as the ASN.1
+                          `CurvePrivateKey` structure specified in Section 7 of [[RFC8410]], and |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the X25519 private key identified by |curvePrivateKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to {{KeyType/"private"}}
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{KeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`X25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field is present and if |usages|
+                          contains an entry which is not
+                          "`deriveKey`" or "`deriveBits`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field is not present and if |usages| is not
+                          empty
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                          "`OKP`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/crv}} field of |jwk| is not
+                          "`X25519`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                          and is not equal to "`enc`" then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of JSON Web
+                          Key [[JWK]], or it does not contain all of the specified |usages|
+                          values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of
+                                  the JWK private key format described in Section 2
+                                  of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} object that represents the
+                                  X25519 private key identified by interpreting
+                                  |jwk| according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |Key| to {{KeyType/"private"}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of
+                                  the JWK public key format described in Section 2
+                                  of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} object that represents the
+                                  X25519 public key identified by interpreting
+                                  |jwk| according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |Key| to {{KeyType/"public"}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new instance of a {{KeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`X25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| is not empty
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{KeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`X25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          representing the key data provided in |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |key|
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="x25519-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |key| be the {{CryptoKey}} to be
+                  exported.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `SubjectPublicKeyInfo`
+                          ASN.1 structure defined in [[RFC5280]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| field to an
+                              `AlgorithmIdentifier` ASN.1 type with the following
+                              properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| object identifier to the
+                                  `id-X25519` OID defined in [[RFC8410]].
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |subjectPublicKey| field to |keyData|.
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `PrivateKeyInfo`
+                          ASN.1 structure defined in [[RFC5208]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |version| field to `0`.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKeyAlgorithm| field to a
+                              `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                              following properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| object identifier to the
+                                  `id-X25519` OID defined in [[RFC8410]].
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKey| field to the result of DER-encoding
+                              a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
+                              X25519 private key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to
+                          "`OKP`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `crv` attribute of |jwk| to
+                          "`X25519`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                          definition in Section 2 of [[RFC8037]].
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
                             If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `SubjectPublicKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| field to an
-                                `AlgorithmIdentifier` ASN.1 type with the following
-                                properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| object identifier to the
-                                    `id-X25519` OID defined in [[RFC8410]].
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |subjectPublicKey| field to |keyData|.
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `PrivateKeyInfo`
-                            ASN.1 structure defined in [[RFC5208]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |version| field to `0`.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKeyAlgorithm| field to a
-                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                                following properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| object identifier to the
-                                    `id-X25519` OID defined in [[RFC8410]].
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKey| field to the result of DER-encoding
-                                a `CurvePrivateKey` ASN.1 type, as defined in Section 7 of [[RFC8410]], that represents the
-                                X25519 private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to
-                            "`OKP`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `crv` attribute of |jwk| to
-                            "`X25519`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                            of |key| is {{KeyType/"private"}}
+                          </dt>
+                          <dd>
+                            Set the {{JsonWebKey/d}} attribute of |jwk| according to the
                             definition in Section 2 of [[RFC8037]].
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{CryptoKey/[[type]]}} internal slot
-                              of |key| is {{KeyType/"private"}}
-                            </dt>
-                            <dd>
-                              Set the {{JsonWebKey/d}} attribute of |jwk| according to the
-                              definition in Section 2 of [[RFC8037]].
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>
-                      If |format| is {{KeyFormat/"raw"}}:
-                    </dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be a [= byte sequence =] representing the X25519
-                            public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>
+                    If |format| is {{KeyFormat/"raw"}}:
+                  </dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be a [= byte sequence =] representing the X25519
+                          public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -4972,945 +4972,949 @@ dictionary RsaPssParams : Algorithm {
         </section>
         <section id="rsa-pss-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Sign</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Perform the signature generation operation defined in Section 8.1 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    as the signer's private key, |K|, and |message| as
-                    the message to be signed, |M|, and using the hash function specified
-                    by the {{RsaHashedKeyAlgorithm/hash}} attribute of the
-                    {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
-                    |normalizedAlgorithm| as the salt length option for the
-                    EMSA-PSS-ENCODE operation.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |signature| be the
-                    signature, S, that results from performing the operation.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |signature|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
 
-            <dt>Verify</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Perform the signature verification operation defined in Section 8.1 of
-                    [[RFC3447]] with the key represented by the
-                    {{CryptoKey/[[handle]]}} internal slot of
-                    |key| as the signer's RSA public key and |message| as
-                    |M| and
-                    |signature| as |S| and using the hash function specified
-                    by the {{RsaHashedKeyAlgorithm/hash}} attribute of the
-                    {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
-                    |normalizedAlgorithm| as the salt length option for the
-                    EMSA-PSS-VERIFY operation.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a boolean with the value true if the
-                    result of the operation was "valid signature" and the value
-                    false otherwise.
-                  </p>
-                </li>
-              </ol>
-            </dd>
+          <section id="rsa-pss-operations-sign">
+            <h5>Sign</h5>
 
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    "`sign`" or "`verify`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
-                    {{RsaKeyGenParams/modulusLength}} member of
-                    |normalizedAlgorithm| and RSA public exponent equal to the
-                    {{RsaKeyGenParams/publicExponent}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{RsaHashedKeyAlgorithm}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`RSA-PSS`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the
-                    {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of |algorithm| to equal the
-                    {{RsaKeyGenParams/modulusLength}}
-                    member of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the
-                    {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of |algorithm| to equal the
-                    {{RsaKeyGenParams/publicExponent}}
-                    member of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaHashedKeyAlgorithm/hash}} attribute
-                    of |algorithm| to equal the
-                    {{RsaHashedKeyGenParams/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be a new {{CryptoKey}}
-                    representing the public key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| to "`public`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |publicKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |publicKey| to true.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |publicKey| to be the [= usage
-                    intersection =] of |usages| and `[ "verify" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |privateKey| be a new {{CryptoKey}}
-                    representing the private key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |privateKey| to {{KeyType/"private"}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |privateKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |privateKey| to |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |privateKey| to be the [= usage
-                    intersection =] of |usages| and `[ "sign" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a new {{CryptoKeyPair}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/publicKey}} attribute
-                    of |result| to |publicKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/privateKey}} attribute
-                    of |result| to |privateKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the signature generation operation defined in Section 8.1 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  as the signer's private key, |K|, and |message| as
+                  the message to be signed, |M|, and using the hash function specified
+                  by the {{RsaHashedKeyAlgorithm/hash}} attribute of the
+                  {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
+                  |normalizedAlgorithm| as the salt length option for the
+                  EMSA-PSS-ENCODE operation.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |signature| be the
+                  signature, S, that results from performing the operation.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |signature|.
+                </p>
+              </li>
+            </ol>
+          </section>
 
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |spki| be the result of running the
-                            [= parse a subjectPublicKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of |spki| is
-                            not equal to the `rsaEncryption`
-                            object identifier defined in [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the
-                            `subjectPublicKeyInfo` field of |spki|,
-                            |structure| as the `RSAPublicKey` structure
-                            specified in Section A.1.1 of [[RFC3447]], and
-                            |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, or it can be determined that |publicKey|
-                            is not a valid public key according to [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the RSA public key identified by
-                            |publicKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                            "`sign`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |privateKeyInfo| be the result of running the
-                            [= parse a privateKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, then [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            |privateKeyInfo| is not equal to the
-                            `rsaEncryption` object identifier defined in [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the
-                            `privateKey` field of |privateKeyInfo|,
-                            |structure| as the `RSAPrivateKey` structure
-                            specified in Section A.1.2 of [[RFC3447]], and
-                            |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, or if |rsaPrivateKey| is not
-                            a valid RSA private key according to [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the RSA private key identified by
-                            |rsaPrivateKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to {{KeyType/"private"}}
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field of |jwk| is present and
-                            |usages| contains an entry which is not
-                            "`sign`", or, if the {{JsonWebKey/d}} field of |jwk|
-                            is not present and
-                            |usages| contains an entry which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not a
-                            case-sensitive string match to "`RSA`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not a case-sensitive string match to "`sig`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{JsonWebKey/alg}} field of |jwk| is not
-                              present:
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be undefined.
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`PS1`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-1`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`PS256`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-256`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`PS384`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-384`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`PS512`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-512`".
-                              </p>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= RSA-PSS key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |jwk|
-                                    and obtaining |hash|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl>
-                            <dt>
-                              If |hash| is not undefined:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |normalizedHash| be the result of
-                                    <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to |hash| and `op` set
-                                    to `digest`.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |normalizedHash| is not equal to the
-                                    {{RsaHashedImportParams/hash}} member of
-                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of
-                                    Section 6.3.2 of JSON Web Algorithms [[JWA]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |privateKey| represent the
-                                    RSA private key identified by interpreting |jwk|
-                                    according to Section 6.3.2 of JSON Web
-                                    Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |privateKey| can be determined to not be a valid RSA private key
-                                    according to [[RFC3447]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} representing |privateKey|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |key| to {{KeyType/"private"}}
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of Section
-                                    6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |publicKey| represent the
-                                    RSA public key identified by interpreting |jwk|
-                                    according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |publicKey| can be determined to not be a valid RSA public key
-                                    according to [[RFC3447]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} representing |publicKey|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |key| to "`public`"
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+          <section id="rsa-pss-operations-verify">
+            <h5>Verify</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the signature verification operation defined in Section 8.1 of
+                  [[RFC3447]] with the key represented by the
+                  {{CryptoKey/[[handle]]}} internal slot of
+                  |key| as the signer's RSA public key and |message| as
+                  |M| and
+                  |signature| as |S| and using the hash function specified
+                  by the {{RsaHashedKeyAlgorithm/hash}} attribute of the
+                  {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| as the Hash option, MGF1 (defined in Section B.2.1 of [[RFC3447]]) as the MGF option and the <a href="#dfn-RsaPssParams-saltLength">saltLength</a> member of
+                  |normalizedAlgorithm| as the salt length option for the
+                  EMSA-PSS-VERIFY operation.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a boolean with the value true if the
+                  result of the operation was "valid signature" and the value
+                  false otherwise.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsa-pss-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  "`sign`" or "`verify`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
+                  {{RsaKeyGenParams/modulusLength}} member of
+                  |normalizedAlgorithm| and RSA public exponent equal to the
+                  {{RsaKeyGenParams/publicExponent}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{RsaHashedKeyAlgorithm}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`RSA-PSS`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the
+                  {{RsaKeyAlgorithm/modulusLength}}
+                  attribute of |algorithm| to equal the
+                  {{RsaKeyGenParams/modulusLength}}
+                  member of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the
+                  {{RsaKeyAlgorithm/publicExponent}}
+                  attribute of |algorithm| to equal the
+                  {{RsaKeyGenParams/publicExponent}}
+                  member of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaHashedKeyAlgorithm/hash}} attribute
+                  of |algorithm| to equal the
+                  {{RsaHashedKeyGenParams/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be a new {{CryptoKey}}
+                  representing the public key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| to "`public`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |publicKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |publicKey| to true.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |publicKey| to be the [= usage
+                  intersection =] of |usages| and `[ "verify" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |privateKey| be a new {{CryptoKey}}
+                  representing the private key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |privateKey| to {{KeyType/"private"}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |privateKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |privateKey| to |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |privateKey| to be the [= usage
+                  intersection =] of |usages| and `[ "sign" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a new {{CryptoKeyPair}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/publicKey}} attribute
+                  of |result| to |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/privateKey}} attribute
+                  of |result| to |privateKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsa-pss-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |spki| be the result of running the
+                          [= parse a subjectPublicKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `algorithm` AlgorithmIdentifier field of |spki| is
+                          not equal to the `rsaEncryption`
+                          object identifier defined in [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the
+                          `subjectPublicKeyInfo` field of |spki|,
+                          |structure| as the `RSAPublicKey` structure
+                          specified in Section A.1.1 of [[RFC3447]], and
+                          |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, or it can be determined that |publicKey|
+                          is not a valid public key according to [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the RSA public key identified by
+                          |publicKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                          "`sign`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |privateKeyInfo| be the result of running the
+                          [= parse a privateKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, then [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                          |privateKeyInfo| is not equal to the
+                          `rsaEncryption` object identifier defined in [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the
+                          `privateKey` field of |privateKeyInfo|,
+                          |structure| as the `RSAPrivateKey` structure
+                          specified in Section A.1.2 of [[RFC3447]], and
+                          |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, or if |rsaPrivateKey| is not
+                          a valid RSA private key according to [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the RSA private key identified by
+                          |rsaPrivateKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to {{KeyType/"private"}}
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field of |jwk| is present and
+                          |usages| contains an entry which is not
+                          "`sign`", or, if the {{JsonWebKey/d}} field of |jwk|
+                          is not present and
+                          |usages| contains an entry which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not a
+                          case-sensitive string match to "`RSA`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not a case-sensitive string match to "`sig`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{JsonWebKey/alg}} field of |jwk| is not
+                            present:
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be undefined.
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`PS1`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-1`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`PS256`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-256`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`PS384`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-384`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`PS512`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-512`".
+                            </p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= RSA-PSS key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |jwk|
+                                  and obtaining |hash|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl>
+                          <dt>
+                            If |hash| is not undefined:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |normalizedHash| be the result of
+                                  <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
+                                  with `alg` set to |hash| and `op` set
+                                  to `digest`.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |normalizedHash| is not equal to the
+                                  {{RsaHashedImportParams/hash}} member of
+                                  |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of
+                                  Section 6.3.2 of JSON Web Algorithms [[JWA]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |privateKey| represent the
+                                  RSA private key identified by interpreting |jwk|
+                                  according to Section 6.3.2 of JSON Web
+                                  Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |privateKey| can be determined to not be a valid RSA private key
+                                  according to [[RFC3447]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} representing |privateKey|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |key| to {{KeyType/"private"}}
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of Section
+                                  6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |publicKey| represent the
+                                  RSA public key identified by interpreting |jwk|
+                                  according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |publicKey| can be determined to not be a valid RSA public key
+                                  according to [[RFC3447]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} representing |publicKey|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |key| to "`public`"
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{RsaHashedKeyAlgorithm}} dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`RSA-PSS`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaKeyAlgorithm/modulusLength}}
+                  attribute of |algorithm| to the length, in bits, of the RSA public
+                  modulus.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaKeyAlgorithm/publicExponent}}
+                  attribute of |algorithm| to the {{BigInteger}}
+                  representation of the RSA public exponent.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
+                  |algorithm| to the {{RsaHashedImportParams/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|
+                </p>
+              </li>
+              <li>
+                <p>Return |key|.</p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsa-pss-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |key| be the key to be exported.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `SubjectPublicKeyInfo`
+                          ASN.1 structure defined in [[RFC5280]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| field to an
+                              `AlgorithmIdentifier` ASN.1 type with the following
+                              properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `rsaEncryption` defined in
+                                  [[RFC3447]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |params| field to the ASN.1 type NULL.
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |subjectPublicKey| field to the result of
+                              DER-encoding an `RSAPublicKey` ASN.1 type, as defined
+                              in [[RFC3447]], Appendix A.1.1, that
+                              represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `PrivateKeyInfo`
+                          ASN.1 structure defined in [[RFC5208]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |version| field to `0`.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKeyAlgorithm| field to a
+                              `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                              following properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `rsaEncryption` defined in
+                                  [[RFC3447]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |params| field to the ASN.1 type NULL.
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKey| field to the result of DER-encoding
+                              an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
+                              RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                            <div class=note>
+                              [[RFC5208]] specifies that the encoding of
+                              this field should be <em>BER</em> encoded in Section 5 (as a "for
+                              example"). However, to avoid requiring WebCrypto implementations
+                              support BER-encoding and BER-decoding, only <em>DER</em> encodings
+                              are produced or accepted.
+                            </div>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>Let |jwk| be a new {{JsonWebKey}} dictionary.</p>
+                      </li>
+                      <li>
+                        <p>Set the `kty` attribute of |jwk| to the string
+                        "`RSA`".</p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |hash| be the {{KeyAlgorithm/name}}
+                          attribute of the {{RsaHashedKeyAlgorithm/hash}}
+                          attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |hash| is "`SHA-1`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`PS1`".
+                            </p>
+                          </dd>
+                          <dt>If |hash| is "`SHA-256`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`PS256`".
+                            </p>
+                          </dd>
+                          <dt>If |hash| is "`SHA-384`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`PS384`".
+                            </p>
+                          </dd>
+                          <dt>If |hash| is "`SHA-512`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`PS512`".
+                            </p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= RSA-PSS key export steps | key export steps =]
+                                  defined by <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format| and the
+                                  {{RsaHashedKeyAlgorithm/hash}} attribute of
+                                  the {{CryptoKey/[[algorithm]]}}
+                                  internal slot of |key|
+                                  and obtaining |alg|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the `alg` attribute of |jwk| to |alg|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
+                          according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{CryptoKey/[[type]]}} internal slot of
+                            |key| is {{KeyType/"private"}}:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
+                                  {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
+                                  {{JsonWebKey/qi}} of |jwk| according to the
+                                  corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
+                                  of |key| is represented by more than two primes, set
+                                  the attribute named {{JsonWebKey/oth}} of |jwk|
+                                  according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
                       {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{RsaHashedKeyAlgorithm}} dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`RSA-PSS`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of |algorithm| to the length, in bits, of the RSA public
-                    modulus.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of |algorithm| to the {{BigInteger}}
-                    representation of the RSA public exponent.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
-                    |algorithm| to the {{RsaHashedImportParams/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|
-                  </p>
-                </li>
-                <li>
-                  <p>Return |key|.</p>
-                </li>
-              </ol>
-            </dd>
-
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |key| be the key to be exported.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `SubjectPublicKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| field to an
-                                `AlgorithmIdentifier` ASN.1 type with the following
-                                properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `rsaEncryption` defined in
-                                    [[RFC3447]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |params| field to the ASN.1 type NULL.
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |subjectPublicKey| field to the result of
-                                DER-encoding an `RSAPublicKey` ASN.1 type, as defined
-                                in [[RFC3447]], Appendix A.1.1, that
-                                represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `PrivateKeyInfo`
-                            ASN.1 structure defined in [[RFC5208]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |version| field to `0`.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKeyAlgorithm| field to a
-                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                                following properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `rsaEncryption` defined in
-                                    [[RFC3447]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |params| field to the ASN.1 type NULL.
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKey| field to the result of DER-encoding
-                                an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
-                                RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                              <div class=note>
-                                [[RFC5208]] specifies that the encoding of
-                                this field should be <em>BER</em> encoded in Section 5 (as a "for
-                                example"). However, to avoid requiring WebCrypto implementations
-                                support BER-encoding and BER-decoding, only <em>DER</em> encodings
-                                are produced or accepted.
-                              </div>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>Let |jwk| be a new {{JsonWebKey}} dictionary.</p>
-                        </li>
-                        <li>
-                          <p>Set the `kty` attribute of |jwk| to the string
-                          "`RSA`".</p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |hash| be the {{KeyAlgorithm/name}}
-                            attribute of the {{RsaHashedKeyAlgorithm/hash}}
-                            attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |hash| is "`SHA-1`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`PS1`".
-                              </p>
-                            </dd>
-                            <dt>If |hash| is "`SHA-256`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`PS256`".
-                              </p>
-                            </dd>
-                            <dt>If |hash| is "`SHA-384`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`PS384`".
-                              </p>
-                            </dd>
-                            <dt>If |hash| is "`SHA-512`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`PS512`".
-                              </p>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= RSA-PSS key export steps | key export steps =]
-                                    defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format| and the
-                                    {{RsaHashedKeyAlgorithm/hash}} attribute of
-                                    the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of |key|
-                                    and obtaining |alg|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the `alg` attribute of |jwk| to |alg|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
-                            according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{CryptoKey/[[type]]}} internal slot of
-                              |key| is {{KeyType/"private"}}:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
-                                    {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
-                                    {{JsonWebKey/qi}} of |jwk| according to the
-                                    corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                    of |key| is represented by more than two primes, set
-                                    the attribute named {{JsonWebKey/oth}} of |jwk|
-                                    according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -7089,1628 +7089,1631 @@ dictionary EcKeyImportParams : Algorithm {
 
         <section id="ecdsa-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Sign</dt>
-            <dd>
-              When signing, the following algorithm should be used:
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |hashAlgorithm| be the {{EcdsaParams/hash}}
-                    member of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |M| be the result of performing the digest operation specified by
-                    |hashAlgorithm| using |message|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |d| be the ECDSA private key associated with |key|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |params| be the EC domain parameters associated with
-                    |key|.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{EcKeyAlgorithm/namedCurve}} attribute of the
-                      {{CryptoKey/[[algorithm]]}} internal slot of
-                      |key| is "`P-256`", "`P-384`" or "`P-521`":
-                    </dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Perform the ECDSA signing process, as specified in [[RFC6090]],
-                            Section 5.4, with |M| as the message, using |params| as the
-                            EC domain parameters, and with |d| as the private key.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                          Let |r| and |s| be the pair of integers resulting from
-                          performing the ECDSA signing process.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be an empty [= byte sequence =].
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |n| be the smallest integer such that |n| * 8 is greater than
-                            the logarithm to base 2 of the order of the base point of the elliptic curve identified
-                            by |params|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            <a href="#dfn-convert-integer-to-byte-sequence">Convert |r| to a byte sequence of
-                            length |n|</a> and append it to |result|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            <a href="#dfn-convert-integer-to-byte-sequence">Convert |s| to a byte sequence of
-                            length |n|</a> and append it to |result|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>
-                      Otherwise, the {{EcKeyAlgorithm/namedCurve}} attribute
-                      of the {{CryptoKey/[[algorithm]]}} internal slot of
-                      |key| is a value specified in an
-                      <a href="#dfn-applicable-specification">applicable specification</a>:
-                    </dt>
-                    <dd>
-                      <p>
-                        Perform the [= ECDSA signature steps =]
-                        specified in that specification, passing in |M|, |params|
-                        and |d| and resulting in |result|.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Verify</dt>
-            <dd>
-              When verifying, the following algorithm should be used:
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |hashAlgorithm| be the {{EcdsaParams/hash}}
-                    member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |M| be the result of performing the digest operation specified by
-                    |hashAlgorithm| using |message|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |Q| be the ECDSA public key associated with |key|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |params| be the EC domain parameters associated with
-                    |key|.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{EcKeyAlgorithm/namedCurve}} attribute of the
-                      {{CryptoKey/[[algorithm]]}} internal slot of
-                      |key| is "`P-256`", "`P-384`" or "`P-521`":
-                    </dt>
-                    <dd>
-                      <p>
-                        Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.3, with |M| as the received
-                        message, |signature| as the received signature and using
-                        |params| as the EC domain parameters, and
-                        |Q| as the public key.
-                      </p>
-                    </dd>
-                    <dt>
-                      Otherwise, the {{EcKeyAlgorithm/namedCurve}} attribute
-                      of the {{CryptoKey/[[algorithm]]}} internal slot of
-                      |key| is a value specified in an
-                      <a href="#dfn-applicable-specification">applicable specification</a>:
-                    </dt>
-                    <dd>
-                      <p>
-                        Perform the [= ECDSA verification steps =]
-                        specified in that specification passing in |M|, |signature|,
-                        |params| and |Q| and resulting in an indication of whether
-                        or not the purported signature is valid.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a boolean with the value `true` if the signature is valid
-                    and the value `false` otherwise.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains a value which is not
-                    one of "`sign`" or "`verify`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{EcKeyGenParams/namedCurve}} member of
-                      |normalizedAlgorithm| is "`P-256`", "`P-384`"
-                      or "`P-521`":
-                    </dt>
-                    <dd>
-                      <p>
-                        Generate an Elliptic Curve key pair, as defined in [[RFC6090]]
-                        with domain parameters for the curve identified by
-                        the {{EcKeyGenParams/namedCurve}} member of
-                        |normalizedAlgorithm|.
-                      </p>
-                    </dd>
-                    <dt>
-                      If the {{EcKeyGenParams/namedCurve}} member of
-                      |normalizedAlgorithm| is a value specified in an
-                      <a href="#dfn-applicable-specification">applicable specification</a>:
-                    </dt>
-                    <dd>
-                      <p>
-                        Perform the [=ECDSA
-                        generation steps =] specified in that specification, passing in
-                        |normalizedAlgorithm| and resulting in an elliptic curve key pair.
-                      </p>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    If performing the key generation operation results in an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{EcKeyAlgorithm}}
-                    object.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`ECDSA`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{EcKeyAlgorithm/namedCurve}}
-                    attribute of |algorithm| to equal the
-                    {{namedCurve}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be a new {{CryptoKey}}
-                    representing the public key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| to "`public`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |publicKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |publicKey| to true.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |publicKey| to be the [= usage
-                    intersection =] of |usages| and `[ "verify" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |privateKey| be a new {{CryptoKey}}
-                    representing the private key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |privateKey| to {{KeyType/"private"}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |privateKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |privateKey| to |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |privateKey| to be the [= usage
-                    intersection =] of |usages| and `[ "sign" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a new {{CryptoKeyPair}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/publicKey}} attribute
-                    of |result| to be |publicKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/privateKey}} attribute
-                    of |result| to be |privateKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
 
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains a value which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |spki| be the result of running the
-                            [= parse a subjectPublicKeyInfo =]
-                            algorithm over |keyData|
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of |spki| is
-                            not equal to the `id-ecPublicKey`
-                            object identifier defined in [[RFC5480]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the `algorithm`
-                            AlgorithmIdentifier field of |spki| is absent,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |params| be the `parameters` field of the
-                            `algorithm` AlgorithmIdentifier field of |spki|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |params| is not an instance of the
-                            `ECParameters` ASN.1 type defined in
-                            [[RFC5480]] that specifies a
-                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |namedCurve| be a string whose initial value is
-                            undefined.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |params| is equivalent to the `secp256r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-256`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp384r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-384`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp521r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-521`".
-                              </p>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |namedCurve| is not undefined:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |publicKey| be the Elliptic Curve public key identified by
-                                    performing the conversion steps defined in Section 2.3.4 of [[SEC1]] using the `subjectPublicKey`
-                                    field of |spki|.
-                                  </p>
-                                  <p>
-                                    The uncompressed point format MUST be supported.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the implementation does not support the compressed point format and
-                                    a compressed point is provided,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If a decode error occurs or an identity point is found,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}}
-                                    that represents |publicKey|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDSA key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |spki|
-                                    and obtaining |namedCurve| and |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the public key value is not a valid point on the Elliptic Curve
-                            identified by the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDSA`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to |namedCurve|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains a value which is not
-                            "`sign`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |privateKeyInfo| be the result of running the
-                            [= parse a privateKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurs while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            |privateKeyInfo| is not equal to the
-                            `id-ecPublicKey` object identifier defined in [[RFC5480]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of |privateKeyInfo| is not present,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |params| be the `parameters` field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of |privateKeyInfo|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |params| is not an instance of the
-                            `ECParameters` ASN.1 type defined in
-                            [[RFC5480]] that specifies a
-                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |namedCurve| be a string whose initial value is
-                            undefined.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |params| is equivalent to the `secp256r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-256`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp384r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-384`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp521r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-521`".
-                              </p>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |namedCurve| is not undefined:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |ecPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
-                                    algorithm, with |data| as the `privateKey` field
-                                    of |privateKeyInfo|, |structure| as the ASN.1
-                                    `ECPrivateKey` structure specified in Section 3 of [[RFC5915]], and |exactData| set to true.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred while parsing,
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the `parameters` field of |ecPrivateKey| is
-                                    present, and is not an instance of the `namedCurve` ASN.1
-                                    type defined in [[RFC5480]], or does not contain
-                                    the same object identifier as the `parameters` field of the
-                                    `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                                    of |privateKeyInfo|,
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}}
-                                    that represents the Elliptic Curve private key identified by
-                                    performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDSA key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |privateKeyInfo|
-                                    and obtaining |namedCurve| and |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the private key value is not a valid point on the Elliptic Curve
-                            identified by the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to {{KeyType/"private"}}
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDSA`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to |namedCurve|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field is present and |usages| contains
-                            a value which is not
-                            "`sign`", or,
-                            if the {{JsonWebKey/d}} field is not present and |usages| contains
-                            a value which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                            "`EC`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not  "`sig`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of JSON Web
-                            Key [[JWK]], or it does not contain all of the specified |usages|
-                            values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |namedCurve| be a string whose value is equal to the
-                            {{JsonWebKey/crv}} field of |jwk|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |namedCurve| is not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |namedCurve| is equal to "`P-256`",
-                              "`P-384`" or "`P-521`":
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |algNamedCurve| be a string whose initial value is
-                                    undefined.
-                                  </p>
-                                </li>
-                                <li>
-                                  <dl class="switch">
-                                    <dt>If the {{JsonWebKey/alg}} field is not present:</dt>
-                                    <dd>
-                                      Let |algNamedCurve| be undefined.
-                                    </dd>
-                                    <dt>
-                                      If the {{JsonWebKey/alg}} field is equal to the string "ES256":
-                                    </dt>
-                                    <dd>
-                                      Let |algNamedCurve| be the string "`P-256`".
-                                    </dd>
-                                    <dt>
-                                      If the {{JsonWebKey/alg}} field is equal to the string "ES384":
-                                    </dt>
-                                    <dd>
-                                      Let |algNamedCurve| be the string "`P-384`".
-                                    </dd>
-                                    <dt>
-                                      If the {{JsonWebKey/alg}} field is equal to the string "ES512":
-                                    </dt>
-                                    <dd>
-                                      Let |algNamedCurve| be the string "`P-521`".
-                                    </dd>
-                                    <dt>otherwise:</dt>
-                                    <dd>
-                                      [= exception/throw =] a
-                                      {{DataError}}.
-                                    </dd>
-                                  </dl>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |algNamedCurve| is defined, and is not equal to
-                                    |namedCurve|, [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <dl class="switch">
-                                    <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                                    <dd>
-                                      <ol>
-                                        <li>
-                                          <p>
-                                            If |jwk| does not meet the requirements of Section
-                                            6.2.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Let |key| be a new {{CryptoKey}} object that represents the
-                                            Elliptic Curve private key identified by interpreting
-                                            |jwk| according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Set the {{CryptoKey/[[type]]}}
-                                            internal slot of |Key| to {{KeyType/"private"}}.
-                                          </p>
-                                        </li>
-                                      </ol>
-                                    </dd>
-                                    <dt>Otherwise:</dt>
-                                    <dd>
-                                      <ol>
-                                        <li>
-                                          <p>
-                                            If |jwk| does not meet the requirements of Section
-                                            6.2.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Let |key| be a new {{CryptoKey}} object that represents the
-                                            Elliptic Curve public key identified by interpreting
-                                            |jwk| according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Set the {{CryptoKey/[[type]]}}
-                                            internal slot of |Key| to "`public`".
-                                          </p>
-                                        </li>
-                                      </ol>
-                                    </dd>
-                                  </dl>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>
-                              Otherwise:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDSA key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |jwk|
-                                    and obtaining |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the key value is not a valid point on the Elliptic Curve
-                            identified by the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new instance of an {{EcKeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDSA`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to |namedCurve|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{EcKeyImportParams/namedCurve}}
-                            member of |normalizedAlgorithm| is not a
-                            <a href="#dfn-NamedCurve">named curve</a>,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| contains a value which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |namedCurve| is "`P-256`",
-                              "`P-384`" or "`P-521`":
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |Q| be the elliptic curve point on the curve identified
-                                    by the {{EcKeyImportParams/namedCurve}}
-                                    member of |normalizedAlgorithm| identified by performing
-                                    the conversion steps defined in Section 2.3.4 of [[SEC1]] on |keyData|.
-                                  </p>
-                                  <p>
-                                    The uncompressed point format MUST be supported.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the implementation does not support the compressed point format and
-                                    a compressed point is provided,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If a decode error occurs or an identity point is found,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}}
-                                    that represents |Q|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDH key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |keyData|
-                                    and obtaining |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{EcKeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDSA`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to equal the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |key|
-                  </p>
-                </li>
-              </ol>
-            </dd>
+          <section id="ecdsa-operations-sign">
+            <h5>Sign</h5>
 
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |key| be the {{CryptoKey}} to be
-                    exported.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `SubjectPublicKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| field to an
-                                `AlgorithmIdentifier` ASN.1 type with the following
-                                properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `id-ecPublicKey` defined in
-                                    [[RFC5480]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |parameters| field to an instance of the
-                                    `ECParameters` ASN.1 type defined in
-                                    [[RFC5480]] as follows:
-                                  </p>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of |key| is "`P-256`",
-                                      "`P-384`" or "`P-521`":
-                                    </dt>
-                                    <dd>
-                                      <p>
-                                        Let |keyData| be the
-                                        [= byte sequence =] that
-                                        represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        |key| according to the encoding rules specified in
-                                        Section 2.2 of [[RFC5480]] and using the
-                                        uncompressed form. and |keyData|.
-                                      </p>
-                                      <dl class="switch">
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-256`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier
-                                            `secp256r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-384`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier
-                                            `secp384r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-521`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier
-                                            `secp521r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                      </dl>
-                                    </dd>
-                                    <dt>
-                                      Otherwise:
-                                    </dt>
-                                    <dd>
-                                      <ol>
-                                        <li>
-                                          <p>
-                                            Perform any [= ECDSA key export steps | key export steps =]
-                                            defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing |format| and the
-                                            {{EcKeyAlgorithm/namedCurve}} attribute of
-                                            the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of |key|
-                                            and obtaining |namedCurveOid| and |keyData|.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier |namedCurveOid|.
-                                          </p>
-                                        </li>
-                                      </ol>
-                                    </dd>
-                                  </dl>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |subjectPublicKey| field to |keyData|.
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `PrivateKeyInfo`
-                            ASN.1 structure defined in [[RFC5208]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |version| field to `0`.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKeyAlgorithm| field to a
-                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                                following properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `id-ecPublicKey` defined in
-                                    [[RFC5480]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |parameters| field to an instance of the
-                                    `ECParameters` ASN.1 type defined in
-                                    [[RFC5480]] as follows:
-                                  </p>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of |key| is "`P-256`",
-                                      "`P-384`" or "`P-521`":
-                                    </dt>
-                                    <dd>
-                                      <p>
-                                        Let |keyData| be the result of DER-encoding
-                                        an instance of the `ECPrivateKey` structure defined in
-                                        Section 3 of [[RFC5915]] for the Elliptic
-                                        Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        |key| and that conforms to the following:
-                                      </p>
-                                      <ul>
-                                        <li>
-                                          <p>
-                                            The |parameters| field is present, and is equivalent
-                                            to the |parameters| field of the
-                                            |privateKeyAlgorithm| field of this
-                                            `PrivateKeyInfo` ASN.1 structure.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            The |publicKey| field is present and represents the
-                                            Elliptic Curve public key associated with the Elliptic Curve
-                                            private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                            of |key|.
-                                          </p>
-                                        </li>
-                                      </ul>
-                                      <dl class="switch">
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-256`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier
-                                            `secp256r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-384`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier
-                                            `secp384r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-521`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier
-                                            `secp521r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                      </dl>
-                                    </dd>
-                                    <dt>
-                                      Otherwise:
-                                    </dt>
-                                    <dd>
-                                      <ol>
-                                        <li>
-                                          <p>
-                                            Perform any [= ECDSA key export steps | key export steps =]
-                                            defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing |format| and the
-                                            {{EcKeyAlgorithm/namedCurve}} attribute of
-                                            the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of |key|
-                                            and obtaining |namedCurveOid| and |keyData|.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier |namedCurveOid|.
-                                          </p>
-                                        </li>
-                                      </ol>
-                                    </dd>
-                                  </dl>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKey| field to |keyData|.
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to
-                            "`EC`".
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{EcKeyAlgorithm/namedCurve}}
-                              attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of |key| is "`P-256`", "`P-384`" or
-                              "`P-521`":
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of |key| is "`P-256`":
-                                    </dt>
-                                    <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                      "`P-256`"
-                                    </dd>
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of |key| is "`P-384`":
-                                    </dt>
-                                    <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                      "`P-384`"
-                                    </dd>
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of |key| is "`P-521`":
-                                    </dt>
-                                    <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                      "`P-521`"
-                                    </dd>
-                                  </dl>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{JsonWebKey/x}} attribute of |jwk| according to the
-                                    definition in Section 6.2.1.2 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{JsonWebKey/y}} attribute of |jwk| according to the
-                                    definition in Section 6.2.1.3 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{CryptoKey/[[type]]}} internal slot
-                                      of |key| is {{KeyType/"private"}}
-                                    </dt>
-                                    <dd>
-                                      <p>
-                                        Set the {{JsonWebKey/d}} attribute of |jwk| according to
-                                        the definition in Section 6.2.2.1 of JSON Web Algorithms [[JWA]].
-                                      </p>
-                                    </dd>
-                                  </dl>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>
-                              Otherwise:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDSA key export steps | key export steps =]
-                                    defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format| and the
-                                    {{EcKeyAlgorithm/namedCurve}} attribute of
-                                    the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of |key|
-                                    and obtaining |namedCurve| and a new value of |jwk|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |hashAlgorithm| be the {{EcdsaParams/hash}}
+                  member of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |M| be the result of performing the digest operation specified by
+                  |hashAlgorithm| using |message|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |d| be the ECDSA private key associated with |key|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |params| be the EC domain parameters associated with
+                  |key|.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{EcKeyAlgorithm/namedCurve}} attribute of the
+                    {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key| is "`P-256`", "`P-384`" or "`P-521`":
+                  </dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Perform the ECDSA signing process, as specified in [[RFC6090]],
+                          Section 5.4, with |M| as the message, using |params| as the
+                          EC domain parameters, and with |d| as the private key.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                        Let |r| and |s| be the pair of integers resulting from
+                        performing the ECDSA signing process.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be an empty [= byte sequence =].
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |n| be the smallest integer such that |n| * 8 is greater than
+                          the logarithm to base 2 of the order of the base point of the elliptic curve identified
+                          by |params|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          <a href="#dfn-convert-integer-to-byte-sequence">Convert |r| to a byte sequence of
+                          length |n|</a> and append it to |result|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          <a href="#dfn-convert-integer-to-byte-sequence">Convert |s| to a byte sequence of
+                          length |n|</a> and append it to |result|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>
+                    Otherwise, the {{EcKeyAlgorithm/namedCurve}} attribute
+                    of the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key| is a value specified in an
+                    <a href="#dfn-applicable-specification">applicable specification</a>:
+                  </dt>
+                  <dd>
+                    <p>
+                      Perform the [= ECDSA signature steps =]
+                      specified in that specification, passing in |M|, |params|
+                      and |d| and resulting in |result|.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ecdsa-operations-verify">
+            <h5>Verify</h5>
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |hashAlgorithm| be the {{EcdsaParams/hash}}
+                  member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |M| be the result of performing the digest operation specified by
+                  |hashAlgorithm| using |message|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |Q| be the ECDSA public key associated with |key|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |params| be the EC domain parameters associated with
+                  |key|.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{EcKeyAlgorithm/namedCurve}} attribute of the
+                    {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key| is "`P-256`", "`P-384`" or "`P-521`":
+                  </dt>
+                  <dd>
+                    <p>
+                      Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.3, with |M| as the received
+                      message, |signature| as the received signature and using
+                      |params| as the EC domain parameters, and
+                      |Q| as the public key.
+                    </p>
+                  </dd>
+                  <dt>
+                    Otherwise, the {{EcKeyAlgorithm/namedCurve}} attribute
+                    of the {{CryptoKey/[[algorithm]]}} internal slot of
+                    |key| is a value specified in an
+                    <a href="#dfn-applicable-specification">applicable specification</a>:
+                  </dt>
+                  <dd>
+                    <p>
+                      Perform the [= ECDSA verification steps =]
+                      specified in that specification passing in |M|, |signature|,
+                      |params| and |Q| and resulting in an indication of whether
+                      or not the purported signature is valid.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a boolean with the value `true` if the signature is valid
+                  and the value `false` otherwise.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ecdsa-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains a value which is not
+                  one of "`sign`" or "`verify`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{EcKeyGenParams/namedCurve}} member of
+                    |normalizedAlgorithm| is "`P-256`", "`P-384`"
+                    or "`P-521`":
+                  </dt>
+                  <dd>
+                    <p>
+                      Generate an Elliptic Curve key pair, as defined in [[RFC6090]]
+                      with domain parameters for the curve identified by
+                      the {{EcKeyGenParams/namedCurve}} member of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </dd>
+                  <dt>
+                    If the {{EcKeyGenParams/namedCurve}} member of
+                    |normalizedAlgorithm| is a value specified in an
+                    <a href="#dfn-applicable-specification">applicable specification</a>:
+                  </dt>
+                  <dd>
+                    <p>
+                      Perform the [=ECDSA
+                      generation steps =] specified in that specification, passing in
+                      |normalizedAlgorithm| and resulting in an elliptic curve key pair.
+                    </p>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  If performing the key generation operation results in an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{EcKeyAlgorithm}}
+                  object.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`ECDSA`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{EcKeyAlgorithm/namedCurve}}
+                  attribute of |algorithm| to equal the
+                  {{namedCurve}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be a new {{CryptoKey}}
+                  representing the public key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| to "`public`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |publicKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |publicKey| to true.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |publicKey| to be the [= usage
+                  intersection =] of |usages| and `[ "verify" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |privateKey| be a new {{CryptoKey}}
+                  representing the private key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |privateKey| to {{KeyType/"private"}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |privateKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |privateKey| to |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |privateKey| to be the [= usage
+                  intersection =] of |usages| and `[ "sign" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a new {{CryptoKeyPair}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/publicKey}} attribute
+                  of |result| to be |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/privateKey}} attribute
+                  of |result| to be |privateKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ecdsa-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains a value which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |spki| be the result of running the
+                          [= parse a subjectPublicKeyInfo =]
+                          algorithm over |keyData|
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `algorithm` AlgorithmIdentifier field of |spki| is
+                          not equal to the `id-ecPublicKey`
+                          object identifier defined in [[RFC5480]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the `algorithm`
+                          AlgorithmIdentifier field of |spki| is absent,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |params| be the `parameters` field of the
+                          `algorithm` AlgorithmIdentifier field of |spki|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |params| is not an instance of the
+                          `ECParameters` ASN.1 type defined in
+                          [[RFC5480]] that specifies a
+                          `namedCurve`, then [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |namedCurve| be a string whose initial value is
+                          undefined.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |params| is equivalent to the `secp256r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-256`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp384r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-384`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp521r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-521`".
+                            </p>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |namedCurve| is not undefined:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |publicKey| be the Elliptic Curve public key identified by
+                                  performing the conversion steps defined in Section 2.3.4 of [[SEC1]] using the `subjectPublicKey`
+                                  field of |spki|.
+                                </p>
+                                <p>
+                                  The uncompressed point format MUST be supported.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the implementation does not support the compressed point format and
+                                  a compressed point is provided,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If a decode error occurs or an identity point is found,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}}
+                                  that represents |publicKey|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDSA key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |spki|
+                                  and obtaining |namedCurve| and |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the public key value is not a valid point on the Elliptic Curve
+                          identified by the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{EcKeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDSA`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to |namedCurve|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains a value which is not
+                          "`sign`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |privateKeyInfo| be the result of running the
+                          [= parse a privateKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurs while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                          |privateKeyInfo| is not equal to the
+                          `id-ecPublicKey` object identifier defined in [[RFC5480]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                          of |privateKeyInfo| is not present,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |params| be the `parameters` field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                          of |privateKeyInfo|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |params| is not an instance of the
+                          `ECParameters` ASN.1 type defined in
+                          [[RFC5480]] that specifies a
+                          `namedCurve`, then [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |namedCurve| be a string whose initial value is
+                          undefined.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |params| is equivalent to the `secp256r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-256`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp384r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-384`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp521r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-521`".
+                            </p>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |namedCurve| is not undefined:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |ecPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                                  algorithm, with |data| as the `privateKey` field
+                                  of |privateKeyInfo|, |structure| as the ASN.1
+                                  `ECPrivateKey` structure specified in Section 3 of [[RFC5915]], and |exactData| set to true.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred while parsing,
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the `parameters` field of |ecPrivateKey| is
+                                  present, and is not an instance of the `namedCurve` ASN.1
+                                  type defined in [[RFC5480]], or does not contain
+                                  the same object identifier as the `parameters` field of the
+                                  `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                                  of |privateKeyInfo|,
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}}
+                                  that represents the Elliptic Curve private key identified by
+                                  performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDSA key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |privateKeyInfo|
+                                  and obtaining |namedCurve| and |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the private key value is not a valid point on the Elliptic Curve
+                          identified by the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to {{KeyType/"private"}}
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{EcKeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDSA`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to |namedCurve|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field is present and |usages| contains
+                          a value which is not
+                          "`sign`", or,
+                          if the {{JsonWebKey/d}} field is not present and |usages| contains
+                          a value which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                          "`EC`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not  "`sig`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of JSON Web
+                          Key [[JWK]], or it does not contain all of the specified |usages|
+                          values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |namedCurve| be a string whose value is equal to the
+                          {{JsonWebKey/crv}} field of |jwk|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |namedCurve| is not equal to the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |namedCurve| is equal to "`P-256`",
+                            "`P-384`" or "`P-521`":
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |algNamedCurve| be a string whose initial value is
+                                  undefined.
+                                </p>
+                              </li>
+                              <li>
+                                <dl class="switch">
+                                  <dt>If the {{JsonWebKey/alg}} field is not present:</dt>
+                                  <dd>
+                                    Let |algNamedCurve| be undefined.
+                                  </dd>
+                                  <dt>
+                                    If the {{JsonWebKey/alg}} field is equal to the string "ES256":
+                                  </dt>
+                                  <dd>
+                                    Let |algNamedCurve| be the string "`P-256`".
+                                  </dd>
+                                  <dt>
+                                    If the {{JsonWebKey/alg}} field is equal to the string "ES384":
+                                  </dt>
+                                  <dd>
+                                    Let |algNamedCurve| be the string "`P-384`".
+                                  </dd>
+                                  <dt>
+                                    If the {{JsonWebKey/alg}} field is equal to the string "ES512":
+                                  </dt>
+                                  <dd>
+                                    Let |algNamedCurve| be the string "`P-521`".
+                                  </dd>
+                                  <dt>otherwise:</dt>
+                                  <dd>
+                                    [= exception/throw =] a
+                                    {{DataError}}.
+                                  </dd>
+                                </dl>
+                              </li>
+                              <li>
+                                <p>
+                                  If |algNamedCurve| is defined, and is not equal to
+                                  |namedCurve|, [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <dl class="switch">
+                                  <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                                  <dd>
+                                    <ol>
+                                      <li>
+                                        <p>
+                                          If |jwk| does not meet the requirements of Section
+                                          6.2.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Let |key| be a new {{CryptoKey}} object that represents the
+                                          Elliptic Curve private key identified by interpreting
+                                          |jwk| according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Set the {{CryptoKey/[[type]]}}
+                                          internal slot of |Key| to {{KeyType/"private"}}.
+                                        </p>
+                                      </li>
+                                    </ol>
+                                  </dd>
+                                  <dt>Otherwise:</dt>
+                                  <dd>
+                                    <ol>
+                                      <li>
+                                        <p>
+                                          If |jwk| does not meet the requirements of Section
+                                          6.2.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Let |key| be a new {{CryptoKey}} object that represents the
+                                          Elliptic Curve public key identified by interpreting
+                                          |jwk| according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Set the {{CryptoKey/[[type]]}}
+                                          internal slot of |Key| to "`public`".
+                                        </p>
+                                      </li>
+                                    </ol>
+                                  </dd>
+                                </dl>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>
+                            Otherwise:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDSA key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |jwk|
+                                  and obtaining |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the key value is not a valid point on the Elliptic Curve
+                          identified by the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new instance of an {{EcKeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDSA`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to |namedCurve|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{EcKeyImportParams/namedCurve}}
+                          member of |normalizedAlgorithm| is not a
+                          <a href="#dfn-NamedCurve">named curve</a>,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| contains a value which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |namedCurve| is "`P-256`",
+                            "`P-384`" or "`P-521`":
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |Q| be the elliptic curve point on the curve identified
+                                  by the {{EcKeyImportParams/namedCurve}}
+                                  member of |normalizedAlgorithm| identified by performing
+                                  the conversion steps defined in Section 2.3.4 of [[SEC1]] on |keyData|.
+                                </p>
+                                <p>
+                                  The uncompressed point format MUST be supported.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the implementation does not support the compressed point format and
+                                  a compressed point is provided,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If a decode error occurs or an identity point is found,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}}
+                                  that represents |Q|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDH key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |keyData|
+                                  and obtaining |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{EcKeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDSA`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to equal the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |key|
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ecdsa-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |key| be the {{CryptoKey}} to be
+                  exported.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `SubjectPublicKeyInfo`
+                          ASN.1 structure defined in [[RFC5280]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| field to an
+                              `AlgorithmIdentifier` ASN.1 type with the following
+                              properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `id-ecPublicKey` defined in
+                                  [[RFC5480]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |parameters| field to an instance of the
+                                  `ECParameters` ASN.1 type defined in
+                                  [[RFC5480]] as follows:
+                                </p>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}}
+                                    internal slot of |key| is "`P-256`",
+                                    "`P-384`" or "`P-521`":
+                                  </dt>
+                                  <dd>
+                                    <p>
+                                      Let |keyData| be the
+                                      [= byte sequence =] that
+                                      represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                                      |key| according to the encoding rules specified in
+                                      Section 2.2 of [[RFC5480]] and using the
+                                      uncompressed form. and |keyData|.
+                                    </p>
+                                    <dl class="switch">
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-256`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier
+                                          `secp256r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-384`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier
+                                          `secp384r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-521`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier
+                                          `secp521r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                    </dl>
+                                  </dd>
+                                  <dt>
+                                    Otherwise:
+                                  </dt>
+                                  <dd>
+                                    <ol>
+                                      <li>
+                                        <p>
+                                          Perform any [= ECDSA key export steps | key export steps =]
+                                          defined by <a href="#dfn-applicable-specification">other applicable
+                                          specifications</a>, passing |format| and the
+                                          {{EcKeyAlgorithm/namedCurve}} attribute of
+                                          the {{CryptoKey/[[algorithm]]}}
+                                          internal slot of |key|
+                                          and obtaining |namedCurveOid| and |keyData|.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier |namedCurveOid|.
+                                        </p>
+                                      </li>
+                                    </ol>
+                                  </dd>
+                                </dl>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |subjectPublicKey| field to |keyData|.
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `PrivateKeyInfo`
+                          ASN.1 structure defined in [[RFC5208]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |version| field to `0`.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKeyAlgorithm| field to a
+                              `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                              following properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `id-ecPublicKey` defined in
+                                  [[RFC5480]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |parameters| field to an instance of the
+                                  `ECParameters` ASN.1 type defined in
+                                  [[RFC5480]] as follows:
+                                </p>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}}
+                                    internal slot of |key| is "`P-256`",
+                                    "`P-384`" or "`P-521`":
+                                  </dt>
+                                  <dd>
+                                    <p>
+                                      Let |keyData| be the result of DER-encoding
+                                      an instance of the `ECPrivateKey` structure defined in
+                                      Section 3 of [[RFC5915]] for the Elliptic
+                                      Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                                      |key| and that conforms to the following:
+                                    </p>
+                                    <ul>
+                                      <li>
+                                        <p>
+                                          The |parameters| field is present, and is equivalent
+                                          to the |parameters| field of the
+                                          |privateKeyAlgorithm| field of this
+                                          `PrivateKeyInfo` ASN.1 structure.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          The |publicKey| field is present and represents the
+                                          Elliptic Curve public key associated with the Elliptic Curve
+                                          private key represented by the {{CryptoKey/[[handle]]}} internal slot
+                                          of |key|.
+                                        </p>
+                                      </li>
+                                    </ul>
+                                    <dl class="switch">
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-256`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier
+                                          `secp256r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-384`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier
+                                          `secp384r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-521`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier
+                                          `secp521r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                    </dl>
+                                  </dd>
+                                  <dt>
+                                    Otherwise:
+                                  </dt>
+                                  <dd>
+                                    <ol>
+                                      <li>
+                                        <p>
+                                          Perform any [= ECDSA key export steps | key export steps =]
+                                          defined by <a href="#dfn-applicable-specification">other applicable
+                                          specifications</a>, passing |format| and the
+                                          {{EcKeyAlgorithm/namedCurve}} attribute of
+                                          the {{CryptoKey/[[algorithm]]}}
+                                          internal slot of |key|
+                                          and obtaining |namedCurveOid| and |keyData|.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier |namedCurveOid|.
+                                        </p>
+                                      </li>
+                                    </ol>
+                                  </dd>
+                                </dl>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKey| field to |keyData|.
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to
+                          "`EC`".
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{EcKeyAlgorithm/namedCurve}}
+                            attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                            of |key| is "`P-256`", "`P-384`" or
+                            "`P-521`":
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                                    of |key| is "`P-256`":
+                                  </dt>
+                                  <dd>
                                     Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                    |namedCurve|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>
-                      If |format| is {{KeyFormat/"raw"}}:
-                    </dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{EcKeyAlgorithm/namedCurve}}
-                              attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of |key| is "`P-256`", "`P-384`"
-                              or "`P-521`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |data| be a [= byte sequence =] representing the Elliptic Curve
-                                point |Q| represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key| according to [[SEC1]] 2.3.3 using the uncompressed format.
-                              </p>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <p>
-                                Perform any [= ECDH key export steps | key export steps =]
-                                defined by <a href="#dfn-applicable-specification">other applicable
-                                specifications</a>, passing |format| and the
-                                {{EcKeyAlgorithm/namedCurve}} attribute of
-                                the {{CryptoKey/[[algorithm]]}}
-                                internal slot of |key|
-                                and obtaining |namedCurve| and |data|.
-                              </p>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                                    "`P-256`"
+                                  </dd>
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                                    of |key| is "`P-384`":
+                                  </dt>
+                                  <dd>
+                                    Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                    "`P-384`"
+                                  </dd>
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                                    of |key| is "`P-521`":
+                                  </dt>
+                                  <dd>
+                                    Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                    "`P-521`"
+                                  </dd>
+                                </dl>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                                  definition in Section 6.2.1.2 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{JsonWebKey/y}} attribute of |jwk| according to the
+                                  definition in Section 6.2.1.3 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{CryptoKey/[[type]]}} internal slot
+                                    of |key| is {{KeyType/"private"}}
+                                  </dt>
+                                  <dd>
+                                    <p>
+                                      Set the {{JsonWebKey/d}} attribute of |jwk| according to
+                                      the definition in Section 6.2.2.1 of JSON Web Algorithms [[JWA]].
+                                    </p>
+                                  </dd>
+                                </dl>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>
+                            Otherwise:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDSA key export steps | key export steps =]
+                                  defined by <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format| and the
+                                  {{EcKeyAlgorithm/namedCurve}} attribute of
+                                  the {{CryptoKey/[[algorithm]]}}
+                                  internal slot of |key|
+                                  and obtaining |namedCurve| and a new value of |jwk|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                  |namedCurve|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>
+                    If |format| is {{KeyFormat/"raw"}}:
+                  </dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{EcKeyAlgorithm/namedCurve}}
+                            attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                            of |key| is "`P-256`", "`P-384`"
+                            or "`P-521`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |data| be a [= byte sequence =] representing the Elliptic Curve
+                              point |Q| represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key| according to [[SEC1]] 2.3.3 using the uncompressed format.
+                            </p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <p>
+                              Perform any [= ECDH key export steps | key export steps =]
+                              defined by <a href="#dfn-applicable-specification">other applicable
+                              specifications</a>, passing |format| and the
+                              {{EcKeyAlgorithm/namedCurve}} attribute of
+                              the {{CryptoKey/[[algorithm]]}}
+                              internal slot of |key|
+                              and obtaining |namedCurve| and |data|.
+                            </p>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}.
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -15165,158 +15165,162 @@ dictionary HkdfParams : Algorithm {
         </section>
         <section id="hkdf-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Derive Bits</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |length| is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |keyDerivationKey| be the secret represented by the {{CryptoKey/[[handle]]}} internal slot of |key|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be the result of performing the HKDF extract and then
-                    the HKDF expand step described in Section 2 of
-                    [[RFC5869]] using:
-                  </p>
-                  <ul>
-                    <li>
-                      <p>
-                        the {{HkdfParams/hash}} member of
-                        |normalizedAlgorithm| as |Hash|,
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        |keyDerivationKey| as the input keying material,
-                        |IKM|,
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        the {{HkdfParams/salt}} member of
-                        |normalizedAlgorithm| as |salt|,
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        the {{HkdfParams/info}} member of
-                        |normalizedAlgorithm| as |info|,
-                      </p>
-                    </li>
-                    <li>
-                      <p>
-                        |length| divided by 8 as the value of |L|,
-                      </p>
-                    </li>
-                  </ul>
-                </li>
-                <li>
-                  <p>
-                    If the key derivation operation fails,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Import key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If |format| is {{KeyFormat/"raw"}}:
-                    </dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains a value that is not
-                             "`deriveKey`" or "`deriveBits`",
 
-                                then [= exception/throw =] a
-                                {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |extractable| is not `false`,
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            representing the key data provided in |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot of
-                            |key| to {{KeyType/"secret"}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new
-                            {{KeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`HKDF`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}} internal
-                            slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Return |key|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      [= exception/throw =] a
-                      {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-              </ol>
-            </dd>
-            <dt>Get key length</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Return null.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+          <section id="hkdf-operations-derive-bits">
+            <h5>Derive Bits</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |length| is null or is not a multiple of 8, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |keyDerivationKey| be the secret represented by the {{CryptoKey/[[handle]]}} internal slot of |key|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be the result of performing the HKDF extract and then
+                  the HKDF expand step described in Section 2 of
+                  [[RFC5869]] using:
+                </p>
+                <ul>
+                  <li>
+                    <p>
+                      the {{HkdfParams/hash}} member of
+                      |normalizedAlgorithm| as |Hash|,
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      |keyDerivationKey| as the input keying material,
+                      |IKM|,
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      the {{HkdfParams/salt}} member of
+                      |normalizedAlgorithm| as |salt|,
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      the {{HkdfParams/info}} member of
+                      |normalizedAlgorithm| as |info|,
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      |length| divided by 8 as the value of |L|,
+                    </p>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p>
+                  If the key derivation operation fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="hkdf-operations-import-key">
+            <h5>Import key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If |format| is {{KeyFormat/"raw"}}:
+                  </dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains a value that is not
+                           "`deriveKey`" or "`deriveBits`",
+
+                              then [= exception/throw =] a
+                              {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |extractable| is not `false`,
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          representing the key data provided in |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot of
+                          |key| to {{KeyType/"secret"}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new
+                          {{KeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`HKDF`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}} internal
+                          slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Return |key|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+            </ol>
+          </section>
+
+          <section id="hkdf-operations-get-key-length">
+            <h5>Get key length</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Return null.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -12103,468 +12103,478 @@ dictionary AesDerivedKeyParams : Algorithm {
 
         <section id="aes-ctr-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Encrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesCtrParams/counter}} member of
-                    |normalizedAlgorithm| does not have
-                    a [= byte sequence/length =] of 16 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesCtrParams/length}} member of
-                    |normalizedAlgorithm| is zero or is greater
-                    than 128,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |ciphertext| be the result of performing the CTR Encryption
-                    operation described in Section 6.5 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCtrParams/counter}} member of
-                    |normalizedAlgorithm| as the initial value of the counter block, the
-                    {{AesCtrParams/length}} member of
-                    |normalizedAlgorithm| as the input parameter |m| to the
-                    standard counter block incrementing function defined in Appendix B.1 of
-                    [[NIST-SP800-38A]] and
-                    |plaintext| as the input plaintext.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |ciphertext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Decrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesCtrParams/counter}} member of
-                    |normalizedAlgorithm| does not have
-                    a [= byte sequence/length =] of 16 bytes,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesCtrParams/length}} member of
-                    |normalizedAlgorithm| is zero or is greater
-                    than 128,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |plaintext| be the result of performing the CTR Decryption
-                    operation described in Section 6.5 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCtrParams/counter}} member of
-                    |normalizedAlgorithm| as the initial value of the counter block, the
-                    {{AesCtrParams/length}} member of
-                    |normalizedAlgorithm| as the input parameter |m| to the
-                    standard counter block incrementing function defined in Appendix B.1 of
-                    [[NIST-SP800-38A]] and
-                    |ciphertext| as the input ciphertext.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |plaintext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains any entry which is not
-                    one of "`encrypt`", "`decrypt`",
-                    "`wrapKey`" or "`unwrapKey`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm| is not equal to one of
-                    128, 192 or 256,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
 
-                <li>
-                  <p>
-                    Generate an AES key of length
-                    equal to the {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the key generation step fails,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new
-                    {{CryptoKey}} object representing the
-                    generated AES key.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-CTR`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to equal the
-                    {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |key| to be |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |key| to be |usages|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    one of "`encrypt`", "`decrypt`",
-                    "`wrapKey`" or "`unwrapKey`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the [= length in bits =] of |data| is not 128, 192 or 256
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                             "`oct`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |jwk| does not meet the requirements of
-                            Section 6.4 of JSON Web Algorithms [[JWA]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be the [= byte sequence =] obtained by decoding the
-                            {{JsonWebKey/k}} field of |jwk|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the [= length in bits =] of |data| is 128:</dt>
-                            <dd>
-                              If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                              not "`A128CTR`", then [= exception/throw =] a {{DataError}}.
-                            </dd>
-                            <dt>If the [= length in bits =] of |data| is 192:</dt>
-                            <dd>
-                              If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                              not "`A192CTR`", then [= exception/throw =] a {{DataError}}.
-                            </dd>
-                            <dt>If the [= length in bits =] of |data| is 256:</dt>
-                            <dd>
-                              If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                              not "`A256CTR`", then [= exception/throw =] a {{DataError}}.
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              [= exception/throw =] a
-                              {{DataError}}.</dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not "`enc`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+          <section id="aes-ctr-operations-encrypt">
+            <h5>Encrypt</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesCtrParams/counter}} member of
+                  |normalizedAlgorithm| does not have
+                  a [= byte sequence/length =] of 16 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesCtrParams/length}} member of
+                  |normalizedAlgorithm| is zero or is greater
+                  than 128,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |ciphertext| be the result of performing the CTR Encryption
+                  operation described in Section 6.5 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCtrParams/counter}} member of
+                  |normalizedAlgorithm| as the initial value of the counter block, the
+                  {{AesCtrParams/length}} member of
+                  |normalizedAlgorithm| as the input parameter |m| to the
+                  standard counter block incrementing function defined in Appendix B.1 of
+                  [[NIST-SP800-38A]] and
+                  |plaintext| as the input plaintext.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |ciphertext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-ctr-operations-decrypt">
+            <h5>Decrypt</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesCtrParams/counter}} member of
+                  |normalizedAlgorithm| does not have
+                  a [= byte sequence/length =] of 16 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesCtrParams/length}} member of
+                  |normalizedAlgorithm| is zero or is greater
+                  than 128,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |plaintext| be the result of performing the CTR Decryption
+                  operation described in Section 6.5 of [[NIST-SP800-38A]] using AES as the block cipher, the {{AesCtrParams/counter}} member of
+                  |normalizedAlgorithm| as the initial value of the counter block, the
+                  {{AesCtrParams/length}} member of
+                  |normalizedAlgorithm| as the input parameter |m| to the
+                  standard counter block incrementing function defined in Appendix B.1 of
+                  [[NIST-SP800-38A]] and
+                  |ciphertext| as the input ciphertext.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |plaintext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-ctr-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains any entry which is not
+                  one of "`encrypt`", "`decrypt`",
+                  "`wrapKey`" or "`unwrapKey`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm| is not equal to one of
+                  128, 192 or 256,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+
+              <li>
+                <p>
+                  Generate an AES key of length
+                  equal to the {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the key generation step fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new
+                  {{CryptoKey}} object representing the
+                  generated AES key.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-CTR`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to equal the
+                  {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |key| to be |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |key| to be |usages|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-ctr-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  one of "`encrypt`", "`decrypt`",
+                  "`wrapKey`" or "`unwrapKey`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the [= length in bits =] of |data| is not 128, 192 or 256
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                            "`oct`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |jwk| does not meet the requirements of
+                          Section 6.4 of JSON Web Algorithms [[JWA]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be the [= byte sequence =] obtained by decoding the
+                          {{JsonWebKey/k}} field of |jwk|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the [= length in bits =] of |data| is 128:</dt>
+                          <dd>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                            not "`A128CTR`", then [= exception/throw =] a {{DataError}}.
+                          </dd>
+                          <dt>If the [= length in bits =] of |data| is 192:</dt>
+                          <dd>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                            not "`A192CTR`", then [= exception/throw =] a {{DataError}}.
+                          </dd>
+                          <dt>If the [= length in bits =] of |data| is 256:</dt>
+                          <dd>
+                            If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                            not "`A256CTR`", then [= exception/throw =] a {{DataError}}.
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            [= exception/throw =] a
+                            {{DataError}}.</dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not "`enc`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new {{CryptoKey}} object representing an AES key with
+                  value |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-CTR`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to the length, in bits, of |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-ctr-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be a [= byte sequence =] containing
+                          the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to the
+                          string "`oct`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
+                          containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 128:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A128CTR`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 192:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A192CTR`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 256:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A256CTR`".</dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to equal the
+                          {{CryptoKey/[[usages]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
                       {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new {{CryptoKey}} object representing an AES key with
-                    value |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-CTR`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to the length, in bits, of |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be a [= byte sequence =] containing
-                            the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to the
-                            string "`oct`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
-                            containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 128:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A128CTR`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 192:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A192CTR`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 256:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A256CTR`".</dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to equal the
-                            {{CryptoKey/[[usages]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Get key length</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256,
-                    then [= exception/throw =] a
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-ctr-operations-get-key-length">
+            <h5>Get key length</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256,
+                  then [= exception/throw =] a
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -3938,959 +3938,964 @@ dictionary RsaHashedImportParams : Algorithm {
         </section>
         <section id="rsassa-pkcs1-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Sign</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Perform the signature generation operation defined in Section 8.2 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    as the signer's private key and |message| as
-                    |M| and using the hash function specified in the {{RsaHashedKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |signature| be the value |S| that results from
-                    performing the operation.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |signature|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
 
-            <dt>Verify</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Perform the signature verification operation defined in Section 8.2 of
-                    [[RFC3447]] with the key represented by the
-                    {{CryptoKey/[[handle]]}} internal slot of
-                    |key| as the signer's RSA public key and |message| as
-                    |M| and
-                    |signature| as |S| and using the hash function specified
-                    in the {{RsaHashedKeyAlgorithm/hash}} attribute of the
-                    {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a boolean with value true if the
-                    result of the operation was "valid signature" and the value
-                    false otherwise.
-                  </p>
-                </li>
-                <li>
-                  <p>Return |result|.</p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                     "`sign`" or "`verify`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
-                    {{RsaKeyGenParams/modulusLength}} attribute of
-                    |normalizedAlgorithm| and RSA public exponent equal to the
-                    {{RsaKeyGenParams/publicExponent}} attribute of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If generation of the key pair fails,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{RsaHashedKeyAlgorithm}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`RSASSA-PKCS1-v1_5`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the
-                    {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of |algorithm| to equal the
-                    {{RsaKeyGenParams/modulusLength}}
-                    attribute of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the
-                    {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of |algorithm| to equal the
-                    {{RsaKeyGenParams/publicExponent}}
-                    attribute of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaHashedKeyAlgorithm/hash}} attribute
-                    of |algorithm| to equal the
-                    {{RsaHashedKeyGenParams/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be a new {{CryptoKey}}
-                    representing the public key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| to "`public`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |publicKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |publicKey| to true.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |publicKey| to be the [= usage
-                    intersection =] of |usages| and `[ "verify" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |privateKey| be a new {{CryptoKey}}
-                    representing the private key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |privateKey| to {{KeyType/"private"}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |privateKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |privateKey| to |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |privateKey| to be the [= usage
-                    intersection =] of |usages| and `[ "sign" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a new {{CryptoKeyPair}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/publicKey}} attribute
-                    of |result| to be |publicKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/privateKey}} attribute
-                    of |result| to be |privateKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
+          <section id="rsassa-pkcs1-operations-sign">
+            <h5>Sign</h5>
 
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                            "`verify`",
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |spki| be the result of running the
-                            [= parse a subjectPublicKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of |spki| is
-                            not equal to the `rsaEncryption`
-                            object identifier defined in [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the
-                            `subjectPublicKeyInfo` field of |spki|,
-                            |structure| as the `RSAPublicKey` structure
-                            specified in Section A.1.1 of [[RFC3447]], and
-                            |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, or it can be determined that |publicKey|
-                            is not a valid public key according to [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the RSA public key identified by
-                            |publicKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                             "`sign`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |privateKeyInfo| be the result of running the
-                            [= parse a privateKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            |privateKeyInfo| is not equal to the
-                            `rsaEncryption` object identifier defined in [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the
-                            `privateKey` field of |privateKeyInfo|,
-                            |structure| as the `RSAPrivateKey` structure
-                            specified in Section A.1.2 of [[RFC3447]], and
-                            |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, or if |rsaPrivateKey| is not
-                            a valid RSA private key according to [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the RSA private key identified by
-                            |rsaPrivateKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to {{KeyType/"private"}}
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field of |jwk| is present and
-                            |usages| contains an entry which is not
-                            "`sign`", or, if the {{JsonWebKey/d}} field of |jwk|
-                            is not present and
-                            |usages| contains an entry which is not
-                            "`verify`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not a
-                            case-sensitive string match to "`RSA`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not a case-sensitive string match to "`sig`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |hash| be a be a string whose initial value is
-                            undefined.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{JsonWebKey/alg}} field of |jwk| is not
-                              present:
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be undefined.
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`RS1`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-1`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`RS256`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-256`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`RS384`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-384`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If the {{JsonWebKey/alg}} field is equal to the string
-                              "`RS512`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |hash| be the string "`SHA-512`".
-                              </p>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= RSASSA-PKCS1-v1_5 key import steps | key
-                                    import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |jwk|
-                                    and obtaining |hash|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl>
-                            <dt>
-                              If |hash| is not undefined:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |normalizedHash| be the result of
-                                    <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to |hash| and `op` set
-                                    to `digest`.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |normalizedHash| is not equal to the
-                                    {{RsaHashedImportParams/hash}} member of
-                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of
-                                    Section 6.3.2 of JSON Web Algorithms [[JWA]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |privateKey| represents the
-                                    RSA private key identified by interpreting |jwk|
-                                    according to Section 6.3.2 of JSON Web
-                                    Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |privateKey| is not a valid RSA private key
-                                    according to [[RFC3447]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} object that represents
-                                    |privateKey|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |key| to {{KeyType/"private"}}
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of Section
-                                    6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |publicKey| represent the
-                                    RSA public key identified by interpreting |jwk|
-                                    according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |publicKey| can be determined to not be a valid RSA public key
-                                    according to [[RFC3447]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} representing |publicKey|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}}
-                                    internal slot of |key| to "`public`"
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the signature generation operation defined in Section 8.2 of [[RFC3447]] with the key represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  as the signer's private key and |message| as
+                  |M| and using the hash function specified in the {{RsaHashedKeyAlgorithm/hash}} attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |signature| be the value |S| that results from
+                  performing the operation.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |signature|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsassa-pkcs1-operations-verify">
+            <h5>Verify</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the signature verification operation defined in Section 8.2 of
+                  [[RFC3447]] with the key represented by the
+                  {{CryptoKey/[[handle]]}} internal slot of
+                  |key| as the signer's RSA public key and |message| as
+                  |M| and
+                  |signature| as |S| and using the hash function specified
+                  in the {{RsaHashedKeyAlgorithm/hash}} attribute of the
+                  {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| as the Hash option for the EMSA-PKCS1-v1_5 encoding method.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a boolean with value true if the
+                  result of the operation was "valid signature" and the value
+                  false otherwise.
+                </p>
+              </li>
+              <li>
+                <p>Return |result|.</p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsassa-pkcs1-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                   "`sign`" or "`verify`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
+                  {{RsaKeyGenParams/modulusLength}} attribute of
+                  |normalizedAlgorithm| and RSA public exponent equal to the
+                  {{RsaKeyGenParams/publicExponent}} attribute of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If generation of the key pair fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{RsaHashedKeyAlgorithm}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`RSASSA-PKCS1-v1_5`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the
+                  {{RsaKeyAlgorithm/modulusLength}}
+                  attribute of |algorithm| to equal the
+                  {{RsaKeyGenParams/modulusLength}}
+                  attribute of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the
+                  {{RsaKeyAlgorithm/publicExponent}}
+                  attribute of |algorithm| to equal the
+                  {{RsaKeyGenParams/publicExponent}}
+                  attribute of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaHashedKeyAlgorithm/hash}} attribute
+                  of |algorithm| to equal the
+                  {{RsaHashedKeyGenParams/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be a new {{CryptoKey}}
+                  representing the public key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| to "`public`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |publicKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |publicKey| to true.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |publicKey| to be the [= usage
+                  intersection =] of |usages| and `[ "verify" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |privateKey| be a new {{CryptoKey}}
+                  representing the private key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |privateKey| to {{KeyType/"private"}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |privateKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |privateKey| to |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |privateKey| to be the [= usage
+                  intersection =] of |usages| and `[ "sign" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a new {{CryptoKeyPair}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/publicKey}} attribute
+                  of |result| to be |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/privateKey}} attribute
+                  of |result| to be |privateKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsassa-pkcs1-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                          "`verify`",
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |spki| be the result of running the
+                          [= parse a subjectPublicKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `algorithm` AlgorithmIdentifier field of |spki| is
+                          not equal to the `rsaEncryption`
+                          object identifier defined in [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the
+                          `subjectPublicKeyInfo` field of |spki|,
+                          |structure| as the `RSAPublicKey` structure
+                          specified in Section A.1.1 of [[RFC3447]], and
+                          |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, or it can be determined that |publicKey|
+                          is not a valid public key according to [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the RSA public key identified by
+                          |publicKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                           "`sign`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |privateKeyInfo| be the result of running the
+                          [= parse a privateKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                          |privateKeyInfo| is not equal to the
+                          `rsaEncryption` object identifier defined in [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the
+                          `privateKey` field of |privateKeyInfo|,
+                          |structure| as the `RSAPrivateKey` structure
+                          specified in Section A.1.2 of [[RFC3447]], and
+                          |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, or if |rsaPrivateKey| is not
+                          a valid RSA private key according to [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the RSA private key identified by
+                          |rsaPrivateKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to {{KeyType/"private"}}
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field of |jwk| is present and
+                          |usages| contains an entry which is not
+                          "`sign`", or, if the {{JsonWebKey/d}} field of |jwk|
+                          is not present and
+                          |usages| contains an entry which is not
+                          "`verify`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not a
+                          case-sensitive string match to "`RSA`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not a case-sensitive string match to "`sig`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |hash| be a be a string whose initial value is
+                          undefined.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{JsonWebKey/alg}} field of |jwk| is not
+                            present:
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be undefined.
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`RS1`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-1`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`RS256`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-256`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`RS384`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-384`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If the {{JsonWebKey/alg}} field is equal to the string
+                            "`RS512`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |hash| be the string "`SHA-512`".
+                            </p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= RSASSA-PKCS1-v1_5 key import steps | key
+                                  import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |jwk|
+                                  and obtaining |hash|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl>
+                          <dt>
+                            If |hash| is not undefined:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |normalizedHash| be the result of
+                                  <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
+                                  with `alg` set to |hash| and `op` set
+                                  to `digest`.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |normalizedHash| is not equal to the
+                                  {{RsaHashedImportParams/hash}} member of
+                                  |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of
+                                  Section 6.3.2 of JSON Web Algorithms [[JWA]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |privateKey| represents the
+                                  RSA private key identified by interpreting |jwk|
+                                  according to Section 6.3.2 of JSON Web
+                                  Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |privateKey| is not a valid RSA private key
+                                  according to [[RFC3447]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} object that represents
+                                  |privateKey|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |key| to {{KeyType/"private"}}
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of Section
+                                  6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |publicKey| represent the
+                                  RSA public key identified by interpreting |jwk|
+                                  according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |publicKey| can be determined to not be a valid RSA public key
+                                  according to [[RFC3447]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} representing |publicKey|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}}
+                                  internal slot of |key| to "`public`"
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{RsaHashedKeyAlgorithm}} dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`RSASSA-PKCS1-v1_5`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaKeyAlgorithm/modulusLength}}
+                  attribute of |algorithm| to the length, in bits, of the RSA public
+                  modulus.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the <a href="#dfn-RsaKeyAlgorithm-publicExponent">publicExponent</a>
+                  attribute of |algorithm| to the <a href="#dfn-BigInteger">BigInteger</a>
+                  representation of the RSA public exponent.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
+                  |algorithm| to the {{RsaHashedImportParams/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>Return |key|.</p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsassa-pkcs1-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |key| be the key to be exported.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `SubjectPublicKeyInfo`
+                          ASN.1 structure defined in [[RFC5280]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| field to an
+                              `AlgorithmIdentifier` ASN.1 type with the following
+                              properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `rsaEncryption` defined in
+                                  [[RFC3447]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |params| field to the ASN.1 type NULL.
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |subjectPublicKey| field to the result of
+                              DER-encoding an `RSAPublicKey` ASN.1 type, as defined
+                              in [[RFC3447]], Appendix A.1.1, that
+                              represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `PrivateKeyInfo`
+                          ASN.1 structure defined in [[RFC5208]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |version| field to `0`.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKeyAlgorithm| field to a
+                              `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                              following properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `rsaEncryption` defined in
+                                  [[RFC3447]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |params| field to the ASN.1 type NULL.
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKey| field to the result of DER-encoding
+                              an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
+                              RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                            <div class=note>
+                              [[RFC5208]] specifies that the encoding of
+                              this field should be <em>BER</em> encoded in Section 5 (as a "for
+                              example"). However, to avoid requiring WebCrypto implementations
+                              support BER-encoding and BER-decoding, only <em>DER</em> encodings
+                              are produced or accepted.
+                            </div>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>Let |jwk| be a new {{JsonWebKey}}
+                        dictionary.</p>
+                      </li>
+                      <li>
+                        <p>Set the `kty` attribute of |jwk| to the string
+                        "`RSA`".</p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |hash| be the {{KeyAlgorithm/name}}
+                          attribute of the {{RsaHashedKeyAlgorithm/hash}}
+                          attribute of the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |hash| is "`SHA-1`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RS1`".
+                            </p>
+                          </dd>
+                          <dt>If |hash| is "`SHA-256`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RS256`".
+                            </p>
+                          </dd>
+                          <dt>If |hash| is "`SHA-384`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RS384`".
+                            </p>
+                          </dd>
+                          <dt>If |hash| is "`SHA-512`":</dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RS512`".
+                            </p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= RSASSA-PKCS1-v1_5 key import steps | key
+                                  export steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |key|
+                                  and obtaining |alg|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{NotSupportedError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the `alg` attribute of |jwk| to |alg|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
+                          according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{CryptoKey/[[type]]}} internal slot
+                            of |key| is {{KeyType/"private"}}:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
+                                  {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
+                                  {{JsonWebKey/qi}} of |jwk| according to the
+                                  corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
+                                  of |key| is represented by more than two primes, set
+                                  the attribute named {{JsonWebKey/oth}} of |jwk|
+                                  according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to the <a href="#dfn-CryptoKey-usages">usages</a> attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
                       {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{RsaHashedKeyAlgorithm}} dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`RSASSA-PKCS1-v1_5`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of |algorithm| to the length, in bits, of the RSA public
-                    modulus.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the <a href="#dfn-RsaKeyAlgorithm-publicExponent">publicExponent</a>
-                    attribute of |algorithm| to the <a href="#dfn-BigInteger">BigInteger</a>
-                    representation of the RSA public exponent.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
-                    |algorithm| to the {{RsaHashedImportParams/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>Return |key|.</p>
-                </li>
-              </ol>
-            </dd>
-
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |key| be the key to be exported.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `SubjectPublicKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| field to an
-                                `AlgorithmIdentifier` ASN.1 type with the following
-                                properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `rsaEncryption` defined in
-                                    [[RFC3447]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |params| field to the ASN.1 type NULL.
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |subjectPublicKey| field to the result of
-                                DER-encoding an `RSAPublicKey` ASN.1 type, as defined
-                                in [[RFC3447]], Appendix A.1.1, that
-                                represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `PrivateKeyInfo`
-                            ASN.1 structure defined in [[RFC5208]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |version| field to `0`.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKeyAlgorithm| field to a
-                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                                following properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `rsaEncryption` defined in
-                                    [[RFC3447]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |params| field to the ASN.1 type NULL.
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKey| field to the result of DER-encoding
-                                an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
-                                RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                              <div class=note>
-                                [[RFC5208]] specifies that the encoding of
-                                this field should be <em>BER</em> encoded in Section 5 (as a "for
-                                example"). However, to avoid requiring WebCrypto implementations
-                                support BER-encoding and BER-decoding, only <em>DER</em> encodings
-                                are produced or accepted.
-                              </div>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>Let |jwk| be a new {{JsonWebKey}}
-                          dictionary.</p>
-                        </li>
-                        <li>
-                          <p>Set the `kty` attribute of |jwk| to the string
-                          "`RSA`".</p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |hash| be the {{KeyAlgorithm/name}}
-                            attribute of the {{RsaHashedKeyAlgorithm/hash}}
-                            attribute of the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |hash| is "`SHA-1`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RS1`".
-                              </p>
-                            </dd>
-                            <dt>If |hash| is "`SHA-256`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RS256`".
-                              </p>
-                            </dd>
-                            <dt>If |hash| is "`SHA-384`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RS384`".
-                              </p>
-                            </dd>
-                            <dt>If |hash| is "`SHA-512`":</dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RS512`".
-                              </p>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= RSASSA-PKCS1-v1_5 key import steps | key
-                                    export steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |key|
-                                    and obtaining |alg|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{NotSupportedError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the `alg` attribute of |jwk| to |alg|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
-                            according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{CryptoKey/[[type]]}} internal slot
-                              of |key| is {{KeyType/"private"}}:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
-                                    {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
-                                    {{JsonWebKey/qi}} of |jwk| according to the
-                                    corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                    of |key| is represented by more than two primes, set
-                                    the attribute named {{JsonWebKey/oth}} of |jwk|
-                                    according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to the <a href="#dfn-CryptoKey-usages">usages</a> attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -8785,1500 +8785,1504 @@ dictionary EcdhKeyDeriveParams : Algorithm {
         </section>
         <section id="ecdh-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    "`deriveKey`" or "`deriveBits`"
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{EcKeyGenParams/namedCurve}} member of
-                      |normalizedAlgorithm| is "`P-256`", "`P-384`"
-                      or "`P-521`":
-                    </dt>
-                    <dd>
-                      <p>
-                        Generate an Elliptic Curve key pair, as defined in [[RFC6090]] with domain parameters for the curve identified by
-                        the {{EcKeyGenParams/namedCurve}} member of
-                        |normalizedAlgorithm|.
-                      </p>
-                    </dd>
-                    <dt>
-                      If the {{EcKeyGenParams/namedCurve}} member of
-                      |normalizedAlgorithm| is a value specified in an
-                      <a href="#dfn-applicable-specification">applicable specification</a> that
-                      specifies the use of that value with ECDH:
-                    </dt>
-                    <dd>
-                      <p>
-                        Perform the [= ECDH
-                        generation steps =] specified in that specification, passing in
-                        |normalizedAlgorithm| and resulting in an elliptic curve key pair.
-                      </p>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] a
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{EcKeyAlgorithm}}
-                    object.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{Algorithm/name}} member of
-                    |algorithm| to "`ECDH`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{EcKeyAlgorithm/namedCurve}}
-                    attribute of |algorithm| to equal the
-                    {{namedCurve}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be a new {{CryptoKey}}
-                    representing the public key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| to "`public`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |publicKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |publicKey| to true.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |publicKey| to be the empty list.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |privateKey| be a new {{CryptoKey}}
-                    representing the private key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |privateKey| to {{KeyType/"private"}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |privateKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |privateKey| to |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |privateKey| to be the
-                    [= usage intersection =] of
-                    |usages| and `[ "deriveKey", "deriveBits" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a new {{CryptoKeyPair}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/publicKey}} attribute
-                    of |result| to be |publicKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/privateKey}} attribute
-                    of |result| to be |privateKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Derive Bits</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be the
-                    {{EcdhKeyDeriveParams/public}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{KeyAlgorithm/name}} attribute of
-                    the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key|, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{EcKeyAlgorithm/namedCurve}} attribute of
-                    the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |publicKey| is not equal to the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key|, then [= exception/throw =] an {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>
-                      If the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| is "`P-256`", "`P-384`"
-                      or "`P-521`":
-                    </dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Perform the ECDH primitive specified in [[RFC6090]] Section
-                            4 with |key| as the EC private key |d| and the EC public
-                            key represented by the {{CryptoKey/[[handle]]}}
-                            internal slot of |publicKey| as the EC public key.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |secret| be a [= byte sequence =] containing
-                            the result of applying the field element to
-                            octet string conversion defined in Section
-                            6.2 of [[RFC6090]]
-                            to the output of the ECDH primitive.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>
-                      If the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| is a value specified in an
-                      <a href="#dfn-applicable-specification">applicable specification</a> that
-                      specifies the use of that value with ECDH:
-                    </dt>
-                    <dd>
-                      <p>
-                        Perform the [= ECDH
-                        derivation steps =] specified in that specification, passing in
-                        |key| and |publicKey| and resulting in |secret|.
-                      </p>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}
-                      </p>
-                    </dd>
-                  </dl>
 
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] a
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |length| is null:</dt>
-                    <dd>Return |secret|</dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <dl class="switch">
-                        <dt>
-                          If the [= length in bits =] of |secret| is less than
-                          |length|:
-                        </dt>
-                        <dd>
-                          [= exception/throw =] an
-                          {{OperationError}}.
-                        </dd>
-                        <dt>Otherwise:</dt>
-                        <dd>
-                          Return a [= byte sequence containing =] the first |length| bits of |secret|.
-                        </dd>
-                      </dl>
-                    </dd>
-                  </dl>
-                </li>
-              </ol>
-            </dd>
+          <section id="ecdh-operations-generate-key">
+            <h5>Generate Key</h5>
 
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| is not empty
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |spki| be the result of running the
-                            [= parse a subjectPublicKeyInfo =]
-                            algorithm over |keyData|
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of |spki| is
-                            not equal to the `id-ecPublicKey`
-                            object identifier defined in [[RFC5480]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the `algorithm`
-                            AlgorithmIdentifier field of |spki| is absent,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |params| be the `parameters` field of the
-                            `algorithm` AlgorithmIdentifier field of |spki|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |params| is not an instance of the
-                            `ECParameters` ASN.1 type defined in
-                            [[RFC5480]] that specifies a
-                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |namedCurve| be a string whose initial value is
-                            undefined.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |params| is equivalent to the `secp256r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-256`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp384r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-384`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp521r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| "`P-521`".
-                              </p>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |namedCurve| is not undefined:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |publicKey| be the Elliptic Curve public key identified by
-                                    performing the conversion steps defined in Section 2.3.4 of [[SEC1]] to the `subjectPublicKey` field of
-                                    |spki|.
-                                  </p>
-                                  <p>
-                                    The uncompressed point format MUST be supported.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the implementation does not support the compressed point format and
-                                    a compressed point is provided,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If a decode error occurs or an identity point is found,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}}
-                                    that represents |publicKey|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDH key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |spki|
-                                    and obtaining |namedCurve| and |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the key value is not a valid point on the Elliptic Curve
-                            identified by the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDH`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to |namedCurve|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                            "`deriveKey`" or "`deriveBits`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |privateKeyInfo| be the result of running the
-                            [= parse a privateKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurs while parsing,
-                            [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            |privateKeyInfo| is not equal to the
-                            `id-ecPublicKey` object identifier
-                            defined in [[RFC5480]],
-                            [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `parameters` field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of |privateKeyInfo| is not present,
-                            [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |params| be the `parameters` field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                            of |privateKeyInfo|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |params| is not an instance of the
-                            `ECParameters` ASN.1 type defined in
-                            [[RFC5480]] that specifies a
-                            `namedCurve`, then [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |namedCurve| be a string whose initial value is
-                            undefined.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |params| is equivalent to the `secp256r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| to "`P-256`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp384r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| to "`P-384`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |params| is equivalent to the `secp521r1`
-                              object identifier defined in [[RFC5480]]:
-                            </dt>
-                            <dd>
-                              <p>
-                                Set |namedCurve| to "`P-521`".
-                              </p>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |namedCurve| is not undefined:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |ecPrivateKey| be the result of performing the
-                                    [= parse an ASN.1 structure =]
-                                    algorithm, with |data| as the `privateKey` field
-                                    of |privateKeyInfo|, |structure| as the ASN.1
-                                    `ECPrivateKey` structure specified in Section 3 of
-                                    [[RFC5915]], and |exactData| set to true.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred while parsing,
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the `parameters` field of |ecPrivateKey| is
-                                    present, and is not an instance of the `namedCurve` ASN.1
-                                    type defined in [[RFC5480]], or does not contain
-                                    the same object identifier as the `parameters` field of the
-                                    `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
-                                    of |privateKeyInfo|,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}}
-                                    that represents the Elliptic Curve private key identified by
-                                    performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDH key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |privateKeyInfo|
-                                    and obtaining |namedCurve| and |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the key value is not a valid point on the Elliptic Curve
-                            identified by the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to {{KeyType/"private"}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{EcKeyAlgorithm}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDH`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to |namedCurve|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field is present and if |usages|
-                            contains an entry which is not
-                            "`deriveKey`" or "`deriveBits`"
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field is not present and if |usages| is not
-                            empty
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is
-                            not "`EC`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
-                            and is not equal to "`enc`" then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of JSON Web
-                            Key [[JWK]], or it does not contain all of the specified |usages|
-                            values, then [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |namedCurve| be a string whose value is equal to the
-                            {{JsonWebKey/crv}} field of |jwk|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |namedCurve| is not equal to the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |namedCurve| is "`P-256`",
-                              "`P-384`" or "`P-521`":
-                            </dt>
-                            <dd>
-                              <dl class="switch">
-                                <dt>If the {{JsonWebKey/d}} field is present:</dt>
-                                <dd>
-                                  <ol>
-                                    <li>
-                                      <p>
-                                        If |jwk| does not meet the requirements of Section
-                                        6.2.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                      </p>
-                                    </li>
-                                    <li>
-                                      <p>
-                                        Let |key| be a new {{CryptoKey}} object that represents the
-                                        Elliptic Curve private key identified by interpreting
-                                        |jwk| according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
-                                      </p>
-                                    </li>
-                                    <li>
-                                      <p>
-                                        Set the {{CryptoKey/[[type]]}}
-                                        internal slot of |Key| to {{KeyType/"private"}}.
-                                      </p>
-                                    </li>
-                                  </ol>
-                                </dd>
-                                <dt>Otherwise:</dt>
-                                <dd>
-                                  <ol>
-                                    <li>
-                                      <p>
-                                        If |jwk| does not meet the requirements of Section
-                                        6.2.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                      </p>
-                                    </li>
-                                    <li>
-                                      <p>
-                                        Let |key| be a new {{CryptoKey}} object that represents the
-                                        Elliptic Curve public key identified by interpreting
-                                        |jwk| according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
-                                      </p>
-                                    </li>
-                                    <li>
-                                      <p>
-                                        Set the {{CryptoKey/[[type]]}}
-                                        internal slot of |Key| to "`public`".
-                                      </p>
-                                    </li>
-                                  </ol>
-                                </dd>
-                              </dl>
-                            </dd>
-                            <dt>Otherwise</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDH key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |jwk|
-                                    and obtaining |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the key value is not a valid point on the Elliptic Curve
-                            identified by the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new instance of an {{EcKeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDH`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to |namedCurve|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{EcKeyImportParams/namedCurve}}
-                            member of |normalizedAlgorithm| is not a
-                            <a href="#dfn-NamedCurve">named curve</a>,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is not the empty list,
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |namedCurve| is "`P-256`",
-                              "`P-384`" or "`P-521`":
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |Q| be the Elliptic Curve public key on the curve identified
-                                    by the {{EcKeyImportParams/namedCurve}}
-                                    member of |normalizedAlgorithm| identified by performing
-                                    the conversion steps defined in Section 2.3.4 of [[SEC1]] to |keyData|.
-                                  </p>
-                                  <p>
-                                    The uncompressed point format MUST be supported.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the implementation does not support the compressed point format and
-                                    a compressed point is provided,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If a decode error occurs or an identity point is found,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}}
-                                    that represents |Q|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDH key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |keyData|
-                                    and obtaining |key|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occured or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Let |algorithm| be a new {{EcKeyAlgorithm}} object.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{KeyAlgorithm/name}} attribute of
-                            |algorithm| to "`ECDH`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{EcKeyAlgorithm/namedCurve}}
-                            attribute of |algorithm| to equal the {{EcKeyImportParams/namedCurve}} member of
-                            |normalizedAlgorithm|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot
-                            of |key| to "`public`"
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[algorithm]]}}
-                            internal slot of |key| to |algorithm|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |key|
-                  </p>
-                </li>
-              </ol>
-            </dd>
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  "`deriveKey`" or "`deriveBits`"
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{EcKeyGenParams/namedCurve}} member of
+                    |normalizedAlgorithm| is "`P-256`", "`P-384`"
+                    or "`P-521`":
+                  </dt>
+                  <dd>
+                    <p>
+                      Generate an Elliptic Curve key pair, as defined in [[RFC6090]] with domain parameters for the curve identified by
+                      the {{EcKeyGenParams/namedCurve}} member of
+                      |normalizedAlgorithm|.
+                    </p>
+                  </dd>
+                  <dt>
+                    If the {{EcKeyGenParams/namedCurve}} member of
+                    |normalizedAlgorithm| is a value specified in an
+                    <a href="#dfn-applicable-specification">applicable specification</a> that
+                    specifies the use of that value with ECDH:
+                  </dt>
+                  <dd>
+                    <p>
+                      Perform the [= ECDH
+                      generation steps =] specified in that specification, passing in
+                      |normalizedAlgorithm| and resulting in an elliptic curve key pair.
+                    </p>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] a
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{EcKeyAlgorithm}}
+                  object.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{Algorithm/name}} member of
+                  |algorithm| to "`ECDH`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{EcKeyAlgorithm/namedCurve}}
+                  attribute of |algorithm| to equal the
+                  {{namedCurve}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be a new {{CryptoKey}}
+                  representing the public key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| to "`public`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |publicKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |publicKey| to true.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |publicKey| to be the empty list.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |privateKey| be a new {{CryptoKey}}
+                  representing the private key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |privateKey| to {{KeyType/"private"}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |privateKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |privateKey| to |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |privateKey| to be the
+                  [= usage intersection =] of
+                  |usages| and `[ "deriveKey", "deriveBits" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a new {{CryptoKeyPair}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/publicKey}} attribute
+                  of |result| to be |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/privateKey}} attribute
+                  of |result| to be |privateKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
 
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |key| be the {{CryptoKey}} to be
-                    exported.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `SubjectPublicKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| field to an
-                                `AlgorithmIdentifier` ASN.1 type with the following
-                                properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `id-ecPublicKey` defined in
-                                    [[RFC5480]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |parameters| field to an instance of the
-                                    `ECParameters` ASN.1 type defined in
-                                    [[RFC5480]] as follows:
-                                  </p>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of |key| is "`P-256`",
-                                      "`P-384`" or "`P-521`":
-                                    </dt>
-                                    <dd>
-                                      <p>
-                                        Let |keyData| be the [= byte sequence =] that
-                                        represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        |key| according to the encoding rules specified in
-                                        Section 2.3.3 of [[SEC1]] and using the
-                                        uncompressed form.
-                                      </p>
-                                      <dl class="switch">
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-256`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the |namedCurve| choice
-                                            with value equal to the object identifier
-                                            `secp256r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-384`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the |namedCurve| choice
-                                            with value equal to the object identifier
-                                            `secp384r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-521`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the |namedCurve| choice
-                                            with value equal to the object identifier
-                                            `secp521r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                      </dl>
-                                    </dd>
-                                    <dt>
-                                      Otherwise:
-                                    </dt>
-                                    <dd>
-                                      <ol>
-                                        <li>
-                                          <p>
-                                            Perform any [= ECDH key export steps | key export steps =]
-                                            defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing |format| and the
-                                            {{EcKeyAlgorithm/namedCurve}} attribute of
-                                            the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of |key|
-                                            and obtaining |namedCurveOid| and |keyData|.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier |namedCurveOid|.
-                                          </p>
-                                        </li>
-                                      </ol>
-                                    </dd>
-                                  </dl>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |subjectPublicKey| field to |keyData|
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `PrivateKeyInfo`
-                            ASN.1 structure defined in [[RFC5208]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |version| field to `0`.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKeyAlgorithm| field to a
-                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                                following properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `id-ecPublicKey` defined in
-                                    [[RFC5480]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |parameters| field to an instance of the
-                                    `ECParameters` ASN.1 type defined in
-                                    [[RFC5480]] as follows:
-                                  </p>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}}
-                                      internal slot of |key| is "`P-256`",
-                                      "`P-384`" or "`P-521`":
-                                    </dt>
-                                    <dd>
-                                      <p>
-                                        Let |keyData| be the result of DER-encoding
-                                        an instance of the `ECPrivateKey` structure defined in
-                                        Section 3 of [[RFC5915]] for the Elliptic
-                                        Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                        |key| and that conforms to the following:
-                                      </p>
-                                      <ul>
-                                        <li>
-                                          <p>
-                                            The |parameters| field is present, and is equivalent
-                                            to the |parameters| field of the
-                                            |privateKeyAlgorithm| field of this
-                                            `PrivateKeyInfo` ASN.1 structure.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            The |publicKey| field is present and represents the
-                                            Elliptic Curve public key associated with the Elliptic Curve
-                                            private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                            of |key|.
-                                          </p>
-                                        </li>
-                                      </ul>
-                                      <dl class="switch">
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-256`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the |namedCurve| choice
-                                            with value equal to the object identifier
-                                            `secp256r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-384`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the |namedCurve| choice
-                                            with value equal to the object identifier
-                                            `secp384r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                        <dt>
-                                          If the {{EcKeyAlgorithm/namedCurve}}
-                                          attribute of the {{CryptoKey/[[algorithm]]}}
-                                          internal slot of |key| is "`P-521`":
-                                        </dt>
-                                        <dd>
-                                          <p>
-                                            Set |parameters| to the |namedCurve| choice
-                                            with value equal to the object identifier
-                                            `secp521r1` defined in [[RFC5480]]
-                                          </p>
-                                        </dd>
-                                      </dl>
-                                    </dd>
-                                    <dt>
-                                      Otherwise:
-                                    </dt>
-                                    <dd>
-                                      <ol>
-                                        <li>
-                                          <p>
-                                            Perform any [= ECDH key export steps | key export steps =]
-                                            defined by <a href="#dfn-applicable-specification">other applicable
-                                            specifications</a>, passing |format| and the
-                                            {{EcKeyAlgorithm/namedCurve}} attribute of
-                                            the {{CryptoKey/[[algorithm]]}}
-                                            internal slot of |key|
-                                            and obtaining |namedCurveOid| and |keyData|.
-                                          </p>
-                                        </li>
-                                        <li>
-                                          <p>
-                                            Set |parameters| to the `namedCurve` choice
-                                            with value equal to the object identifier |namedCurveOid|.
-                                          </p>
-                                        </li>
-                                      </ol>
-                                    </dd>
-                                  </dl>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKey| field to |keyData|.
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to
-                            "`EC`".
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{EcKeyAlgorithm/namedCurve}}
-                              attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of |key| is "`P-256`", "`P-384`"
-                              or "`P-521`":
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of |key| is "`P-256`":
-                                    </dt>
-                                    <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                      "`P-256`"
-                                    </dd>
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of |key| is "`P-384`":
-                                    </dt>
-                                    <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                      "`P-384`"
-                                    </dd>
-                                    <dt>
-                                      If the {{EcKeyAlgorithm/namedCurve}}
-                                      attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                                      of |key| is "`P-521`":
-                                    </dt>
-                                    <dd>
-                                      Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                      "`P-521`"
-                                    </dd>
-                                  </dl>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{JsonWebKey/x}} attribute of |jwk| according to the
-                                    definition in Section 6.2.1.2 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{JsonWebKey/y}} attribute of |jwk| according to the
-                                    definition in Section 6.2.1.3 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <dl class="switch">
-                                    <dt>
-                                      If the {{CryptoKey/[[type]]}} internal slot
-                                      of |key| is {{KeyType/"private"}}
-                                    </dt>
-                                    <dd>
-                                      <p>
-                                        Set the {{JsonWebKey/d}} attribute of |jwk| according to the
-                                        definition in Section 6.2.2.1 of JSON Web Algorithms [[JWA]].
-                                      </p>
-                                    </dd>
-                                  </dl>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>
-                              Otherwise:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= ECDH key export steps | key export steps =]
-                                    defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format| and the
-                                    {{EcKeyAlgorithm/namedCurve}} attribute of
-                                    the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of |key|
-                                    and obtaining |namedCurve| and a new value of |jwk|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
+          <section id="ecdh-operations-derive-bits">
+            <h5>Derive Bits</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be the
+                  {{EcdhKeyDeriveParams/public}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{KeyAlgorithm/name}} attribute of
+                  the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |publicKey| is not equal to the {{KeyAlgorithm/name}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key|, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{EcKeyAlgorithm/namedCurve}} attribute of
+                  the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |publicKey| is not equal to the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key|, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>
+                    If the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| is "`P-256`", "`P-384`"
+                    or "`P-521`":
+                  </dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Perform the ECDH primitive specified in [[RFC6090]] Section
+                          4 with |key| as the EC private key |d| and the EC public
+                          key represented by the {{CryptoKey/[[handle]]}}
+                          internal slot of |publicKey| as the EC public key.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |secret| be a [= byte sequence =] containing
+                          the result of applying the field element to
+                          octet string conversion defined in Section
+                          6.2 of [[RFC6090]]
+                          to the output of the ECDH primitive.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>
+                    If the {{EcKeyAlgorithm/namedCurve}} property of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| is a value specified in an
+                    <a href="#dfn-applicable-specification">applicable specification</a> that
+                    specifies the use of that value with ECDH:
+                  </dt>
+                  <dd>
+                    <p>
+                      Perform the [= ECDH
+                      derivation steps =] specified in that specification, passing in
+                      |key| and |publicKey| and resulting in |secret|.
+                    </p>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
+                      [= exception/throw =] a
+                      {{NotSupportedError}}
+                    </p>
+                  </dd>
+                </dl>
+
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] a
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |length| is null:</dt>
+                  <dd>Return |secret|</dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <dl class="switch">
+                      <dt>
+                        If the [= length in bits =] of |secret| is less than
+                        |length|:
+                      </dt>
+                      <dd>
+                        [= exception/throw =] an
+                        {{OperationError}}.
+                      </dd>
+                      <dt>Otherwise:</dt>
+                      <dd>
+                        Return a [= byte sequence containing =] the first |length| bits of |secret|.
+                      </dd>
+                    </dl>
+                  </dd>
+                </dl>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ecdh-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| is not empty
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |spki| be the result of running the
+                          [= parse a subjectPublicKeyInfo =]
+                          algorithm over |keyData|
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `algorithm` AlgorithmIdentifier field of |spki| is
+                          not equal to the `id-ecPublicKey`
+                          object identifier defined in [[RFC5480]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the `algorithm`
+                          AlgorithmIdentifier field of |spki| is absent,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |params| be the `parameters` field of the
+                          `algorithm` AlgorithmIdentifier field of |spki|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |params| is not an instance of the
+                          `ECParameters` ASN.1 type defined in
+                          [[RFC5480]] that specifies a
+                          `namedCurve`, then [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |namedCurve| be a string whose initial value is
+                          undefined.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |params| is equivalent to the `secp256r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-256`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp384r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-384`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp521r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| "`P-521`".
+                            </p>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |namedCurve| is not undefined:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |publicKey| be the Elliptic Curve public key identified by
+                                  performing the conversion steps defined in Section 2.3.4 of [[SEC1]] to the `subjectPublicKey` field of
+                                  |spki|.
+                                </p>
+                                <p>
+                                  The uncompressed point format MUST be supported.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the implementation does not support the compressed point format and
+                                  a compressed point is provided,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If a decode error occurs or an identity point is found,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}}
+                                  that represents |publicKey|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDH key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |spki|
+                                  and obtaining |namedCurve| and |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the key value is not a valid point on the Elliptic Curve
+                          identified by the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{EcKeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDH`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to |namedCurve|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                          "`deriveKey`" or "`deriveBits`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |privateKeyInfo| be the result of running the
+                          [= parse a privateKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurs while parsing,
+                          [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                          |privateKeyInfo| is not equal to the
+                          `id-ecPublicKey` object identifier
+                          defined in [[RFC5480]],
+                          [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `parameters` field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                          of |privateKeyInfo| is not present,
+                          [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |params| be the `parameters` field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                          of |privateKeyInfo|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |params| is not an instance of the
+                          `ECParameters` ASN.1 type defined in
+                          [[RFC5480]] that specifies a
+                          `namedCurve`, then [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |namedCurve| be a string whose initial value is
+                          undefined.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |params| is equivalent to the `secp256r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| to "`P-256`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp384r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| to "`P-384`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |params| is equivalent to the `secp521r1`
+                            object identifier defined in [[RFC5480]]:
+                          </dt>
+                          <dd>
+                            <p>
+                              Set |namedCurve| to "`P-521`".
+                            </p>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |namedCurve| is not undefined:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |ecPrivateKey| be the result of performing the
+                                  [= parse an ASN.1 structure =]
+                                  algorithm, with |data| as the `privateKey` field
+                                  of |privateKeyInfo|, |structure| as the ASN.1
+                                  `ECPrivateKey` structure specified in Section 3 of
+                                  [[RFC5915]], and |exactData| set to true.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred while parsing,
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the `parameters` field of |ecPrivateKey| is
+                                  present, and is not an instance of the `namedCurve` ASN.1
+                                  type defined in [[RFC5480]], or does not contain
+                                  the same object identifier as the `parameters` field of the
+                                  `privateKeyAlgorithm` PrivateKeyAlgorithmIdentifier field
+                                  of |privateKeyInfo|,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}}
+                                  that represents the Elliptic Curve private key identified by
+                                  performing the conversion steps defined in Section 3 of [[RFC5915]] using |ecPrivateKey|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDH key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |privateKeyInfo|
+                                  and obtaining |namedCurve| and |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |namedCurve| is defined, and not equal to the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the key value is not a valid point on the Elliptic Curve
+                          identified by the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to {{KeyType/"private"}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{EcKeyAlgorithm}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDH`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to |namedCurve|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field is present and if |usages|
+                          contains an entry which is not
+                          "`deriveKey`" or "`deriveBits`"
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field is not present and if |usages| is not
+                          empty
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is
+                          not "`EC`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present
+                          and is not equal to "`enc`" then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of JSON Web
+                          Key [[JWK]], or it does not contain all of the specified |usages|
+                          values, then [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |namedCurve| be a string whose value is equal to the
+                          {{JsonWebKey/crv}} field of |jwk|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |namedCurve| is not equal to the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |namedCurve| is "`P-256`",
+                            "`P-384`" or "`P-521`":
+                          </dt>
+                          <dd>
+                            <dl class="switch">
+                              <dt>If the {{JsonWebKey/d}} field is present:</dt>
+                              <dd>
+                                <ol>
+                                  <li>
+                                    <p>
+                                      If |jwk| does not meet the requirements of Section
+                                      6.2.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p>
+                                      Let |key| be a new {{CryptoKey}} object that represents the
+                                      Elliptic Curve private key identified by interpreting
+                                      |jwk| according to Section 6.2.2 of JSON Web Algorithms [[JWA]].
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p>
+                                      Set the {{CryptoKey/[[type]]}}
+                                      internal slot of |Key| to {{KeyType/"private"}}.
+                                    </p>
+                                  </li>
+                                </ol>
+                              </dd>
+                              <dt>Otherwise:</dt>
+                              <dd>
+                                <ol>
+                                  <li>
+                                    <p>
+                                      If |jwk| does not meet the requirements of Section
+                                      6.2.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p>
+                                      Let |key| be a new {{CryptoKey}} object that represents the
+                                      Elliptic Curve public key identified by interpreting
+                                      |jwk| according to Section 6.2.1 of JSON Web Algorithms [[JWA]].
+                                    </p>
+                                  </li>
+                                  <li>
+                                    <p>
+                                      Set the {{CryptoKey/[[type]]}}
+                                      internal slot of |Key| to "`public`".
+                                    </p>
+                                  </li>
+                                </ol>
+                              </dd>
+                            </dl>
+                          </dd>
+                          <dt>Otherwise</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDH key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |jwk|
+                                  and obtaining |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the key value is not a valid point on the Elliptic Curve
+                          identified by the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm| [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new instance of an {{EcKeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDH`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to |namedCurve|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{EcKeyImportParams/namedCurve}}
+                          member of |normalizedAlgorithm| is not a
+                          <a href="#dfn-NamedCurve">named curve</a>,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is not the empty list,
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |namedCurve| is "`P-256`",
+                            "`P-384`" or "`P-521`":
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |Q| be the Elliptic Curve public key on the curve identified
+                                  by the {{EcKeyImportParams/namedCurve}}
+                                  member of |normalizedAlgorithm| identified by performing
+                                  the conversion steps defined in Section 2.3.4 of [[SEC1]] to |keyData|.
+                                </p>
+                                <p>
+                                  The uncompressed point format MUST be supported.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the implementation does not support the compressed point format and
+                                  a compressed point is provided,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If a decode error occurs or an identity point is found,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}}
+                                  that represents |Q|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDH key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |keyData|
+                                  and obtaining |key|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occured or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Let |algorithm| be a new {{EcKeyAlgorithm}} object.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{KeyAlgorithm/name}} attribute of
+                          |algorithm| to "`ECDH`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{EcKeyAlgorithm/namedCurve}}
+                          attribute of |algorithm| to equal the {{EcKeyImportParams/namedCurve}} member of
+                          |normalizedAlgorithm|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot
+                          of |key| to "`public`"
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[algorithm]]}}
+                          internal slot of |key| to |algorithm|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |key|
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="ecdh-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |key| be the {{CryptoKey}} to be
+                  exported.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `SubjectPublicKeyInfo`
+                          ASN.1 structure defined in [[RFC5280]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| field to an
+                              `AlgorithmIdentifier` ASN.1 type with the following
+                              properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `id-ecPublicKey` defined in
+                                  [[RFC5480]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |parameters| field to an instance of the
+                                  `ECParameters` ASN.1 type defined in
+                                  [[RFC5480]] as follows:
+                                </p>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}}
+                                    internal slot of |key| is "`P-256`",
+                                    "`P-384`" or "`P-521`":
+                                  </dt>
+                                  <dd>
+                                    <p>
+                                      Let |keyData| be the [= byte sequence =] that
+                                      represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                                      |key| according to the encoding rules specified in
+                                      Section 2.3.3 of [[SEC1]] and using the
+                                      uncompressed form.
+                                    </p>
+                                    <dl class="switch">
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-256`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the |namedCurve| choice
+                                          with value equal to the object identifier
+                                          `secp256r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-384`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the |namedCurve| choice
+                                          with value equal to the object identifier
+                                          `secp384r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-521`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the |namedCurve| choice
+                                          with value equal to the object identifier
+                                          `secp521r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                    </dl>
+                                  </dd>
+                                  <dt>
+                                    Otherwise:
+                                  </dt>
+                                  <dd>
+                                    <ol>
+                                      <li>
+                                        <p>
+                                          Perform any [= ECDH key export steps | key export steps =]
+                                          defined by <a href="#dfn-applicable-specification">other applicable
+                                          specifications</a>, passing |format| and the
+                                          {{EcKeyAlgorithm/namedCurve}} attribute of
+                                          the {{CryptoKey/[[algorithm]]}}
+                                          internal slot of |key|
+                                          and obtaining |namedCurveOid| and |keyData|.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier |namedCurveOid|.
+                                        </p>
+                                      </li>
+                                    </ol>
+                                  </dd>
+                                </dl>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |subjectPublicKey| field to |keyData|
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `PrivateKeyInfo`
+                          ASN.1 structure defined in [[RFC5208]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |version| field to `0`.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKeyAlgorithm| field to a
+                              `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                              following properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `id-ecPublicKey` defined in
+                                  [[RFC5480]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |parameters| field to an instance of the
+                                  `ECParameters` ASN.1 type defined in
+                                  [[RFC5480]] as follows:
+                                </p>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}}
+                                    internal slot of |key| is "`P-256`",
+                                    "`P-384`" or "`P-521`":
+                                  </dt>
+                                  <dd>
+                                    <p>
+                                      Let |keyData| be the result of DER-encoding
+                                      an instance of the `ECPrivateKey` structure defined in
+                                      Section 3 of [[RFC5915]] for the Elliptic
+                                      Curve private key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                                      |key| and that conforms to the following:
+                                    </p>
+                                    <ul>
+                                      <li>
+                                        <p>
+                                          The |parameters| field is present, and is equivalent
+                                          to the |parameters| field of the
+                                          |privateKeyAlgorithm| field of this
+                                          `PrivateKeyInfo` ASN.1 structure.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          The |publicKey| field is present and represents the
+                                          Elliptic Curve public key associated with the Elliptic Curve
+                                          private key represented by the {{CryptoKey/[[handle]]}} internal slot
+                                          of |key|.
+                                        </p>
+                                      </li>
+                                    </ul>
+                                    <dl class="switch">
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-256`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the |namedCurve| choice
+                                          with value equal to the object identifier
+                                          `secp256r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-384`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the |namedCurve| choice
+                                          with value equal to the object identifier
+                                          `secp384r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                      <dt>
+                                        If the {{EcKeyAlgorithm/namedCurve}}
+                                        attribute of the {{CryptoKey/[[algorithm]]}}
+                                        internal slot of |key| is "`P-521`":
+                                      </dt>
+                                      <dd>
+                                        <p>
+                                          Set |parameters| to the |namedCurve| choice
+                                          with value equal to the object identifier
+                                          `secp521r1` defined in [[RFC5480]]
+                                        </p>
+                                      </dd>
+                                    </dl>
+                                  </dd>
+                                  <dt>
+                                    Otherwise:
+                                  </dt>
+                                  <dd>
+                                    <ol>
+                                      <li>
+                                        <p>
+                                          Perform any [= ECDH key export steps | key export steps =]
+                                          defined by <a href="#dfn-applicable-specification">other applicable
+                                          specifications</a>, passing |format| and the
+                                          {{EcKeyAlgorithm/namedCurve}} attribute of
+                                          the {{CryptoKey/[[algorithm]]}}
+                                          internal slot of |key|
+                                          and obtaining |namedCurveOid| and |keyData|.
+                                        </p>
+                                      </li>
+                                      <li>
+                                        <p>
+                                          Set |parameters| to the `namedCurve` choice
+                                          with value equal to the object identifier |namedCurveOid|.
+                                        </p>
+                                      </li>
+                                    </ol>
+                                  </dd>
+                                </dl>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKey| field to |keyData|.
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to
+                          "`EC`".
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{EcKeyAlgorithm/namedCurve}}
+                            attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                            of |key| is "`P-256`", "`P-384`"
+                            or "`P-521`":
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                                    of |key| is "`P-256`":
+                                  </dt>
+                                  <dd>
                                     Set the {{JsonWebKey/crv}} attribute of |jwk| to
-                                    |namedCurve|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to the
-                            {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>
-                      If |format| is {{KeyFormat/"raw"}}:
-                    </dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot
-                            of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{EcKeyAlgorithm/namedCurve}}
-                              attribute of the {{CryptoKey/[[algorithm]]}} internal slot
-                              of |key| is "`P-256`", "`P-384`"
-                              or "`P-521`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Let |data| be the [= byte sequence =] that
-                                represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key| according to the encoding rules specified in
-                                Section 2.3.3 of [[SEC1]] and using the
-                                uncompressed form.
-                              </p>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <p>
-                                Perform any [= ECDH key export steps | key export steps =]
-                                defined by <a href="#dfn-applicable-specification">other applicable
-                                specifications</a>, passing |format| and the
-                                {{EcKeyAlgorithm/namedCurve}} attribute of
-                                the {{CryptoKey/[[algorithm]]}}
-                                internal slot of |key|
-                                and obtaining |namedCurve| and |data|.
-                              </p>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                                    "`P-256`"
+                                  </dd>
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                                    of |key| is "`P-384`":
+                                  </dt>
+                                  <dd>
+                                    Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                    "`P-384`"
+                                  </dd>
+                                  <dt>
+                                    If the {{EcKeyAlgorithm/namedCurve}}
+                                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                                    of |key| is "`P-521`":
+                                  </dt>
+                                  <dd>
+                                    Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                    "`P-521`"
+                                  </dd>
+                                </dl>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{JsonWebKey/x}} attribute of |jwk| according to the
+                                  definition in Section 6.2.1.2 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{JsonWebKey/y}} attribute of |jwk| according to the
+                                  definition in Section 6.2.1.3 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <dl class="switch">
+                                  <dt>
+                                    If the {{CryptoKey/[[type]]}} internal slot
+                                    of |key| is {{KeyType/"private"}}
+                                  </dt>
+                                  <dd>
+                                    <p>
+                                      Set the {{JsonWebKey/d}} attribute of |jwk| according to the
+                                      definition in Section 6.2.2.1 of JSON Web Algorithms [[JWA]].
+                                    </p>
+                                  </dd>
+                                </dl>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>
+                            Otherwise:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= ECDH key export steps | key export steps =]
+                                  defined by <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format| and the
+                                  {{EcKeyAlgorithm/namedCurve}} attribute of
+                                  the {{CryptoKey/[[algorithm]]}}
+                                  internal slot of |key|
+                                  and obtaining |namedCurve| and a new value of |jwk|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{JsonWebKey/crv}} attribute of |jwk| to
+                                  |namedCurve|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to the
+                          {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>
+                    If |format| is {{KeyFormat/"raw"}}:
+                  </dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot
+                          of |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{EcKeyAlgorithm/namedCurve}}
+                            attribute of the {{CryptoKey/[[algorithm]]}} internal slot
+                            of |key| is "`P-256`", "`P-384`"
+                            or "`P-521`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Let |data| be the [= byte sequence =] that
+                              represents the Elliptic Curve public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key| according to the encoding rules specified in
+                              Section 2.3.3 of [[SEC1]] and using the
+                              uncompressed form.
+                            </p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <p>
+                              Perform any [= ECDH key export steps | key export steps =]
+                              defined by <a href="#dfn-applicable-specification">other applicable
+                              specifications</a>, passing |format| and the
+                              {{EcKeyAlgorithm/namedCurve}} attribute of
+                              the {{CryptoKey/[[algorithm]]}}
+                              internal slot of |key|
+                              and obtaining |namedCurve| and |data|.
+                            </p>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13828,428 +13828,438 @@ dictionary AesGcmParams : Algorithm {
         </section>
         <section id="aes-kw-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Wrap Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |plaintext| is not a multiple of 64 bits in length,
-                            then [= exception/throw =] an
-                            {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |ciphertext| be the result of performing the Key Wrap
-                    operation described in Section 2.2.1 of [[RFC3394]]
-                    with |plaintext| as the plaintext to be wrapped and using the default
-                    Initial Value defined in Section 2.2.3.1 of the same document.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |ciphertext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Unwrap Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |plaintext| be the result of performing the Key Unwrap
-                    operation described in Section 2.2.2 of [[RFC3394]] with
-                    |ciphertext| as the input ciphertext and using the default Initial
-                    Value defined in Section 2.2.3.1 of the same document.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the Key Unwrap operation returns an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |plaintext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains any entry which is not one of
-                    "`wrapKey`" or "`unwrapKey`", then [= exception/throw =] a {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the {{AesKeyGenParams/length}} property of
-                    |normalizedAlgorithm| is not equal to one of 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Generate an AES key of length
-                    equal to the {{AesKeyGenParams/length}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the key generation step fails,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new
-                    {{CryptoKey}} object representing the
-                    generated AES key.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-KW`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to equal the
-                    {{AesKeyGenParams/length}} property of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal
-                    slot of |key| to be |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |key| to be |usages|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                     one of "`wrapKey`" or "`unwrapKey`",
 
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the [= length in bits =] of |data| is not 128, 192 or 256
+          <section id="aes-kw-operations-wrap-key">
+            <h5>Wrap Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |plaintext| is not a multiple of 64 bits in length,
+                          then [= exception/throw =] an
+                          {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |ciphertext| be the result of performing the Key Wrap
+                  operation described in Section 2.2.1 of [[RFC3394]]
+                  with |plaintext| as the plaintext to be wrapped and using the default
+                  Initial Value defined in Section 2.2.3.1 of the same document.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |ciphertext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-kw-operations-unwrap-key">
+            <h5>Unwrap Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |plaintext| be the result of performing the Key Unwrap
+                  operation described in Section 2.2.2 of [[RFC3394]] with
+                  |ciphertext| as the input ciphertext and using the default Initial
+                  Value defined in Section 2.2.3.1 of the same document.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the Key Unwrap operation returns an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |plaintext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-kw-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains any entry which is not one of
+                  "`wrapKey`" or "`unwrapKey`", then [= exception/throw =] a {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{AesKeyGenParams/length}} property of
+                  |normalizedAlgorithm| is not equal to one of 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Generate an AES key of length
+                  equal to the {{AesKeyGenParams/length}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the key generation step fails,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new
+                  {{CryptoKey}} object representing the
+                  generated AES key.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-KW`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to equal the
+                  {{AesKeyGenParams/length}} property of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal
+                  slot of |key| to be |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |key| to be |usages|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-kw-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                   one of "`wrapKey`" or "`unwrapKey`",
+
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the [= length in bits =] of |data| is not 128, 192 or 256
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not
+                          "`oct`",
                             then [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not
-                            "`oct`",
-                              then [= exception/throw =] a
-                              {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |jwk| does not meet the requirements of
-                            Section 6.4 of JSON Web Algorithms [[JWA]],
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |jwk| does not meet the requirements of
+                          Section 6.4 of JSON Web Algorithms [[JWA]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be the [= byte sequence =] obtained by decoding the
+                          {{JsonWebKey/k}} field of |jwk|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the [= length in bits =] of |data| is 128:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A128KW`",
+                            then [= exception/throw =] a
+                            {{DataError}}.</dd>
+                          <dt>If the [= length in bits =] of |data| is 192:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A192KW`",
+                            then [= exception/throw =] a
+                            {{DataError}}.</dd>
+                          <dt>If the [= length in bits =] of |data| is 256:</dt>
+                          <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
+                          not  "`A256KW`",
+                            then [= exception/throw =] a
+                            {{DataError}}.</dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            [= exception/throw =] a
+                            {{DataError}}.
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not  "`enc`",
                             then [= exception/throw =] a
                             {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be the [= byte sequence =] obtained by decoding the
-                            {{JsonWebKey/k}} field of |jwk|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the [= length in bits =] of |data| is 128:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A128KW`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>If the [= length in bits =] of |data| is 192:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A192KW`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>If the [= length in bits =] of |data| is 256:</dt>
-                            <dd>If the {{JsonWebKey/alg}} field of |jwk| is present, and is
-                            not  "`A256KW`",
-                              then [= exception/throw =] a
-                              {{DataError}}.</dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              [= exception/throw =] a
-                              {{DataError}}.
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not  "`enc`",
-                              then [= exception/throw =] a
-                              {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
-                              then [= exception/throw =] a
-                              {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                              then [= exception/throw =] a
-                              {{DataError}}.                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                            then [= exception/throw =] a
+                            {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                            then [= exception/throw =] a
+                            {{DataError}}.                          </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |key| be a new {{CryptoKey}}
+                  representing an AES key with value |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |key| to {{KeyType/"secret"}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{AesKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`AES-KW`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{AesKeyAlgorithm/length}} attribute of
+                  |algorithm| to the length, in bits, of |data|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal
+                  slot of |key| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |key|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-kw-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |data| be a [= byte sequence =] containing
+                          the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to the
+                          string "`oct`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
+                          containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                          |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 128:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A128KW`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 192:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A192KW`".</dd>
+                          <dt>If the {{AesKeyAlgorithm/length}} attribute of
+                          |key| is 256:</dt>
+                          <dd>Set the `alg` attribute of |jwk| to
+                          the string "`A256KW`".</dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to equal the
+                          {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
                       {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |key| be a new {{CryptoKey}}
-                    representing an AES key with value |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |key| to {{KeyType/"secret"}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{AesKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`AES-KW`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{AesKeyAlgorithm/length}} attribute of
-                    |algorithm| to the length, in bits, of |data|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal
-                    slot of |key| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |key|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"raw"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |data| be a [= byte sequence =] containing
-                            the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to the
-                            string "`oct`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{JsonWebKey/k}} attribute of |jwk| to be a string
-                            containing the raw octets of the key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                            |key|, encoded according to Section 6.4 of JSON Web Algorithms [[JWA]].
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 128:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A128KW`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 192:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A192KW`".</dd>
-                            <dt>If the {{AesKeyAlgorithm/length}} attribute of
-                            |key| is 256:</dt>
-                            <dd>Set the `alg` attribute of |jwk| to
-                            the string "`A256KW`".</dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to equal the
-                            {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to equal the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Get key length</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return the {{AesDerivedKeyParams/length}} member of
-                    |normalizedDerivedKeyAlgorithm|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="aes-kw-operations-get-key-length">
+            <h5>Get key length</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm| is not 128, 192 or 256, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return the {{AesDerivedKeyParams/length}} member of
+                  |normalizedDerivedKeyAlgorithm|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -5992,968 +5992,974 @@ dictionary RsaOaepParams : Algorithm {
         </section>
         <section id="rsa-oaep-operations">
           <h4>Operations</h4>
-          <dl>
-            <dt>Encrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of |key|
-                    is not "`public`",
-                    then [= exception/throw =] an
-                    {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |label| be the {{RsaOaepParams/label}} member of
-                    |normalizedAlgorithm| or the empty byte sequence if the
-                    {{RsaOaepParams/label}} member of
-                    |normalizedAlgorithm| is not present.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Perform the encryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by |key|
-                    as the recipient's RSA public key, |plaintext|
-                    as the message to be encrypted, |M| and |label|
-                    as the label, |L|, and with the hash
-                    function specified by the {{RsaHashedKeyAlgorithm/hash}}
-                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| as the Hash option and MGF1 (defined in Section B.2.1 of
-                    [[RFC3447]]) as the MGF option.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |ciphertext| be the value |C| that results from performing the
-                    operation.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |ciphertext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Decrypt</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If the {{CryptoKey/[[type]]}} internal slot of |key|
-                    is not {{KeyType/"private"}},
-                    then [= exception/throw =] an
-                    {{InvalidAccessError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |label| be the {{RsaOaepParams/label}} member of
-                    |normalizedAlgorithm| or the empty byte sequence if the
-                    {{RsaOaepParams/label}} member of
-                    |normalizedAlgorithm| is not present.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Perform the decryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by |key|
-                    as the recipient's RSA private key, |ciphertext|
-                    as the ciphertext to be decrypted, C, and |label|
-                    as the label, |L|, and with the hash
-                    function specified by the {{RsaHashedKeyAlgorithm/hash}}
-                    attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| as the Hash option and MGF1 (defined in Section B.2.1 of
-                    [[RFC3447]]) as the MGF option.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |plaintext| the value |M| that results from performing the
-                    operation.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |plaintext|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-            <dt>Generate Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    If |usages| contains an entry which is not
-                    "`encrypt`", "`decrypt`",
-                    "`wrapKey`" or "`unwrapKey`",
-                    then [= exception/throw =] a
-                    {{SyntaxError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
-                    {{RsaKeyGenParams/modulusLength}} member of
-                    |normalizedAlgorithm| and RSA public exponent equal to the
-                    {{RsaKeyGenParams/publicExponent}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If performing the operation results in an error,
-                    then [= exception/throw =] an
-                    {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{RsaHashedKeyAlgorithm}}
-                    object.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`RSA-OAEP`".
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the
-                    {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of |algorithm| to equal the
-                    {{RsaKeyGenParams/modulusLength}}
-                    member of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the
-                    {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of |algorithm| to equal the
-                    {{RsaKeyGenParams/publicExponent}}
-                    member of |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaHashedKeyAlgorithm/hash}} attribute
-                    of |algorithm| to equal the
-                    {{RsaHashedKeyGenParams/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |publicKey| be a new {{CryptoKey}}
-                    representing the public key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |publicKey| to "`public`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |publicKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal slot of
-                    |publicKey| to true.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |publicKey| to be the
-                    [= usage intersection =] of
-                    |usages| and `[ "encrypt", "wrapKey" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |privateKey| be a new {{CryptoKey}}
-                    representing the private key of the generated key pair.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[type]]}} internal slot of
-                    |privateKey| to {{KeyType/"private"}}
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |privateKey| to |algorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[extractable]]}} internal slot of
-                    |privateKey| to |extractable|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[usages]]}} internal slot of
-                    |privateKey| to be the
-                    [= usage intersection =] of
-                    |usages| and `[ "decrypt", "unwrapKey" ]`.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Let |result| be a new {{CryptoKeyPair}}
-                    dictionary.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/publicKey}} attribute
-                    of |result| to be |publicKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKeyPair/privateKey}} attribute
-                    of |result| to be |privateKey|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
 
-            <dt>Import Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>Let |keyData| be the key data to be imported.</p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                            "`encrypt`" or
-                            "`wrapKey`",
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |spki| be the result of running the
-                            [= parse a subjectPublicKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `algorithm` AlgorithmIdentifier field of |spki| is
-                            not equal to the `rsaEncryption`
-                            object identifier defined in [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the
-                            `subjectPublicKeyInfo` field of |spki|,
-                            |structure| as the `RSAPublicKey` structure
-                            specified in Section A.1.1 of [[RFC3447]], and
-                            |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, or it can be determined that |publicKey|
-                            is not a valid public key according to [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the RSA public key identified by
-                            |publicKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot of
-                            |key| to "`public`"
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If |usages| contains an entry which is not
-                            "`decrypt`" or "`unwrapKey`",
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |privateKeyInfo| be the result of running the
-                            [= parse a privateKeyInfo =]
-                            algorithm over |keyData|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, then [= exception/throw =] a {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the `algorithm` object identifier field of the
-                            `privateKeyAlgorithm` PrivateKeyAlgorithm field of
-                            |privateKeyInfo| is not equal to the
-                            `rsaEncryption` object identifier defined in [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
-                            algorithm, with |data| as the
-                            `privateKey` field of |privateKeyInfo|,
-                            |structure| as the `RSAPrivateKey` structure
-                            specified in Section A.1.2 of [[RFC3447]], and
-                            |exactData| set to true.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If an error occurred while parsing, or if |rsaPrivateKey| is not
-                            a valid RSA private key according to [[RFC3447]],
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |key| be a new {{CryptoKey}}
-                            that represents the RSA private key identified by
-                            |rsaPrivateKey|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the {{CryptoKey/[[type]]}} internal slot of
-                            |key| to {{KeyType/"private"}}
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <dl class="switch">
-                            <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
-                            <dd><p>Let |jwk| equal |keyData|.</p></dd>
-                            <dt>Otherwise:</dt>
-                            <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field of |jwk| is present and
-                            |usages| contains an entry which is not
-                            "`decrypt`" or "`unwrapKey`",
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/d}} field of |jwk| is not present and
-                            |usages| contains an entry which is not
-                            "`encrypt`" or "`wrapKey`",
-                            then [= exception/throw =] a
-                            {{SyntaxError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/kty}} field of |jwk| is not a
-                            case-sensitive string match to "`RSA`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                            not a case-sensitive string match to "`enc`",
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
-                            is invalid according to the requirements of
-                            JSON Web Key [[JWK]] or
-                            does not contain all of the specified |usages| values,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            If the {{JsonWebKey/ext}} field of |jwk| is present and
-                            has the value false and |extractable| is true,
-                            then [= exception/throw =] a
-                            {{DataError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the `alg` field of |jwk| is not present:</dt>
-                            <dd>Let |hash| be undefined.</dd>
-                            <dt>
-                              If the `alg` field of |jwk| is equal to
-                              "`RSA-OAEP`":
-                            </dt>
-                            <dd>Let |hash| be the string "`SHA-1`".</dd>
-                            <dt>
-                              If the `alg` field of |jwk| is equal to
-                              "`RSA-OAEP-256`":
-                            </dt>
-                            <dd>Let |hash| be the string "`SHA-256`".</dd>
-                            <dt>
-                              If the `alg` field of |jwk| is equal to
-                              "`RSA-OAEP-384`":
-                            </dt>
-                            <dd>Let |hash| be the string "`SHA-384`".</dd>
-                            <dt>
-                              If the `alg` field of |jwk| is equal to
-                              "`RSA-OAEP-512`":
-                            </dt>
-                            <dd>Let |hash| be the string "`SHA-512`".</dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= RSA-OAEP key import steps | key import steps =] defined by
-                                    <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format|, |jwk|
-                                    and obtaining |hash|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If an error occurred or there are no
-                                    <a href="#dfn-applicable-specification">applicable
-                                    specifications</a>,
-                                    [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl>
-                            <dt>
-                              If |hash| is not undefined:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Let |normalizedHash| be the result of
-                                    <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
-                                    with `alg` set to |hash| and `op` set
-                                    to `digest`.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |normalizedHash| is not equal to the
-                                    {{RsaHashedImportParams/hash}} member of
-                                    |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of Section
-                                    6.3.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |privateKey| represent the
-                                    RSA private key identified by interpreting |jwk|
-                                    according to Section 6.3.2 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |privateKey| can be determined to not be a valid RSA private key
-                                    according to [[RFC3447]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} representing |privateKey|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}} internal slot of
-                                    |key| to {{KeyType/"private"}}
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    If |jwk| does not meet the requirements of Section
-                                    6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |publicKey| represent the
-                                    RSA public key identified by interpreting |jwk|
-                                    according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If |publicKey| can be determined to not be a valid RSA public key
-                                    according to [[RFC3447]],
-                                    then [= exception/throw =] a
-                                    {{DataError}}.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Let |key| be a new {{CryptoKey}} representing |publicKey|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the {{CryptoKey/[[type]]}} internal slot of
-                                    |key| to "`public`"
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise:</dt>
-                    <dd>
+          <section id="rsa-oaep-operations-encrypt">
+            <h5>Encrypt</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of |key|
+                  is not "`public`",
+                  then [= exception/throw =] an
+                  {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |label| be the {{RsaOaepParams/label}} member of
+                  |normalizedAlgorithm| or the empty byte sequence if the
+                  {{RsaOaepParams/label}} member of
+                  |normalizedAlgorithm| is not present.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the encryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by |key|
+                  as the recipient's RSA public key, |plaintext|
+                  as the message to be encrypted, |M| and |label|
+                  as the label, |L|, and with the hash
+                  function specified by the {{RsaHashedKeyAlgorithm/hash}}
+                  attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| as the Hash option and MGF1 (defined in Section B.2.1 of
+                  [[RFC3447]]) as the MGF option.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |ciphertext| be the value |C| that results from performing the
+                  operation.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |ciphertext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsa-oaep-operations-decrypt">
+            <h5>Decrypt</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of |key|
+                  is not {{KeyType/"private"}},
+                  then [= exception/throw =] an
+                  {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |label| be the {{RsaOaepParams/label}} member of
+                  |normalizedAlgorithm| or the empty byte sequence if the
+                  {{RsaOaepParams/label}} member of
+                  |normalizedAlgorithm| is not present.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the decryption operation defined in Section 7.1 of [[RFC3447]] with the key represented by |key|
+                  as the recipient's RSA private key, |ciphertext|
+                  as the ciphertext to be decrypted, C, and |label|
+                  as the label, |L|, and with the hash
+                  function specified by the {{RsaHashedKeyAlgorithm/hash}}
+                  attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| as the Hash option and MGF1 (defined in Section B.2.1 of
+                  [[RFC3447]]) as the MGF option.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |plaintext| the value |M| that results from performing the
+                  operation.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |plaintext|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsa-oaep-operations-generate-key">
+            <h5>Generate Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  If |usages| contains an entry which is not
+                  "`encrypt`", "`decrypt`",
+                  "`wrapKey`" or "`unwrapKey`",
+                  then [= exception/throw =] a
+                  {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Generate an RSA key pair, as defined in [[RFC3447]], with RSA modulus length equal to the
+                  {{RsaKeyGenParams/modulusLength}} member of
+                  |normalizedAlgorithm| and RSA public exponent equal to the
+                  {{RsaKeyGenParams/publicExponent}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If performing the operation results in an error,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{RsaHashedKeyAlgorithm}}
+                  object.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`RSA-OAEP`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the
+                  {{RsaKeyAlgorithm/modulusLength}}
+                  attribute of |algorithm| to equal the
+                  {{RsaKeyGenParams/modulusLength}}
+                  member of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the
+                  {{RsaKeyAlgorithm/publicExponent}}
+                  attribute of |algorithm| to equal the
+                  {{RsaKeyGenParams/publicExponent}}
+                  member of |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaHashedKeyAlgorithm/hash}} attribute
+                  of |algorithm| to equal the
+                  {{RsaHashedKeyGenParams/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |publicKey| be a new {{CryptoKey}}
+                  representing the public key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |publicKey| to "`public`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |publicKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal slot of
+                  |publicKey| to true.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |publicKey| to be the
+                  [= usage intersection =] of
+                  |usages| and `[ "encrypt", "wrapKey" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |privateKey| be a new {{CryptoKey}}
+                  representing the private key of the generated key pair.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[type]]}} internal slot of
+                  |privateKey| to {{KeyType/"private"}}
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |privateKey| to |algorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[extractable]]}} internal slot of
+                  |privateKey| to |extractable|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[usages]]}} internal slot of
+                  |privateKey| to be the
+                  [= usage intersection =] of
+                  |usages| and `[ "decrypt", "unwrapKey" ]`.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |result| be a new {{CryptoKeyPair}}
+                  dictionary.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/publicKey}} attribute
+                  of |result| to be |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKeyPair/privateKey}} attribute
+                  of |result| to be |privateKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsa-oaep-operations-import-key">
+            <h5>Import Key</h5>
+
+            <ol>
+              <li>
+                <p>Let |keyData| be the key data to be imported.</p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                          "`encrypt`" or
+                          "`wrapKey`",
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |spki| be the result of running the
+                          [= parse a subjectPublicKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `algorithm` AlgorithmIdentifier field of |spki| is
+                          not equal to the `rsaEncryption`
+                          object identifier defined in [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |publicKey| be the result of performing the [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the
+                          `subjectPublicKeyInfo` field of |spki|,
+                          |structure| as the `RSAPublicKey` structure
+                          specified in Section A.1.1 of [[RFC3447]], and
+                          |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, or it can be determined that |publicKey|
+                          is not a valid public key according to [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the RSA public key identified by
+                          |publicKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot of
+                          |key| to "`public`"
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If |usages| contains an entry which is not
+                          "`decrypt`" or "`unwrapKey`",
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |privateKeyInfo| be the result of running the
+                          [= parse a privateKeyInfo =]
+                          algorithm over |keyData|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, then [= exception/throw =] a {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the `algorithm` object identifier field of the
+                          `privateKeyAlgorithm` PrivateKeyAlgorithm field of
+                          |privateKeyInfo| is not equal to the
+                          `rsaEncryption` object identifier defined in [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |rsaPrivateKey| be the result of performing the [= parse an ASN.1 structure =]
+                          algorithm, with |data| as the
+                          `privateKey` field of |privateKeyInfo|,
+                          |structure| as the `RSAPrivateKey` structure
+                          specified in Section A.1.2 of [[RFC3447]], and
+                          |exactData| set to true.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If an error occurred while parsing, or if |rsaPrivateKey| is not
+                          a valid RSA private key according to [[RFC3447]],
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |key| be a new {{CryptoKey}}
+                          that represents the RSA private key identified by
+                          |rsaPrivateKey|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the {{CryptoKey/[[type]]}} internal slot of
+                          |key| to {{KeyType/"private"}}
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <dl class="switch">
+                          <dt>If |keyData| is a {{JsonWebKey}} dictionary:</dt>
+                          <dd><p>Let |jwk| equal |keyData|.</p></dd>
+                          <dt>Otherwise:</dt>
+                          <dd><p>[= exception/Throw =] a {{DataError}}.</p></dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field of |jwk| is present and
+                          |usages| contains an entry which is not
+                          "`decrypt`" or "`unwrapKey`",
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/d}} field of |jwk| is not present and
+                          |usages| contains an entry which is not
+                          "`encrypt`" or "`wrapKey`",
+                          then [= exception/throw =] a
+                          {{SyntaxError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/kty}} field of |jwk| is not a
+                          case-sensitive string match to "`RSA`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
+                          not a case-sensitive string match to "`enc`",
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/key_ops}} field of |jwk| is present, and
+                          is invalid according to the requirements of
+                          JSON Web Key [[JWK]] or
+                          does not contain all of the specified |usages| values,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If the {{JsonWebKey/ext}} field of |jwk| is present and
+                          has the value false and |extractable| is true,
+                          then [= exception/throw =] a
+                          {{DataError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the `alg` field of |jwk| is not present:</dt>
+                          <dd>Let |hash| be undefined.</dd>
+                          <dt>
+                            If the `alg` field of |jwk| is equal to
+                            "`RSA-OAEP`":
+                          </dt>
+                          <dd>Let |hash| be the string "`SHA-1`".</dd>
+                          <dt>
+                            If the `alg` field of |jwk| is equal to
+                            "`RSA-OAEP-256`":
+                          </dt>
+                          <dd>Let |hash| be the string "`SHA-256`".</dd>
+                          <dt>
+                            If the `alg` field of |jwk| is equal to
+                            "`RSA-OAEP-384`":
+                          </dt>
+                          <dd>Let |hash| be the string "`SHA-384`".</dd>
+                          <dt>
+                            If the `alg` field of |jwk| is equal to
+                            "`RSA-OAEP-512`":
+                          </dt>
+                          <dd>Let |hash| be the string "`SHA-512`".</dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= RSA-OAEP key import steps | key import steps =] defined by
+                                  <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format|, |jwk|
+                                  and obtaining |hash|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If an error occurred or there are no
+                                  <a href="#dfn-applicable-specification">applicable
+                                  specifications</a>,
+                                  [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl>
+                          <dt>
+                            If |hash| is not undefined:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Let |normalizedHash| be the result of
+                                  <a href="#dfn-normalize-an-algorithm">normalize an algorithm</a>
+                                  with `alg` set to |hash| and `op` set
+                                  to `digest`.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |normalizedHash| is not equal to the
+                                  {{RsaHashedImportParams/hash}} member of
+                                  |normalizedAlgorithm|, [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>If the {{JsonWebKey/d}} field of |jwk| is present:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of Section
+                                  6.3.2 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |privateKey| represent the
+                                  RSA private key identified by interpreting |jwk|
+                                  according to Section 6.3.2 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |privateKey| can be determined to not be a valid RSA private key
+                                  according to [[RFC3447]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} representing |privateKey|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}} internal slot of
+                                  |key| to {{KeyType/"private"}}
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  If |jwk| does not meet the requirements of Section
+                                  6.3.1 of JSON Web Algorithms [[JWA]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |publicKey| represent the
+                                  RSA public key identified by interpreting |jwk|
+                                  according to Section 6.3.1 of JSON Web Algorithms [[JWA]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If |publicKey| can be determined to not be a valid RSA public key
+                                  according to [[RFC3447]],
+                                  then [= exception/throw =] a
+                                  {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |key| be a new {{CryptoKey}} representing |publicKey|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the {{CryptoKey/[[type]]}} internal slot of
+                                  |key| to "`public`"
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise:</dt>
+                  <dd>
+                    [= exception/throw =] a
+                    {{NotSupportedError}}.
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Let |algorithm| be a new
+                  {{RsaHashedKeyAlgorithm}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{KeyAlgorithm/name}} attribute of
+                  |algorithm| to "`RSA-OAEP`"
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaKeyAlgorithm/modulusLength}}
+                  attribute of |algorithm| to the length, in bits, of the RSA public
+                  modulus.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaKeyAlgorithm/publicExponent}}
+                  attribute of |algorithm| to the {{BigInteger}}</a>
+                  representation of the RSA public exponent.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
+                  |algorithm| to the {{RsaHashedImportParams/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |key| to |algorithm|
+                </p>
+              </li>
+              <li>
+                <p>Return |key|.</p>
+              </li>
+            </ol>
+          </section>
+
+          <section id="rsa-oaep-operations-export-key">
+            <h5>Export Key</h5>
+
+            <ol>
+              <li>
+                <p>
+                  Let |key| be the key to be exported.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
+                  cannot be accessed, then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <dl class="switch">
+                  <dt>If |format| is {{KeyFormat/"spki"}}</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot of
+                          |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `SubjectPublicKeyInfo`
+                          ASN.1 structure defined in [[RFC5280]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |algorithm| field to an
+                              `AlgorithmIdentifier` ASN.1 type with the following
+                              properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `rsaEncryption` defined in
+                                  [[RFC3447]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |params| field to the ASN.1 type NULL.
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |subjectPublicKey| field to the result of
+                              DER-encoding an `RSAPublicKey` ASN.1 type, as defined
+                              in [[RFC3447]], Appendix A.1.1, that
+                              represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          If the {{CryptoKey/[[type]]}} internal slot of
+                          |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |data| be an instance of the `PrivateKeyInfo`
+                          ASN.1 structure defined in [[RFC5208]]
+                          with the following properties:
+                        </p>
+                        <ul>
+                          <li>
+                            <p>
+                              Set the |version| field to `0`.
+                            </p>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKeyAlgorithm| field to a
+                              `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
+                              following properties:
+                            </p>
+                            <ul>
+                              <li>
+                                <p>
+                                  Set the |algorithm| field to the OID
+                                  `rsaEncryption` defined in
+                                  [[RFC3447]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the |params| field to the ASN.1 type NULL.
+                                </p>
+                              </li>
+                            </ul>
+                          </li>
+                          <li>
+                            <p>
+                              Set the |privateKey| field to the result of DER-encoding
+                              an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
+                              RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
+                              |key|
+                            </p>
+                            <div class=note>
+                              [[RFC5208]] specifies that the encoding of
+                              this field should be <em>BER</em> encoded in Section 5 (as a "for
+                              example"). However, to avoid requiring WebCrypto implementations
+                              support BER-encoding and BER-decoding, only <em>DER</em> encodings
+                              are produced or accepted.
+                            </div>
+                          </li>
+                        </ul>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be the result of DER-encoding |data|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
+                  <dd>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |jwk| be a new {{JsonWebKey}}
+                          dictionary.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `kty` attribute of |jwk| to the string
+                          "`RSA`".
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |hash| be the {{KeyAlgorithm/name}}
+                          attribute of the {{RsaHashedKeyAlgorithm/hash}}
+                          attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
+                          |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If |hash| is "`SHA-1`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RSA-OAEP`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |hash| is "`SHA-256`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RSA-OAEP-256`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |hash| is "`SHA-384`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RSA-OAEP-384`".
+                            </p>
+                          </dd>
+                          <dt>
+                            If |hash| is "`SHA-512`":
+                          </dt>
+                          <dd>
+                            <p>
+                              Set the `alg` attribute of |jwk| to the string
+                              "`RSA-OAEP-512`".
+                            </p>
+                          </dd>
+                          <dt>Otherwise:</dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Perform any [= RSA-OAEP key export steps | key export steps =]
+                                  defined by <a href="#dfn-applicable-specification">other applicable
+                                  specifications</a>, passing |format| and the
+                                  {{RsaHashedKeyAlgorithm/hash}} attribute of
+                                  the {{CryptoKey/[[algorithm]]}}
+                                  internal slot of |key|
+                                  and obtaining |alg|.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Set the `alg` attribute of |jwk| to |alg|.
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
+                          according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
+                        </p>
+                      </li>
+                      <li>
+                        <dl class="switch">
+                          <dt>
+                            If the {{CryptoKey/[[type]]}} internal slot
+                            of |key| is {{KeyType/"private"}}:
+                          </dt>
+                          <dd>
+                            <ol>
+                              <li>
+                                <p>
+                                  Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
+                                  {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
+                                  {{JsonWebKey/qi}} of |jwk| according to the
+                                  corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
+                                  of |key| is represented by more than two primes, set
+                                  the attribute named {{JsonWebKey/oth}} of |jwk|
+                                  according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
+                                </p>
+                              </li>
+                            </ol>
+                          </dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
+                          of |key|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |result| be |jwk|.
+                        </p>
+                      </li>
+                    </ol>
+                  </dd>
+                  <dt>Otherwise</dt>
+                  <dd>
+                    <p>
                       [= exception/throw =] a
                       {{NotSupportedError}}.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Let |algorithm| be a new
-                    {{RsaHashedKeyAlgorithm}}.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{KeyAlgorithm/name}} attribute of
-                    |algorithm| to "`RSA-OAEP`"
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaKeyAlgorithm/modulusLength}}
-                    attribute of |algorithm| to the length, in bits, of the RSA public
-                    modulus.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaKeyAlgorithm/publicExponent}}
-                    attribute of |algorithm| to the {{BigInteger}}</a>
-                    representation of the RSA public exponent.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{RsaHashedKeyAlgorithm/hash}} attribute of
-                    |algorithm| to the {{RsaHashedImportParams/hash}} member of
-                    |normalizedAlgorithm|.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    Set the {{CryptoKey/[[algorithm]]}} internal slot of
-                    |key| to |algorithm|
-                  </p>
-                </li>
-                <li>
-                  <p>Return |key|.</p>
-                </li>
-              </ol>
-            </dd>
-
-            <dt>Export Key</dt>
-            <dd>
-              <ol>
-                <li>
-                  <p>
-                    Let |key| be the key to be exported.
-                  </p>
-                </li>
-                <li>
-                  <p>
-                    If the underlying cryptographic key material represented by the {{CryptoKey/[[handle]]}} internal slot of |key|
-                    cannot be accessed, then [= exception/throw =] an {{OperationError}}.
-                  </p>
-                </li>
-                <li>
-                  <dl class="switch">
-                    <dt>If |format| is {{KeyFormat/"spki"}}</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot of
-                            |key| is not "`public`", then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `SubjectPublicKeyInfo`
-                            ASN.1 structure defined in [[RFC5280]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |algorithm| field to an
-                                `AlgorithmIdentifier` ASN.1 type with the following
-                                properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `rsaEncryption` defined in
-                                    [[RFC3447]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |params| field to the ASN.1 type NULL.
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |subjectPublicKey| field to the result of
-                                DER-encoding an `RSAPublicKey` ASN.1 type, as defined
-                                in [[RFC3447]], Appendix A.1.1, that
-                                represents the RSA public key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"pkcs8"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            If the {{CryptoKey/[[type]]}} internal slot of
-                            |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |data| be an instance of the `PrivateKeyInfo`
-                            ASN.1 structure defined in [[RFC5208]]
-                            with the following properties:
-                          </p>
-                          <ul>
-                            <li>
-                              <p>
-                                Set the |version| field to `0`.
-                              </p>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKeyAlgorithm| field to a
-                                `PrivateKeyAlgorithmIdentifier` ASN.1 type with the
-                                following properties:
-                              </p>
-                              <ul>
-                                <li>
-                                  <p>
-                                    Set the |algorithm| field to the OID
-                                    `rsaEncryption` defined in
-                                    [[RFC3447]].
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the |params| field to the ASN.1 type NULL.
-                                  </p>
-                                </li>
-                              </ul>
-                            </li>
-                            <li>
-                              <p>
-                                Set the |privateKey| field to the result of DER-encoding
-                                an `RSAPrivateKey` ASN.1 type, as defined in [[RFC3447]], Appendix A.1.2, that represents the
-                                RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot of
-                                |key|
-                              </p>
-                              <div class=note>
-                                [[RFC5208]] specifies that the encoding of
-                                this field should be <em>BER</em> encoded in Section 5 (as a "for
-                                example"). However, to avoid requiring WebCrypto implementations
-                                support BER-encoding and BER-decoding, only <em>DER</em> encodings
-                                are produced or accepted.
-                              </div>
-                            </li>
-                          </ul>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be the result of DER-encoding |data|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>If |format| is {{KeyFormat/"jwk"}}:</dt>
-                    <dd>
-                      <ol>
-                        <li>
-                          <p>
-                            Let |jwk| be a new {{JsonWebKey}}
-                            dictionary.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `kty` attribute of |jwk| to the string
-                            "`RSA`".
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |hash| be the {{KeyAlgorithm/name}}
-                            attribute of the {{RsaHashedKeyAlgorithm/hash}}
-                            attribute of the {{CryptoKey/[[algorithm]]}} internal slot of
-                            |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If |hash| is "`SHA-1`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RSA-OAEP`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |hash| is "`SHA-256`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RSA-OAEP-256`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |hash| is "`SHA-384`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RSA-OAEP-384`".
-                              </p>
-                            </dd>
-                            <dt>
-                              If |hash| is "`SHA-512`":
-                            </dt>
-                            <dd>
-                              <p>
-                                Set the `alg` attribute of |jwk| to the string
-                                "`RSA-OAEP-512`".
-                              </p>
-                            </dd>
-                            <dt>Otherwise:</dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Perform any [= RSA-OAEP key export steps | key export steps =]
-                                    defined by <a href="#dfn-applicable-specification">other applicable
-                                    specifications</a>, passing |format| and the
-                                    {{RsaHashedKeyAlgorithm/hash}} attribute of
-                                    the {{CryptoKey/[[algorithm]]}}
-                                    internal slot of |key|
-                                    and obtaining |alg|.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    Set the `alg` attribute of |jwk| to |alg|.
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the attributes {{JsonWebKey/n}} and {{JsonWebKey/e}} of |jwk|
-                            according to the corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.1.
-                          </p>
-                        </li>
-                        <li>
-                          <dl class="switch">
-                            <dt>
-                              If the {{CryptoKey/[[type]]}} internal slot
-                              of |key| is {{KeyType/"private"}}:
-                            </dt>
-                            <dd>
-                              <ol>
-                                <li>
-                                  <p>
-                                    Set the attributes named {{JsonWebKey/d}}, {{JsonWebKey/p}},
-                                    {{JsonWebKey/q}}, {{JsonWebKey/dp}}, {{JsonWebKey/dq}}, and
-                                    {{JsonWebKey/qi}} of |jwk| according to the
-                                    corresponding definitions in JSON Web Algorithms [[JWA]], Section 6.3.2.
-                                  </p>
-                                </li>
-                                <li>
-                                  <p>
-                                    If the underlying RSA private key represented by the {{CryptoKey/[[handle]]}} internal slot
-                                    of |key| is represented by more than two primes, set
-                                    the attribute named {{JsonWebKey/oth}} of |jwk|
-                                    according to the corresponding definition in JSON Web Algorithms [[JWA]], Section 6.3.2.7
-                                  </p>
-                                </li>
-                              </ol>
-                            </dd>
-                          </dl>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `key_ops` attribute of |jwk| to the {{CryptoKey/usages}} attribute of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Set the `ext` attribute of |jwk| to the {{CryptoKey/[[extractable]]}} internal slot
-                            of |key|.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Let |result| be |jwk|.
-                          </p>
-                        </li>
-                      </ol>
-                    </dd>
-                    <dt>Otherwise</dt>
-                    <dd>
-                      <p>
-                        [= exception/throw =] a
-                        {{NotSupportedError}}.
-                      </p>
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>
-                    Return |result|.
-                  </p>
-                </li>
-              </ol>
-            </dd>
-          </dl>
+                    </p>
+                  </dd>
+                </dl>
+              </li>
+              <li>
+                <p>
+                  Return |result|.
+                </p>
+              </li>
+            </ol>
+          </section>
         </section>
       </section>
 
@@ -14932,7 +14938,8 @@ dictionary HmacKeyGenParams : Algorithm {
           </dl>
         </section>
       </section>
-    <section id="sha">
+
+      <section id="sha">
         <h3>SHA</h3>
         <section id="sha-description" class="informative">
           <h4>Description</h4>


### PR DESCRIPTION
Moving individual algorithm operations to their own section to be able to get an anchor deep link for them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto/pull/402.html" title="Last updated on Mar 7, 2025, 4:41 PM UTC (a8439fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/402/e3459a5...panva:a8439fa.html" title="Last updated on Mar 7, 2025, 4:41 PM UTC (a8439fa)">Diff</a>