### PR TITLE
Require HMAC comparison to be constant time

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14437,6 +14437,7 @@ dictionary HmacKeyGenParams : Algorithm {
                 <p>
                   Return true if |mac| is equal to |signature| and false
                   otherwise.
+                  This comparison must be performed in constant-time.
                 </p>
               </li>
             </ol>


### PR DESCRIPTION
See CVE-2026-21713 https://nodejs.org/en/blog/vulnerability/march-2026-security-releases


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto/pull/553.html" title="Last updated on Mar 26, 2026, 4:29 PM UTC (47463cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/553/5b57233...panva:47463cf.html" title="Last updated on Mar 26, 2026, 4:29 PM UTC (47463cf)">Diff</a>