### PR TITLE
Normalize usage list in generateKey operations

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -12301,7 +12301,7 @@ dictionary AesDerivedKeyParams : Algorithm {
               <li>
                 <p>
                   Set the {{CryptoKey/[[usages]]}} internal slot of
-                  |key| to be |usages|.
+                  |key| to be the [= normalized value =] of |usages|.
                 </p>
               </li>
               <li>
@@ -12860,7 +12860,7 @@ dictionary AesCbcParams : Algorithm {
               <li>
                 <p>
                   Set the {{CryptoKey/[[usages]]}} internal slot of
-                  |key| to be |usages|.
+                  |key| to be the [= normalized value =] of |usages|.
                 </p>
               </li>
               <li>
@@ -13498,7 +13498,7 @@ dictionary AesGcmParams : Algorithm {
               <li>
                 <p>
                   Set the {{CryptoKey/[[usages]]}} internal slot of
-                  |key| to be |usages|.
+                  |key| to be the [= normalized value =] of |usages|.
                 </p>
               </li>
               <li>
@@ -13995,7 +13995,7 @@ dictionary AesGcmParams : Algorithm {
               <li>
                 <p>
                   Set the {{CryptoKey/[[usages]]}} internal slot of
-                  |key| to be |usages|.
+                  |key| to be the [= normalized value =] of |usages|.
                 </p>
               </li>
               <li>
@@ -14559,7 +14559,7 @@ dictionary HmacKeyGenParams : Algorithm {
               <li>
                 <p>
                   Set the {{CryptoKey/[[usages]]}} internal slot of
-                  |key| to be |usages|.
+                  |key| to be the [= normalized value =] of |usages|.
                 </p>
               </li>
               <li>


### PR DESCRIPTION
Found from the recent changes (https://github.com/web-platform-tests/wpt/pull/61397) in WPT.

For the generateKey operations of symmetric key algorithms (AES-CTR, AES-CBC, AES-GCM, AES-KW and HMAC), we should normalize the usage list assigned to the [[usages]] internal slot of the new CryptoKey.

Note that, for the generateKey operations of asymmetric key algorithms (RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP, ECDH, ECDSA, Ed25519 and X25519), the usage lists assigned to the [[usages]] internal slots of the new CryptoKey are already normalized by the usage intersection (https://w3c.github.io/webcrypto/#concept-usage-intersection).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kkoyung/webcrypto/pull/557.html" title="Last updated on Aug 6, 2026, 3:36 PM UTC (c3f7dde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/557/851575b...kkoyung:c3f7dde.html" title="Last updated on Aug 6, 2026, 3:36 PM UTC (c3f7dde)">Diff</a>