### PR TITLE
Reorder reading algorithm and data arguments

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1417,14 +1417,6 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |data| be the result of
-                  [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the `data` parameter passed to the
-                  {{SubtleCrypto/encrypt()}} method.
-                </p>
-              </li>
-              <li>
-                <p>
                   Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
                   `alg` set to |algorithm| and `op` set to
@@ -1435,6 +1427,14 @@ interface SubtleCrypto {
                 <p>
                   If an error occurred, return a Promise rejected with
                   |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |data| be the result of
+                  [= get a copy of the buffer source |
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
+                  {{SubtleCrypto/encrypt()}} method.
                 </p>
               </li>
               <li>
@@ -1524,14 +1524,6 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |data| be the result of
-                  [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the `data` parameter passed to the
-                  {{SubtleCrypto/decrypt()}} method.
-                </p>
-              </li>
-              <li>
-                <p>
                   Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
                   `alg` set to |algorithm| and `op` set to
@@ -1542,6 +1534,14 @@ interface SubtleCrypto {
                 <p>
                   If an error occurred, return a Promise rejected with
                   |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |data| be the result of
+                  [= get a copy of the buffer source |
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
+                  {{SubtleCrypto/decrypt()}} method.
                 </p>
               </li>
               <li>
@@ -1631,14 +1631,6 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |data| be the result of
-                  [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the `data` parameter passed to the
-                  {{SubtleCrypto/sign()}} method.
-                </p>
-              </li>
-              <li>
-                <p>
                   Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
                   `alg` set to |algorithm| and `op` set to
@@ -1649,6 +1641,14 @@ interface SubtleCrypto {
                 <p>
                   If an error occurred, return a Promise rejected with
                   |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |data| be the result of
+                  [= get a copy of the buffer source |
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
+                  {{SubtleCrypto/sign()}} method.
                 </p>
               </li>
               <li>
@@ -1736,6 +1736,20 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
+                  Let |normalizedAlgorithm| be the result of
+                  <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
+                  `alg` set to |algorithm| and `op` set to
+                  "`verify`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  If an error occurred, return a Promise rejected with
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |signature| be the result of
                   [= get a copy of the buffer source |
                   getting a copy of the bytes held by =] the `signature` parameter passed to the
@@ -1750,21 +1764,6 @@ interface SubtleCrypto {
                   {{SubtleCrypto/verify()}} method.
                 </p>
               </li>
-              <li>
-                <p>
-                  Let |normalizedAlgorithm| be the result of
-                  <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to |algorithm| and `op` set to
-                  "`verify`".
-                </p>
-              </li>
-              <li>
-                <p>
-                  If an error occurred, return a Promise rejected with
-                  |normalizedAlgorithm|.
-                </p>
-              </li>
-
               <li>
                 <p>
                   Let |realm| be the [= relevant realm =] of [= this =].
@@ -1845,14 +1844,6 @@ interface SubtleCrypto {
               </li>
               <li>
                 <p>
-                  Let |data| be the result of
-                  [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the `data` parameter passed to the
-                  {{SubtleCrypto/digest()}} method.
-                </p>
-              </li>
-              <li>
-                <p>
                   Let |normalizedAlgorithm| be the result of
                   <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
                   `alg` set to |algorithm| and `op` set to
@@ -1863,6 +1854,14 @@ interface SubtleCrypto {
                 <p>
                   If an error occurred, return a Promise rejected with
                   |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |data| be the result of
+                  [= get a copy of the buffer source |
+                  getting a copy of the bytes held by =] the `data` parameter passed to the
+                  {{SubtleCrypto/digest()}} method.
                 </p>
               </li>
               <li>
@@ -2299,6 +2298,20 @@ interface SubtleCrypto {
                 </p>
               </li>
               <li>
+                <p>
+                  Let |normalizedAlgorithm| be the result of
+                  <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
+                  `alg` set to |algorithm| and `op` set to
+                  "`importKey`".
+                </p>
+              </li>
+              <li>
+                <p>
+                  If an error occurred, return a Promise rejected with
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
                 <dl class="switch">
                   <dt>
                     If |format| is equal to the string {{KeyFormat/"jwk"}}:
@@ -2344,20 +2357,6 @@ interface SubtleCrypto {
                     </ol>
                   </dd>
                 </dl>
-              </li>
-              <li>
-                <p>
-                  Let |normalizedAlgorithm| be the result of
-                  <a href="#dfn-normalize-an-algorithm">normalizing an algorithm</a>, with
-                  `alg` set to |algorithm| and `op` set to
-                  "`importKey`".
-                </p>
-              </li>
-              <li>
-                <p>
-                  If an error occurred, return a Promise rejected with
-                  |normalizedAlgorithm|.
-                </p>
               </li>
               <li>
                 <p>
@@ -2751,7 +2750,7 @@ interface SubtleCrypto {
               MUST perform the following steps:
             </p>
             <ol>
-            <li>
+              <li>
                 <p>
                   Let |format|, |unwrappingKey|,
                   |algorithm|, |unwrappedKeyAlgorithm|,
@@ -2762,15 +2761,6 @@ interface SubtleCrypto {
                   parameters passed to the
                   {{SubtleCrypto/unwrapKey()}} method,
                   respectively.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Let |wrappedKey| be the result of
-                  [= get a copy of the buffer source |
-                  getting a copy of the bytes held by =] the
-                  `wrappedKey` parameter passed to the
-                  {{SubtleCrypto/unwrapKey()}} method.
                 </p>
               </li>
               <li>
@@ -2806,6 +2796,15 @@ interface SubtleCrypto {
                 <p>
                   If an error occurred, return a Promise rejected with
                   |normalizedKeyAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |wrappedKey| be the result of
+                  [= get a copy of the buffer source |
+                  getting a copy of the bytes held by =] the
+                  `wrappedKey` parameter passed to the
+                  {{SubtleCrypto/unwrapKey()}} method.
                 </p>
               </li>
               <li>


### PR DESCRIPTION
Read and normalize the algorithm argument(s) before copying the bytes held by data arguments, to enable avoiding the copy if the operation is performed on the same thread (which is currently not possible because the algorithm object getters may modify the data).

This also matches the current behavior of Firefox, Safari, and Node.js (only Chrome implements the current spec properly).

Closes #422.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/426.html" title="Last updated on Jan 29, 2026, 1:34 PM UTC (df748b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/426/9d98db7...df748b1.html" title="Last updated on Jan 29, 2026, 1:34 PM UTC (df748b1)">Diff</a>