### PR TITLE
Add length check for JWK key import

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -10834,6 +10834,30 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               </li>
                               <li>
                                 <p>
+                                  Let |jwkPublic| be the {{JsonWebKey/x}} field of |jwk| interpreted
+                                  according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the [= length in bits =] of |jwkPublic| is not 256,
+                                  then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |jwkPrivate| be the {{JsonWebKey/d}} field of |jwk| interpreted
+                                  according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the [= length in bits =] of |jwkPrivate| is not 256,
+                                  then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
                                   Let |key| be a new {{CryptoKey}} object that represents the
                                   Ed25519 private key identified by interpreting
                                   |jwk| according to Section 2 of [[RFC8037]].
@@ -10855,6 +10879,18 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   If |jwk| does not meet the requirements of
                                   the JWK public key format described in Section 2
                                   of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |jwkPublic| be the {{JsonWebKey/x}} field of |jwk| interpreted
+                                  according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the [= length in bits =] of |jwkPublic| is not 256,
+                                  then [= exception/throw =] a {{DataError}}.
                                 </p>
                               </li>
                               <li>
@@ -11686,6 +11722,30 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                               </li>
                               <li>
                                 <p>
+                                  Let |jwkPublic| be the {{JsonWebKey/x}} field of |jwk| interpreted
+                                  according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the [= length in bits =] of |jwkPublic| is not 256,
+                                  then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |jwkPrivate| be the {{JsonWebKey/d}} field of |jwk| interpreted
+                                  according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the [= length in bits =] of |jwkPrivate| is not 256,
+                                  then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
                                   Let |key| be a new {{CryptoKey}} object that represents the
                                   X25519 private key identified by interpreting
                                   |jwk| according to Section 2 of [[RFC8037]].
@@ -11707,6 +11767,18 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                                   If |jwk| does not meet the requirements of
                                   the JWK public key format described in Section 2
                                   of [[RFC8037]], then [= exception/throw =] a {{DataError}}.
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  Let |jwkPublic| be the {{JsonWebKey/x}} field of |jwk| interpreted
+                                  according to Section 2 of [[RFC8037]].
+                                </p>
+                              </li>
+                              <li>
+                                <p>
+                                  If the [= length in bits =]
+                                  of |jwkPublic| is not 256, then [= exception/throw =] a {{DataError}}.
                                 </p>
                               </li>
                               <li>


### PR DESCRIPTION
The PR adds length validation of JWK fields provided during key import to match WPT tests.

See https://github.com/WICG/webcrypto-secure-curves/issues/33#issuecomment-3150406438

---

Clone of https://github.com/WICG/webcrypto-secure-curves/pull/38


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/devgianlu/webcrypto/pull/428.html" title="Last updated on Feb 13, 2026, 6:24 PM UTC (e4cf548)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/428/9d98db7...devgianlu:e4cf548.html" title="Last updated on Feb 13, 2026, 6:24 PM UTC (e4cf548)">Diff</a>