### PR TITLE
Check length when importing raw X25519 and Ed25519 keys

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10933,9 +10933,8 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       </li>
                       <li>
                         <p>
-                          If the [= length in bits =] of the data
-                          represented by |keyData| is not 256
-                          then [= exception/throw =] a
+                          If the [= length in bits =] of |keyData|
+                          is not 256 then [= exception/throw =] a
                           {{DataError}}.
                         </p>
                       </li>
@@ -11786,7 +11785,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <li>
                         <p>
                           If the [= length in bits =] of |keyData|
-                          is not 256, then [= exception/throw =] a
+                          is not 256 then [= exception/throw =] a
                           {{DataError}}.
                         </p>
                       </li>


### PR DESCRIPTION
Closes #409

Section 5 of [RFC7748](https://datatracker.ietf.org/doc/html/rfc7748#section-5) specifies that X25519 private and public keys are 32 bytes/256 bits. The spec, however, does not explicitly reject raw keys of different lengths.
This behaviour is already being tested for by [WPT](https://wpt.fyi/results/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.html?label=stable&label=master&aligned) and common implementations already throw a DataError in such cases.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hopafoot/webcrypto/pull/410.html" title="Last updated on Jul 30, 2025, 2:39 PM UTC (7173306)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/410/37f41ce...hopafoot:7173306.html" title="Last updated on Jul 30, 2025, 2:39 PM UTC (7173306)">Diff</a>