### PR TITLE
Remove required and [EnforceRange] attributes from readonly dictionaries

### DIFF
--- a/spec/Overview.html
+++ b/spec/Overview.html
@@ -1029,7 +1029,7 @@ dictionary Algorithm {
         </p>
         <pre class=idl>
 dictionary KeyAlgorithm {
-  required DOMString name;
+  DOMString name;
 };
         </pre>
         <section id="key-algorithm-dictionary-description" class="informative">
@@ -3946,8 +3946,8 @@ dictionary RsaHashedKeyGenParams : RsaKeyGenParams {
           <h4><dfn data-idl id="dfn-RsaKeyAlgorithm">RsaKeyAlgorithm</dfn> dictionary</h4>
           <pre class=idl>
 dictionary RsaKeyAlgorithm : KeyAlgorithm {
-  required [EnforceRange] unsigned long modulusLength;
-  required BigInteger publicExponent;
+  unsigned long modulusLength;
+  BigInteger publicExponent;
 };
           </pre>
           <p>The <dfn data-idl data-dfn-for=RsaKeyAlgorithm id="dfn-RsaKeyAlgorithm-modulusLength">modulusLength</dfn> member contains the length, in bits, of the RSA modulus.</p>
@@ -7125,7 +7125,7 @@ dictionary EcKeyGenParams : Algorithm {
           <h4><dfn data-idl id="dfn-EcKeyAlgorithm">EcKeyAlgorithm</dfn> dictionary</h4>
           <pre class=idl>
 dictionary EcKeyAlgorithm : KeyAlgorithm {
-  required NamedCurve namedCurve;
+  NamedCurve namedCurve;
 };
           </pre>
           <p>The <dfn data-dfn-for=EcKeyAlgorithm id=dfn-EcKeyAlgorithm-namedCurve>namedCurve</dfn> member represents the named curve that the key uses.</p>
@@ -12219,7 +12219,7 @@ dictionary AesCtrParams : Algorithm {
           <h4><dfn data-idl id="dfn-AesKeyAlgorithm">AesKeyAlgorithm</dfn> dictionary</h4>
           <pre class=idl>
 dictionary AesKeyAlgorithm : KeyAlgorithm {
-  required [EnforceRange] unsigned short length;
+  unsigned short length;
 };
           </pre>
           <p>The <dfn data-dfn-for=AesKeyAlgorithm id="dfn-AesKeyAlgorithm-length">length</dfn> member represents the length, in bits, of the key.</p>
@@ -14492,8 +14492,8 @@ dictionary HmacImportParams : Algorithm {
           <h4><dfn data-idl id="dfn-HmacKeyAlgorithm">HmacKeyAlgorithm</dfn> dictionary</h4>
           <pre class=idl>
 dictionary HmacKeyAlgorithm : KeyAlgorithm {
-  required KeyAlgorithm hash;
-  required [EnforceRange] unsigned long length;
+  KeyAlgorithm hash;
+  unsigned long length;
 };
           </pre>
           <p>The <dfn data-dfn-for=HmacKeyAlgorithm id=dfn-HmacKeyAlgorithm-hash>hash</dfn> member represents the inner hash function to use.</p>


### PR DESCRIPTION
Remove the `required` and `[EnforceRange]` attributes of all properties of `KeyAlgorithm` dictionaries, which are only used on the `algorithm` property of `CryptoKey`, which is `readonly`.

WebIDL [says](https://webidl.spec.whatwg.org/#idl-dictionaries):

> Note that specifying [dictionary members](https://webidl.spec.whatwg.org/#dfn-dictionary-member) as [required](https://webidl.spec.whatwg.org/#required-dictionary-member) only has an observable effect when converting other representations of dictionaries (like a JavaScript value supplied as an argument to an [operation](https://webidl.spec.whatwg.org/#dfn-operation)) to an IDL dictionary. Specification authors should leave the members [optional](https://webidl.spec.whatwg.org/#dictionary-member-optional) in all other cases, including when a dictionary type is used solely as the [return type](https://webidl.spec.whatwg.org/#dfn-return-type) of [operations](https://webidl.spec.whatwg.org/#dfn-operation).

[and](https://webidl.spec.whatwg.org/#EnforceRange):

> A type annotated with the [[EnforceRange](https://webidl.spec.whatwg.org/#EnforceRange)] extended attribute must not appear in a [read only](https://webidl.spec.whatwg.org/#dfn-read-only) attribute.

(even though the attributes themselves are not `readonly`, the `algorithm` attribute of `CryptoKey` is).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/pull/559.html" title="Last updated on Aug 20, 2026, 2:11 PM UTC (393a444)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcrypto/559/811c24c...393a444.html" title="Last updated on Aug 20, 2026, 2:11 PM UTC (393a444)">Diff</a>