### PR TITLE
Improve algorithm steps for Modern Algorithms' supports() method

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -14575,6 +14575,13 @@ dictionary HmacKeyGenParams : Algorithm {
 
             <ol>
               <li>
+                <p>
+                  If the {{HmacImportParams/length}} member of
+                  |normalizedAlgorithm| is present and is zero, then
+                  [= exception/throw =] a {{DataError}}.
+                </p>
+              </li>
+              <li>
                 <p>Let |keyData| be the key data to be imported.</p>
               </li>
               <li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -15212,6 +15212,19 @@ dictionary HkdfParams : Algorithm {
               </li>
               <li>
                 <p>
+                  Let |hashLength| be the length in bits of the output of the
+                  hash function identified by the {{HkdfParams/hash}} member of
+                  |normalizedAlgorithm|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |length| is greater than 255 * |hashLength|,
+                  then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
                   Let |keyDerivationKey| be the secret represented by the {{CryptoKey/[[handle]]}} internal slot of |key|.
                 </p>
               </li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -7523,6 +7523,16 @@ dictionary EcKeyImportParams : Algorithm {
 
             <ol>
               <li>
+                <p>
+                  If the {{EcKeyImportParams/namedCurve}} member of
+                  |normalizedAlgorithm| is not one of "`P-256`", "`P-384`" or
+                  "`P-521`", and is not a value specified in an
+                  <a href="#dfn-applicable-specification">applicable specification</a>
+                  that specifies the use of that value with ECDSA, then
+                  [= exception/throw =] a {{NotSupportedError}}.
+                </p>
+              </li>
+              <li>
                 <p>Let |keyData| be the key data to be imported.</p>
               </li>
               <li>
@@ -9182,6 +9192,16 @@ dictionary EcdhKeyDeriveParams : Algorithm {
             <h5>Import Key</h5>
 
             <ol>
+              <li>
+                <p>
+                  If the {{EcKeyImportParams/namedCurve}} member of
+                  |normalizedAlgorithm| is not one of "`P-256`", "`P-384`" or
+                  "`P-521`", and is not a value specified in an
+                  <a href="#dfn-applicable-specification">applicable specification</a>
+                  that specifies the use of that value with ECDH, then
+                  [= exception/throw =] a {{NotSupportedError}}.
+                </p>
+              </li>
               <li>
                 <p>Let |keyData| be the key data to be imported.</p>
               </li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -9038,12 +9038,6 @@ dictionary EcdhKeyDeriveParams : Algorithm {
             <ol>
               <li>
                 <p>
-                  If the {{CryptoKey/[[type]]}} internal slot of
-                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                </p>
-              </li>
-              <li>
-                <p>
                   Let |publicKey| be the
                   {{EcdhKeyDeriveParams/public}} member of
                   |normalizedAlgorithm|.
@@ -9053,6 +9047,35 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <p>
                   If the {{CryptoKey/[[type]]}} internal slot of
                   |publicKey| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{KeyAlgorithm/name}} attribute of
+                  the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |publicKey| is not equal to the {{Algorithm/name}} member of
+                  |normalizedAlgorithm|, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Let |maximumLength| be the length in bits of the output of
+                  the field element to octet string conversion defined in
+                  Section 6.2 of [[RFC6090]] for the EC domain parameters
+                  associated with |publicKey|.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |length| is not null and is greater than
+                  |maximumLength|, then
+                  [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -3903,6 +3903,45 @@ dictionary RsaHashedKeyGenParams : RsaKeyGenParams {
           </pre>
           <p>The <dfn data-dfn-for=RsaHashedKeyGenParams id=dfn-RsaHashedKeyGenParams-hash>hash</dfn> member represents the hash algorithm to use.</p>
         </section>
+        <section id="rsa-key-generation-parameter-validation">
+          <h4>RSA key generation parameter validation</h4>
+          <p>
+            The <dfn id="dfn-validate-rsa-key-generation-parameters">validate RSA key generation parameters</dfn>
+            algorithm takes a {{RsaKeyGenParams}} |normalizedAlgorithm| and
+            performs the following steps:
+          </p>
+          <ol>
+            <li>
+              <p>
+                Let |modulusLength| be the {{RsaKeyGenParams/modulusLength}}
+                member of |normalizedAlgorithm|.
+              </p>
+            </li>
+            <li>
+              <p>
+                Let |publicExponent| be the result of
+                <a href="#dfn-convert-byte-sequence-to-integer">converting the
+                {{RsaKeyGenParams/publicExponent}} member of
+                |normalizedAlgorithm| to a non-negative integer</a>.
+              </p>
+            </li>
+            <li>
+              <p>
+                If |modulusLength| is less than 4, or if |publicExponent| is
+                less than 3, is even, or is greater than or equal to
+                2^|modulusLength| - 1, then
+                [= exception/throw =] an {{OperationError}}.
+              </p>
+            </li>
+          </ol>
+          <p class="note">
+            These checks follow from the definition of a valid RSA public key
+            in [[RFC3447]]: the modulus is the product of at least two
+            distinct odd primes, and the public exponent is an integer
+            between 3 and the modulus minus one that is relatively prime to
+            the least common multiple of the values one less than each prime.
+          </p>
+        </section>
         <section id="RsaKeyAlgorithm-dictionary">
           <h4><dfn data-idl id="dfn-RsaKeyAlgorithm">RsaKeyAlgorithm</dfn> dictionary</h4>
           <pre class=idl>
@@ -4020,6 +4059,12 @@ dictionary RsaHashedImportParams : Algorithm {
                    "`sign`" or "`verify`",
                   then [= exception/throw =] a
                   {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the [= validate RSA key generation parameters =]
+                  algorithm with |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
@@ -5057,6 +5102,12 @@ dictionary RsaPssParams : Algorithm {
                   "`sign`" or "`verify`",
                   then [= exception/throw =] a
                   {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the [= validate RSA key generation parameters =]
+                  algorithm with |normalizedAlgorithm|.
                 </p>
               </li>
               <li>
@@ -6106,6 +6157,12 @@ dictionary RsaOaepParams : Algorithm {
                   "`wrapKey`" or "`unwrapKey`",
                   then [= exception/throw =] a
                   {{SyntaxError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Perform the [= validate RSA key generation parameters =]
+                  algorithm with |normalizedAlgorithm|.
                 </p>
               </li>
               <li>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -13242,14 +13242,6 @@ dictionary AesGcmParams : Algorithm {
             <ol>
               <li>
                 <p>
-                  If |plaintext| has a [= byte sequence/length =]
-                  greater than 2^39 - 256 bytes,
-                  then [= exception/throw =] an
-                  {{OperationError}}.
-                </p>
-              </li>
-              <li>
-                <p>
                   If the {{AesGcmParams/iv}} member of
                   |normalizedAlgorithm| has a [= byte sequence/length =]
                   greater than 2^64 - 1 bytes,
@@ -13283,6 +13275,14 @@ dictionary AesGcmParams : Algorithm {
                     {{OperationError}}.
                   </dd>
                 </dl>
+              </li>
+              <li>
+                <p>
+                  If |plaintext| has a [= byte sequence/length =]
+                  greater than 2^39 - 256 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
               </li>
               <li>
                 <p>
@@ -13339,13 +13339,6 @@ dictionary AesGcmParams : Algorithm {
               </li>
               <li>
                 <p>
-                  If |ciphertext| has a [= length in bits =] less than |tagLength|,
-                  then [= exception/throw =] an
-                  {{OperationError}}.
-                </p>
-              </li>
-              <li>
-                <p>
                   If the {{AesGcmParams/iv}} member of
                   |normalizedAlgorithm| has a [= byte sequence/length =]
                   greater than 2^64 - 1 bytes,
@@ -13359,6 +13352,13 @@ dictionary AesGcmParams : Algorithm {
                   of |normalizedAlgorithm| is present and has a
                   [= byte sequence/length =]
                   greater than 2^64 - 1 bytes,
+                  then [= exception/throw =] an
+                  {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |ciphertext| has a [= length in bits =] less than |tagLength|,
                   then [= exception/throw =] an
                   {{OperationError}}.
                 </p>

--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -11296,12 +11296,6 @@ dictionary EcdhKeyDeriveParams : Algorithm {
             <ol>
               <li>
                 <p>
-                  If the {{CryptoKey/[[type]]}} internal slot of
-                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
-                </p>
-              </li>
-              <li>
-                <p>
                   Let |publicKey| be the
                   {{EcdhKeyDeriveParams/public}} member of
                   |normalizedAlgorithm|.
@@ -11311,6 +11305,26 @@ dictionary EcdhKeyDeriveParams : Algorithm {
                 <p>
                   If the {{CryptoKey/[[type]]}} internal slot of
                   |publicKey| is not {{KeyType/"public"}}, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{KeyAlgorithm/name}} attribute of
+                  the {{CryptoKey/[[algorithm]]}} internal slot of
+                  |publicKey| is not equal to the {{Algorithm/name}} member of
+                  |normalizedAlgorithm|, then [= exception/throw =] an {{InvalidAccessError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If |length| is not null and is greater than 256,
+                  then [= exception/throw =] an {{OperationError}}.
+                </p>
+              </li>
+              <li>
+                <p>
+                  If the {{CryptoKey/[[type]]}} internal slot of
+                  |key| is not {{KeyType/"private"}}, then [= exception/throw =] an {{InvalidAccessError}}.
                 </p>
               </li>
               <li>


### PR DESCRIPTION
The Modern Algorithms specification defines `SubtleCrypto.supports()` by normalizing an algorithm and executing its operation steps until it encounters unavailable key or data, key generation, a return, or an exception.

This makes the ordering and explicitness of validation in the core Web Cryptography specification observable. Some core operations currently reach one of those stopping points before checking parameters that `supports()` does have. This can make `supports()` return `true` for an interaction that:

- cannot succeed with any key or input;
- is not defined for the selected algorithms;
- is not expected to be supported by underlying cryptographic libraries; or
- is already deliberately rejected by implementations.

This PR makes those outcomes observable before `supports()` reaches its stopping point.

## Changes

- Move existing AES-GCM IV, additional-data, and tag-length validation ahead of plaintext or ciphertext access.
- Check HKDF's 255-block output limit before accessing key material.
- Reject an explicitly zero-length HMAC import before examining key data.
- Check necessary RSA modulus-length and public-exponent constraints before key generation.
- Validate supplied X25519 and ECDH public keys and maximum derivation lengths before accessing the unavailable private key.
- Derive the ECDH output limit from the curve's EC domain parameters, including curves defined by applicable specifications.
- Define `NamedCurve` as an enum so names not defined by the core or an applicable specification fail during normalization.
- Make the fixed-output-hash boundary explicit for RSA, ECDSA, HMAC, HKDF, and PBKDF2.

The XOF checks establish an intentionally unsupported boundary rather than claiming every such composition is cryptographically impossible/undefined. Selecting an output length for an XOF does not turn it into the fixed-output hash expected by these traditional algorithms. In particular, implementations already reject RSA and ECDSA combinations with XOF digests using `NotSupportedError`. This just sets it as baseline.

Successful operations are unchanged.

## Examples

Each of the following now returns `false`.

### AES-GCM parameters

```js
SubtleCrypto.supports("encrypt", {
  name: "AES-GCM",
  iv: new Uint8Array(12),
  tagLength: 31,
})
```

A 31-bit AES-GCM tag is never valid, regardless of key or plaintext.

### HKDF output length

```js
SubtleCrypto.supports("deriveBits", {
  name: "HKDF",
  hash: "SHA-256",
  salt: new Uint8Array(),
  info: new Uint8Array(),
}, 65288)
```

With SHA-256 the maximum is 65280 bits, so 65288 bits can never be derived.

### XOFs in traditional algorithms

```js
SubtleCrypto.supports("generateKey", {
  name: "HMAC",
  hash: { name: "cSHAKE128", outputLength: 256 },
})
```

Modern Algorithms implementations deliberately exclude XOF digests from these traditional algorithms. Selecting an output length does not turn cSHAKE into a fixed-output hash.

### Undefined named curves

```js
SubtleCrypto.supports("importKey", {
  name: "ECDSA",
  namedCurve: "not-a-curve",
})
```

No import using an undefined curve could ever succeed.

### Zero-length HMAC imports

```js
SubtleCrypto.supports("importKey", {
  name: "HMAC",
  hash: "SHA-256",
  length: 0,
})
```

No HMAC key data can satisfy an explicitly requested length of zero.

### RSA key generation parameters

```js
SubtleCrypto.supports("generateKey", {
  name: "RSA-PSS",
  modulusLength: 2048,
  publicExponent: new Uint8Array([2]),
  hash: "SHA-256",
})
```

No RSA key can use an even public exponent.

### X25519 derivation length

```js
SubtleCrypto.supports("deriveBits", {
  name: "X25519",
  public: publicKey,
}, 257)
```

X25519 produces at most 256 bits, so 257 bits can never be derived. Refs: https://github.com/WICG/webcrypto-modern-algos/pull/74

### ECDH derivation length

```js
SubtleCrypto.supports("deriveBits", {
  name: "ECDH",
  public: publicKey,
}, 257)
```

With a P-256 public key, the field element encodes to 256 bits. The output limit is derived from the public key’s EC domain parameters, so extended named curves are handled without enumeration. Refs: https://github.com/WICG/webcrypto-modern-algos/pull/74


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/panva/webcrypto/pull/558.html" title="Last updated on Aug 11, 2026, 1:12 PM UTC (b16487f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/558/27b3faa...panva:b16487f.html" title="Last updated on Aug 11, 2026, 1:12 PM UTC (b16487f)">Diff</a>