### PR TITLE
Properly specify the encoding when verifying ECDSA signatures

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -634,6 +634,13 @@
           sequence of 8 bits in that bit sequence as a byte.
         </p>
         <p>
+          To <dfn id="dfn-convert-byte-sequence-to-integer">convert a byte sequence
+          to a non-negative integer</dfn>,
+          interpret the byte sequence as a big-endian non-negative integer
+          (most significant bit first),
+          and return that integer.
+        </p>
+        <p>
           Comparing two strings in a <dfn id="case-sensitive">case-sensitive</dfn>
           manner means comparing them exactly, code point for code point.
         </p>
@@ -7235,12 +7242,41 @@ dictionary EcKeyImportParams : Algorithm {
                     |key| is "`P-256`", "`P-384`" or "`P-521`":
                   </dt>
                   <dd>
-                    <p>
-                      Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.4.3, with |M| as the received
-                      message, |signature| as the received signature and using
-                      |params| as the EC domain parameters, and
-                      |Q| as the public key.
-                    </p>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |n| be the smallest integer such that |n| * 8 is greater than
+                          the logarithm to base 2 of the order of the base point of the elliptic curve identified
+                          by |params|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If |signature| does not have a [= byte sequence/length =] of |n| * 2 bytes,
+                          then return false.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |r| be the result of
+                          <a href="#dfn-convert-byte-sequence-to-integer">converting the first |n| bytes of |signature| to an integer</a>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Let |s| be the result of
+                          <a href="#dfn-convert-byte-sequence-to-integer">converting the last |n| bytes of |signature| to an integer</a>.
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.4.3, with |M| as the received
+                          message, (|r|, |s|) as the signature and using
+                          |params| as the EC domain parameters, and
+                          |Q| as the public key.
+                        </p>
+                      </li>
+                    </ol>
                   </dd>
                   <dt>
                     Otherwise, the {{EcKeyAlgorithm/namedCurve}} attribute

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -625,10 +625,10 @@
           and then considering each consecutive sequence of 8 bits in that string as a byte.
         </p>
         <p>
-          When this specification says to <dfn id="dfn-convert-integer-to-byte-sequence">convert a non-negative
+          To <dfn id="dfn-convert-integer-to-byte-sequence">convert a non-negative
           integer |i| to a byte sequence of length |n|</dfn>, where |n| * 8
-          is greater than the logarithm to base 2 of |i|, the user agent must
-          first calculate the binary representation of |i|, most significant bit first,
+          is greater than the logarithm to base 2 of |i|,
+          calculate the binary representation of |i|, most significant bit first,
           prefix this with sufficient zero bits to form a bit sequence of length |n| * 8, and
           then return the [= byte sequence =] formed by considering each consecutive
           sequence of 8 bits in that bit sequence as a byte.

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -7135,7 +7135,7 @@ dictionary EcKeyImportParams : Algorithm {
                       <li>
                         <p>
                           Perform the ECDSA signing process, as specified in [[RFC6090]],
-                          Section 5.4, with |M| as the message, using |params| as the
+                          Section 5.4.2, with |M| as the message, using |params| as the
                           EC domain parameters, and with |d| as the private key.
                         </p>
                       </li>
@@ -7236,7 +7236,7 @@ dictionary EcKeyImportParams : Algorithm {
                   </dt>
                   <dd>
                     <p>
-                      Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.3, with |M| as the received
+                      Perform the ECDSA verifying process, as specified in [[RFC6090]], Section 5.4.3, with |M| as the received
                       message, |signature| as the received signature and using
                       |params| as the EC domain parameters, and
                       |Q| as the public key.


### PR DESCRIPTION
When verifying an ECDSA signature, properly specify how to convert the byte sequence to a pair of integers, which RFC 6090 requires, by referring to the Octet-String-to-Integer Conversion steps in RFC 6090.

If the signature is of an incorrect length, return false, as the web platform tests require and all implementations seem to do.

Similarly, when signing, refer to the Integer-to-Octet-String Conversion steps in RFC 6090 instead of specifying our own conversion from a byte sequence to an integer.

Also, refer to the proper sections for signing and verifying in RFC 6090. The subsections 5.4.2 and 5.4.3 refer to "KT-I signatures", which are equivalent to ECDSA signatures, while section 5.3 refers to "KT-IV signatures", which are encoded differently.

Finally, harmonize the parameter names with those specified in RFC 6090.

Fixes #404.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/405.html" title="Last updated on Jun 25, 2025, 8:34 PM UTC (bb8d07c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/405/43f2f62...bb8d07c.html" title="Last updated on Jun 25, 2025, 8:34 PM UTC (bb8d07c)">Diff</a>