### PR TITLE
Fixed typo  in a few statements of the EC key import operation

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -4357,7 +4357,7 @@ dictionary RsaHashedImportParams : Algorithm {
                       <li>
                         <p>
                           If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                          not a case-sensitive string match to "`sig`",
+                          not a case-sensitive string match to "`sign`",
                           then [= exception/throw =] a
                           {{DataError}}.
                         </p>
@@ -7922,7 +7922,7 @@ dictionary EcKeyImportParams : Algorithm {
                       <li>
                         <p>
                           If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                          not  "`sig`",
+                          not  "`sign`",
                           then [= exception/throw =] a
                           {{DataError}}.
                         </p>
@@ -10824,7 +10824,7 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                       <li>
                         <p>
                           If |usages| is non-empty and the {{JsonWebKey/use}} field of |jwk| is present and is
-                          not "`sig`",
+                          not "`sign`",
                           then [= exception/throw =] a
                           {{DataError}}.
                         </p>


### PR DESCRIPTION
Replace "sig" with "sign" in a few statements about the allowed values of the "use" JWK field.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/javifernandez/webcrypto/pull/412.html" title="Last updated on Aug 4, 2025, 10:45 AM UTC (8fbbf03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/412/432f094...javifernandez:8fbbf03.html" title="Last updated on Aug 4, 2025, 10:45 AM UTC (8fbbf03)">Diff</a>