### PR TITLE
Align hash property format for HS512 mapping

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -16322,7 +16322,8 @@ dictionary Pbkdf2Params : Algorithm {
                 <td>
 <pre class=js>
 { name: "HMAC",
-  hash: "SHA-512" }
+  hash: { name: "SHA-512" }
+}
 </pre>
                 </td>
               </tr>


### PR DESCRIPTION
In the JWK Algorithm Mappings table, the 'hash' property for the HS512 algorithm is formatted as a string ("SHA-512").

This PR changes the format to be an object ({ name: 'SHA-512' }), making it consistent with the format used by all other HMAC algorithms (HS1, HS256, HS384) in the table.

The table is non-normative, so this change is just to avoid confusing users of the API like me.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cardoso/webcrypto/pull/418.html" title="Last updated on Oct 5, 2025, 4:35 PM UTC (57dc092)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/418/a4cd8e0...cardoso:57dc092.html" title="Last updated on Oct 5, 2025, 4:35 PM UTC (57dc092)">Diff</a>